### PR TITLE
test: conformance tests for three emulator edge cases

### DIFF
--- a/tests/tier1/putItem/conditions.test.ts
+++ b/tests/tier1/putItem/conditions.test.ts
@@ -21,6 +21,9 @@ describe('PutItem — ConditionExpression', () => {
     await cleanupItems(hashTableDef.name, [
       { pk: { S: pk } },
       { pk: { S: 'put-cond-new' } },
+      { pk: { S: 'put-cond-ne-missing' } },
+      { pk: { S: 'put-cond-ne-or-missing' } },
+      { pk: { S: 'put-cond-eq-missing' } },
     ])
   })
 
@@ -112,6 +115,82 @@ describe('PutItem — ConditionExpression', () => {
           ConditionExpression: '#c > :min',
           ExpressionAttributeNames: { '#c': 'count' },
           ExpressionAttributeValues: { ':min': { N: '100' } },
+        }),
+      ),
+      'ConditionalCheckFailedException',
+    )
+  })
+
+  it('not-equals on a missing attribute evaluates to true', async () => {
+    // When the item does not exist, `status <> "working"` should be true
+    // because a non-existent attribute is not equal to any value.
+    const newPk = 'put-cond-ne-missing'
+    await cleanupItems(hashTableDef.name, [{ pk: { S: newPk } }])
+
+    await ddb.send(
+      new PutItemCommand({
+        TableName: hashTableDef.name,
+        Item: { pk: { S: newPk }, status: { S: 'idle' } },
+        ConditionExpression: '#s <> :v',
+        ExpressionAttributeNames: { '#s': 'status' },
+        ExpressionAttributeValues: { ':v': { S: 'working' } },
+      }),
+    )
+
+    const result = await ddb.send(
+      new GetItemCommand({
+        TableName: hashTableDef.name,
+        Key: { pk: { S: newPk } },
+        ConsistentRead: true,
+      }),
+    )
+    expect(result.Item).toBeDefined()
+    expect(result.Item!.status.S).toBe('idle')
+  })
+
+  it('OR with not-equals and less-than on missing attributes succeeds', async () => {
+    // `status <> "working" OR updatedAt < "2099-..."` on a non-existent item:
+    // status is missing → <> returns true → OR short-circuits → condition passes
+    const newPk = 'put-cond-ne-or-missing'
+    await cleanupItems(hashTableDef.name, [{ pk: { S: newPk } }])
+
+    await ddb.send(
+      new PutItemCommand({
+        TableName: hashTableDef.name,
+        Item: { pk: { S: newPk }, status: { S: 'new' } },
+        ConditionExpression: '#s <> :v OR #u < :t',
+        ExpressionAttributeNames: { '#s': 'status', '#u': 'updatedAt' },
+        ExpressionAttributeValues: {
+          ':v': { S: 'working' },
+          ':t': { S: '2099-01-01T00:00:00Z' },
+        },
+      }),
+    )
+
+    const result = await ddb.send(
+      new GetItemCommand({
+        TableName: hashTableDef.name,
+        Key: { pk: { S: newPk } },
+        ConsistentRead: true,
+      }),
+    )
+    expect(result.Item).toBeDefined()
+    expect(result.Item!.status.S).toBe('new')
+  })
+
+  it('equals on a missing attribute evaluates to false', async () => {
+    // Sanity check: `status = "working"` on a non-existent item should fail
+    const newPk = 'put-cond-eq-missing'
+    await cleanupItems(hashTableDef.name, [{ pk: { S: newPk } }])
+
+    await expectDynamoError(
+      () => ddb.send(
+        new PutItemCommand({
+          TableName: hashTableDef.name,
+          Item: { pk: { S: newPk }, status: { S: 'idle' } },
+          ConditionExpression: '#s = :v',
+          ExpressionAttributeNames: { '#s': 'status' },
+          ExpressionAttributeValues: { ':v': { S: 'working' } },
         }),
       ),
       'ConditionalCheckFailedException',

--- a/tests/tier1/query/keyConditionParens.test.ts
+++ b/tests/tier1/query/keyConditionParens.test.ts
@@ -1,0 +1,83 @@
+import {
+  PutItemCommand,
+  QueryCommand,
+} from '@aws-sdk/client-dynamodb'
+import { ddb } from '../../../src/client.js'
+import { compositeTableDef, cleanupItems } from '../../../src/helpers.js'
+
+describe('Query — KeyConditionExpression with parentheses', () => {
+  const pk = 'kce-parens'
+  const items = [
+    { pk: { S: pk }, sk: { S: '1' }, data: { S: 'a' } },
+    { pk: { S: pk }, sk: { S: '2' }, data: { S: 'b' } },
+    { pk: { S: pk }, sk: { S: '3' }, data: { S: 'c' } },
+  ]
+
+  beforeAll(async () => {
+    await Promise.all(
+      items.map((item) =>
+        ddb.send(
+          new PutItemCommand({ TableName: compositeTableDef.name, Item: item }),
+        ),
+      ),
+    )
+  })
+
+  afterAll(async () => {
+    await cleanupItems(
+      compositeTableDef.name,
+      items.map((item) => ({ pk: item.pk, sk: item.sk })),
+    )
+  })
+
+  it('accepts parenthesized sub-expressions in KeyConditionExpression', async () => {
+    const result = await ddb.send(
+      new QueryCommand({
+        TableName: compositeTableDef.name,
+        KeyConditionExpression: '(#pk = :pk) AND (#sk = :sk)',
+        ExpressionAttributeNames: { '#pk': 'pk', '#sk': 'sk' },
+        ExpressionAttributeValues: {
+          ':pk': { S: pk },
+          ':sk': { S: '1' },
+        },
+      }),
+    )
+
+    expect(result.Items).toHaveLength(1)
+    expect(result.Items![0].data?.S).toBe('a')
+  })
+
+  it('accepts parentheses around the full KeyConditionExpression', async () => {
+    const result = await ddb.send(
+      new QueryCommand({
+        TableName: compositeTableDef.name,
+        KeyConditionExpression: '(#pk = :pk AND #sk = :sk)',
+        ExpressionAttributeNames: { '#pk': 'pk', '#sk': 'sk' },
+        ExpressionAttributeValues: {
+          ':pk': { S: pk },
+          ':sk': { S: '2' },
+        },
+      }),
+    )
+
+    expect(result.Items).toHaveLength(1)
+    expect(result.Items![0].data?.S).toBe('b')
+  })
+
+  it('handles nested parentheses in KeyConditionExpression', async () => {
+    const result = await ddb.send(
+      new QueryCommand({
+        TableName: compositeTableDef.name,
+        KeyConditionExpression: '((#pk = :pk)) AND ((#sk = :sk))',
+        ExpressionAttributeNames: { '#pk': 'pk', '#sk': 'sk' },
+        ExpressionAttributeValues: {
+          ':pk': { S: pk },
+          ':sk': { S: '3' },
+        },
+      }),
+    )
+
+    expect(result.Items).toHaveLength(1)
+    expect(result.Items![0].data?.S).toBe('c')
+  })
+})

--- a/tests/tier1/scan/gsiPagination.test.ts
+++ b/tests/tier1/scan/gsiPagination.test.ts
@@ -1,0 +1,135 @@
+import {
+  PutItemCommand,
+  ScanCommand,
+  type AttributeValue,
+} from '@aws-sdk/client-dynamodb'
+import { ddb } from '../../../src/client.js'
+import {
+  uniqueTableName,
+  createTable,
+  deleteTable,
+  waitForGsiConsistency,
+} from '../../../src/helpers.js'
+import type { TestTableDef } from '../../../src/types.js'
+
+describe('Scan — GSI pagination', () => {
+  // Dedicated table: pk=ID(S), GSI on Type(S)+ID(S), ALL projection.
+  // All items share the same GSI PK ("widget") to stress the cursor logic.
+  const tableDef: TestTableDef = {
+    name: uniqueTableName('gsi-page'),
+    hashKey: { name: 'ID', type: 'S' },
+    billingMode: 'PAY_PER_REQUEST',
+    gsis: [
+      {
+        indexName: 'TypeIndex',
+        hashKey: { name: 'Type', type: 'S' },
+        rangeKey: { name: 'ID', type: 'S' },
+        projectionType: 'ALL',
+      },
+    ],
+  }
+
+  const ITEM_COUNT = 50
+
+  beforeAll(async () => {
+    await createTable(tableDef)
+
+    // Insert 50 items all with the same GSI PK ("widget")
+    for (let i = 0; i < ITEM_COUNT; i++) {
+      await ddb.send(
+        new PutItemCommand({
+          TableName: tableDef.name,
+          Item: {
+            ID: { S: `item-${String(i).padStart(3, '0')}` },
+            Type: { S: 'widget' },
+            Num: { N: String(i) },
+          },
+        }),
+      )
+    }
+
+    await waitForGsiConsistency({
+      tableName: tableDef.name,
+      indexName: 'TypeIndex',
+      partitionKey: { name: 'Type', value: { S: 'widget' } },
+      expectedCount: ITEM_COUNT,
+    })
+  }, 30_000)
+
+  afterAll(async () => {
+    await deleteTable(tableDef.name)
+  })
+
+  it('returns all items across paginated GSI scan', async () => {
+    const allItems: Record<string, AttributeValue>[] = []
+    let exclusiveStartKey: Record<string, AttributeValue> | undefined
+    let pages = 0
+
+    do {
+      const result = await ddb.send(
+        new ScanCommand({
+          TableName: tableDef.name,
+          IndexName: 'TypeIndex',
+          Limit: 10,
+          ...(exclusiveStartKey
+            ? { ExclusiveStartKey: exclusiveStartKey }
+            : {}),
+        }),
+      )
+
+      pages++
+      if (result.Items) {
+        allItems.push(...result.Items)
+      }
+      exclusiveStartKey = result.LastEvaluatedKey
+
+      expect(pages).toBeLessThanOrEqual(10) // guard against infinite loops
+    } while (exclusiveStartKey)
+
+    expect(allItems).toHaveLength(ITEM_COUNT)
+  })
+
+  it('returns all matching items with filter across paginated GSI scan', async () => {
+    // Every 5th item has Num divisible by 5 — but filters are applied
+    // after Limit, so we need to paginate to get them all.
+    const allItems: Record<string, AttributeValue>[] = []
+    let exclusiveStartKey: Record<string, AttributeValue> | undefined
+    let pages = 0
+
+    do {
+      const result = await ddb.send(
+        new ScanCommand({
+          TableName: tableDef.name,
+          IndexName: 'TypeIndex',
+          Limit: 10,
+          FilterExpression: 'Num IN (:v0, :v1, :v2, :v3, :v4, :v5, :v6, :v7, :v8, :v9)',
+          ExpressionAttributeValues: {
+            ':v0': { N: '0' },
+            ':v1': { N: '5' },
+            ':v2': { N: '10' },
+            ':v3': { N: '15' },
+            ':v4': { N: '20' },
+            ':v5': { N: '25' },
+            ':v6': { N: '30' },
+            ':v7': { N: '35' },
+            ':v8': { N: '40' },
+            ':v9': { N: '45' },
+          },
+          ...(exclusiveStartKey
+            ? { ExclusiveStartKey: exclusiveStartKey }
+            : {}),
+        }),
+      )
+
+      pages++
+      if (result.Items) {
+        allItems.push(...result.Items)
+      }
+      exclusiveStartKey = result.LastEvaluatedKey
+
+      expect(pages).toBeLessThanOrEqual(20)
+    } while (exclusiveStartKey)
+
+    expect(allItems).toHaveLength(10)
+  })
+})

--- a/tests/tier1/updateItem/conditions.test.ts
+++ b/tests/tier1/updateItem/conditions.test.ts
@@ -16,6 +16,7 @@ describe('UpdateItem — ConditionExpression', () => {
       { pk: { S: 'upd-cond-cmp' } },
       { pk: { S: 'upd-cond-and' } },
       { pk: { S: 'upd-cond-rvcf' } },
+      { pk: { S: 'upd-cond-noexist' } },
     ])
   })
 
@@ -266,5 +267,35 @@ describe('UpdateItem — ConditionExpression', () => {
       expect(err.Item!.status.S).toBe('locked')
       expect(err.Item!.data.S).toBe('important')
     }
+  })
+
+  it('attribute_exists rejects update on non-existent item (no upsert)', async () => {
+    // attribute_exists(pk) on a key that does not exist must fail —
+    // the update should NOT create a ghost item.
+    await cleanupItems(hashTableDef.name, [{ pk: { S: 'upd-cond-noexist' } }])
+
+    await expectDynamoError(
+      () =>
+        ddb.send(
+          new UpdateItemCommand({
+            TableName: hashTableDef.name,
+            Key: { pk: { S: 'upd-cond-noexist' } },
+            UpdateExpression: 'ADD hit_count :inc',
+            ConditionExpression: 'attribute_exists(pk)',
+            ExpressionAttributeValues: { ':inc': { N: '1' } },
+          }),
+        ),
+      'ConditionalCheckFailedException',
+    )
+
+    // Verify no ghost item was created
+    const check = await ddb.send(
+      new GetItemCommand({
+        TableName: hashTableDef.name,
+        Key: { pk: { S: 'upd-cond-noexist' } },
+        ConsistentRead: true,
+      }),
+    )
+    expect(check.Item).toBeUndefined()
   })
 })

--- a/tests/tier2/transactions/transactWrite.test.ts
+++ b/tests/tier2/transactions/transactWrite.test.ts
@@ -40,6 +40,7 @@ const hashKeys = [
   { pk: { S: 'tw-multi-del-3' } },
   { pk: { S: 'tw-dup-1' } },
   { pk: { S: 'tw-idem-mismatch' } },
+  { pk: { S: 'tw-cond-noexist' } },
 ]
 
 const compositeKeys = [
@@ -678,5 +679,45 @@ describe('TransactWriteItems - validation', () => {
         ),
       'ResourceNotFoundException',
     )
+  })
+
+  it('Update with attribute_exists rejects non-existent item', async () => {
+    // TransactWriteItems Update with attribute_exists(pk) on a key that does
+    // not exist must cancel the transaction — not silently create the item.
+    await cleanupItems(hashTableDef.name, [{ pk: { S: 'tw-cond-noexist' } }])
+
+    try {
+      await ddb.send(
+        new TransactWriteItemsCommand({
+          TransactItems: [
+            {
+              Update: {
+                TableName: hashTableDef.name,
+                Key: { pk: { S: 'tw-cond-noexist' } },
+                UpdateExpression: 'ADD hit_count :inc',
+                ConditionExpression: 'attribute_exists(pk)',
+                ExpressionAttributeValues: { ':inc': { N: '1' } },
+              },
+            },
+          ],
+        }),
+      )
+      expect.unreachable('should have thrown TransactionCanceledException')
+    } catch (e) {
+      expect(e).toBeInstanceOf(TransactionCanceledException)
+      const err = e as TransactionCanceledException
+      expect(err.CancellationReasons).toBeDefined()
+      expect(err.CancellationReasons![0].Code).toBe('ConditionalCheckFailed')
+    }
+
+    // Verify no ghost item was created
+    const check = await ddb.send(
+      new GetItemCommand({
+        TableName: hashTableDef.name,
+        Key: { pk: { S: 'tw-cond-noexist' } },
+        ConsistentRead: true,
+      }),
+    )
+    expect(check.Item).toBeUndefined()
   })
 })


### PR DESCRIPTION
Adds conformance tests for four issues found while running dynoxide as a DynamoDB Local replacement in a large Go integration test suite.

## 1. KeyConditionExpression rejects parenthesized sub-expressions

**File:** `tests/tier1/query/keyConditionParens.test.ts`

DynamoDB accepts parentheses in `KeyConditionExpression` — e.g. `(#pk = :pk) AND (#sk = :sk)`. Tests cover parens around individual conditions, around the full expression, and nested parens.

**Dynoxide issue:** https://github.com/nubo-db/dynoxide/issues/3

## 2. UpdateItem ignores ConditionExpression on non-existent items

**Files:** `tests/tier1/updateItem/conditions.test.ts`, `tests/tier2/transactions/transactWrite.test.ts`

`UpdateItem` and `TransactWriteItems` Update with `attribute_exists(pk)` should fail with `ConditionalCheckFailedException` when the item doesn't exist. Tests verify both the error and that no ghost item is created.

**Dynoxide PR:** https://github.com/nubo-db/dynoxide/pull/5

## 3. GSI scan pagination breaks after the first page

**File:** `tests/tier1/scan/gsiPagination.test.ts`

Paginated `Scan` on a GSI (with `Limit`) should return all items across multiple pages. When many items share the same GSI partition key, the `ExclusiveStartKey` cursor must include the base table key to correctly position the next page. Tests cover both plain scan and scan with `FilterExpression`.

**Dynoxide PR:** https://github.com/nubo-db/dynoxide/pull/6

## 4. Not-equals comparison on missing attribute returns false instead of true

**File:** `tests/tier1/putItem/conditions.test.ts`

When an attribute doesn't exist, `<>` (not-equals) should return true — a non-existent value is not equal to any value. Tests cover `<>` on missing attributes, OR with `<>` and `<` on missing attributes, and `=` on missing attributes as a sanity check.