### PR TITLE
test(tier3): pin error-messages to exact strings

### DIFF
--- a/tests/tier3/error-messages/createTable.test.ts
+++ b/tests/tier3/error-messages/createTable.test.ts
@@ -1,9 +1,11 @@
-import { CreateTableCommand } from '@aws-sdk/client-dynamodb'
+import {
+  CreateTableCommand,
+  DynamoDBServiceException,
+} from '@aws-sdk/client-dynamodb'
 import { ddb } from '../../../src/client.js'
 import {
   uniqueTableName,
   deleteTable,
-  expectDynamoError,
 } from '../../../src/helpers.js'
 
 describe('CreateTable — exact error messages', () => {
@@ -13,39 +15,49 @@ describe('CreateTable — exact error messages', () => {
     await Promise.all(tablesToCleanup.map(deleteTable))
   })
 
-  it('missing TableName: exact error message', async () => {
-    await expectDynamoError(
-      () => ddb.send(
+  it('missing TableName: full required-parameter error', async () => {
+    try {
+      await ddb.send(
         new CreateTableCommand({
           TableName: undefined as unknown as string,
           AttributeDefinitions: [{ AttributeName: 'pk', AttributeType: 'S' }],
           KeySchema: [{ AttributeName: 'pk', KeyType: 'HASH' }],
           ProvisionedThroughput: { ReadCapacityUnits: 5, WriteCapacityUnits: 5 },
         }),
-      ),
-      'ValidationException',
-      /TableName.*required|Member must not be null/,
-    )
+      )
+      expect.unreachable('should have thrown')
+    } catch (err) {
+      expect(err).toBeInstanceOf(DynamoDBServiceException)
+      expect((err as DynamoDBServiceException).name).toBe('ValidationException')
+      expect((err as DynamoDBServiceException).message).toBe(
+        "The parameter 'TableName' is required but was not present in the request",
+      )
+    }
   })
 
-  it('empty/short table name: "TableName must be at least 3 characters long"', async () => {
-    await expectDynamoError(
-      () => ddb.send(
+  it('short table name (2 chars): minimum length 3 error', async () => {
+    try {
+      await ddb.send(
         new CreateTableCommand({
           TableName: 'ab',
           AttributeDefinitions: [{ AttributeName: 'pk', AttributeType: 'S' }],
           KeySchema: [{ AttributeName: 'pk', KeyType: 'HASH' }],
           ProvisionedThroughput: { ReadCapacityUnits: 5, WriteCapacityUnits: 5 },
         }),
-      ),
-      'ValidationException',
-      /TableName must be at least 3 characters long|Member must have length greater than or equal to 3/,
-    )
+      )
+      expect.unreachable('should have thrown')
+    } catch (err) {
+      expect(err).toBeInstanceOf(DynamoDBServiceException)
+      expect((err as DynamoDBServiceException).name).toBe('ValidationException')
+      expect((err as DynamoDBServiceException).message).toBe(
+        "1 validation error detected: Value 'ab' at 'tableName' failed to satisfy constraint: Member must have length greater than or equal to 3",
+      )
+    }
   })
 
   it('duplicate attribute in KeySchema', async () => {
-    await expectDynamoError(
-      () => ddb.send(
+    try {
+      await ddb.send(
         new CreateTableCommand({
           TableName: uniqueTableName('ct_dup_key'),
           AttributeDefinitions: [{ AttributeName: 'pk', AttributeType: 'S' }],
@@ -55,15 +67,20 @@ describe('CreateTable — exact error messages', () => {
           ],
           ProvisionedThroughput: { ReadCapacityUnits: 5, WriteCapacityUnits: 5 },
         }),
-      ),
-      'ValidationException',
-      /[Dd]uplicate|Invalid KeySchema|Both the Hash Key and the Range Key element in the KeySchema have the same Attribute/,
-    )
+      )
+      expect.unreachable('should have thrown')
+    } catch (err) {
+      expect(err).toBeInstanceOf(DynamoDBServiceException)
+      expect((err as DynamoDBServiceException).name).toBe('ValidationException')
+      expect((err as DynamoDBServiceException).message).toBe(
+        'Invalid KeySchema: Some index key attribute have no definition',
+      )
+    }
   })
 
   it('more than 2 KeySchema elements', async () => {
-    await expectDynamoError(
-      () => ddb.send(
+    try {
+      await ddb.send(
         new CreateTableCommand({
           TableName: uniqueTableName('ct_3keys'),
           AttributeDefinitions: [
@@ -78,15 +95,20 @@ describe('CreateTable — exact error messages', () => {
           ],
           ProvisionedThroughput: { ReadCapacityUnits: 5, WriteCapacityUnits: 5 },
         }),
-      ),
-      'ValidationException',
-      /[Kk]ey[Ss]chema|Too many key schema elements|keySchema.*member must have length less than or equal to 2/i,
-    )
+      )
+      expect.unreachable('should have thrown')
+    } catch (err) {
+      expect(err).toBeInstanceOf(DynamoDBServiceException)
+      expect((err as DynamoDBServiceException).name).toBe('ValidationException')
+      expect((err as DynamoDBServiceException).message).toBe(
+        "1 validation error detected: Value '[KeySchemaElement(attributeName=pk, keyType=HASH), KeySchemaElement(attributeName=sk, keyType=RANGE), KeySchemaElement(attributeName=extra, keyType=RANGE)]' at 'keySchema' failed to satisfy constraint: Member must have length less than or equal to 2",
+      )
+    }
   })
 
   it('invalid KeyType', async () => {
-    await expectDynamoError(
-      () => ddb.send(
+    try {
+      await ddb.send(
         new CreateTableCommand({
           TableName: uniqueTableName('ct_bad_keytype'),
           AttributeDefinitions: [{ AttributeName: 'pk', AttributeType: 'S' }],
@@ -96,15 +118,20 @@ describe('CreateTable — exact error messages', () => {
           ],
           ProvisionedThroughput: { ReadCapacityUnits: 5, WriteCapacityUnits: 5 },
         }),
-      ),
-      'ValidationException',
-      /[Kk]ey[Tt]ype|enum value set/,
-    )
+      )
+      expect.unreachable('should have thrown')
+    } catch (err) {
+      expect(err).toBeInstanceOf(DynamoDBServiceException)
+      expect((err as DynamoDBServiceException).name).toBe('ValidationException')
+      expect((err as DynamoDBServiceException).message).toBe(
+        "1 validation error detected: Value 'INVALID' at 'keySchema.1.member.keyType' failed to satisfy constraint: Member must satisfy enum value set: [HASH, RANGE]",
+      )
+    }
   })
 
   it('invalid AttributeType', async () => {
-    await expectDynamoError(
-      () => ddb.send(
+    try {
+      await ddb.send(
         new CreateTableCommand({
           TableName: uniqueTableName('ct_bad_attrtype'),
           // @ts-expect-error -- testing invalid AttributeType
@@ -112,15 +139,20 @@ describe('CreateTable — exact error messages', () => {
           KeySchema: [{ AttributeName: 'pk', KeyType: 'HASH' }],
           ProvisionedThroughput: { ReadCapacityUnits: 5, WriteCapacityUnits: 5 },
         }),
-      ),
-      'ValidationException',
-      /[Aa]ttribute[Tt]ype|enum value set/,
-    )
+      )
+      expect.unreachable('should have thrown')
+    } catch (err) {
+      expect(err).toBeInstanceOf(DynamoDBServiceException)
+      expect((err as DynamoDBServiceException).name).toBe('ValidationException')
+      expect((err as DynamoDBServiceException).message).toBe(
+        "1 validation error detected: Value 'INVALID' at 'attributeDefinitions.1.member.attributeType' failed to satisfy constraint: Member must satisfy enum value set: [B, N, S]",
+      )
+    }
   })
 
   it('LSI without range key on base table', async () => {
-    await expectDynamoError(
-      () => ddb.send(
+    try {
+      await ddb.send(
         new CreateTableCommand({
           TableName: uniqueTableName('ct_lsi_no_range'),
           AttributeDefinitions: [
@@ -140,15 +172,20 @@ describe('CreateTable — exact error messages', () => {
           ],
           ProvisionedThroughput: { ReadCapacityUnits: 5, WriteCapacityUnits: 5 },
         }),
-      ),
-      'ValidationException',
-      /[Ll]ocal [Ss]econdary|Table KeySchema does not have a range key/,
-    )
+      )
+      expect.unreachable('should have thrown')
+    } catch (err) {
+      expect(err).toBeInstanceOf(DynamoDBServiceException)
+      expect((err as DynamoDBServiceException).name).toBe('ValidationException')
+      expect((err as DynamoDBServiceException).message).toBe(
+        'One or more parameter values were invalid: Table KeySchema does not have a range key, which is required when specifying a LocalSecondaryIndex',
+      )
+    }
   })
 
   it('duplicate index names', async () => {
-    await expectDynamoError(
-      () => ddb.send(
+    try {
+      await ddb.send(
         new CreateTableCommand({
           TableName: uniqueTableName('ct_dup_idx'),
           AttributeDefinitions: [
@@ -177,9 +214,14 @@ describe('CreateTable — exact error messages', () => {
           ],
           ProvisionedThroughput: { ReadCapacityUnits: 5, WriteCapacityUnits: 5 },
         }),
-      ),
-      'ValidationException',
-      /[Dd]uplicate/,
-    )
+      )
+      expect.unreachable('should have thrown')
+    } catch (err) {
+      expect(err).toBeInstanceOf(DynamoDBServiceException)
+      expect((err as DynamoDBServiceException).name).toBe('ValidationException')
+      expect((err as DynamoDBServiceException).message).toBe(
+        'One or more parameter values were invalid: Duplicate index name: sameIndex',
+      )
+    }
   })
 })

--- a/tests/tier3/error-messages/putItem.test.ts
+++ b/tests/tier3/error-messages/putItem.test.ts
@@ -1,10 +1,11 @@
-import { PutItemCommand } from '@aws-sdk/client-dynamodb'
+import {
+  PutItemCommand,
+  DynamoDBServiceException,
+} from '@aws-sdk/client-dynamodb'
 import { ddb } from '../../../src/client.js'
 import {
   hashTableDef,
-  compositeTableDef,
   cleanupItems,
-  expectDynamoError,
 } from '../../../src/helpers.js'
 
 const keysToCleanup = [
@@ -16,136 +17,186 @@ afterAll(async () => {
 })
 
 describe('PutItem — exact error messages', () => {
-  it('missing table name: "Member must not be null"', async () => {
-    await expectDynamoError(
-      () => ddb.send(
+  it('missing table name: full validation error string', async () => {
+    try {
+      await ddb.send(
         new PutItemCommand({
           TableName: undefined as unknown as string,
           Item: { pk: { S: 'test' } },
         }),
-      ),
-      'ValidationException',
-      'Member must not be null',
-    )
+      )
+      expect.unreachable('should have thrown')
+    } catch (err) {
+      expect(err).toBeInstanceOf(DynamoDBServiceException)
+      expect((err as DynamoDBServiceException).name).toBe('ValidationException')
+      expect((err as DynamoDBServiceException).message).toBe(
+        "1 validation error detected: Value null at 'tableName' failed to satisfy constraint: Member must not be null",
+      )
+    }
   })
 
-  it('empty table name: validation error for minimum length', async () => {
-    await expectDynamoError(
-      () => ddb.send(
+  it('empty table name: minimum length 1 error', async () => {
+    try {
+      await ddb.send(
         new PutItemCommand({
           TableName: '',
           Item: { pk: { S: 'test' } },
         }),
-      ),
-      'ValidationException',
-      /Member must have length greater than or equal to 1|Member must satisfy regular expression/,
-    )
+      )
+      expect.unreachable('should have thrown')
+    } catch (err) {
+      expect(err).toBeInstanceOf(DynamoDBServiceException)
+      expect((err as DynamoDBServiceException).name).toBe('ValidationException')
+      expect((err as DynamoDBServiceException).message).toBe(
+        "1 validation error detected: Value '' at 'tableName' failed to satisfy constraint: Member must have length greater than or equal to 1",
+      )
+    }
   })
 
-  it('table name too long (256 chars): "Member must have length less than or equal to 255"', async () => {
-    await expectDynamoError(
-      () => ddb.send(
+  it('table name too long (256 chars): maximum length 255 error', async () => {
+    try {
+      await ddb.send(
         new PutItemCommand({
           TableName: 'a'.repeat(256),
           Item: { pk: { S: 'test' } },
         }),
-      ),
-      'ValidationException',
-      'Member must have length less than or equal to 255',
-    )
+      )
+      expect.unreachable('should have thrown')
+    } catch (err) {
+      expect(err).toBeInstanceOf(DynamoDBServiceException)
+      expect((err as DynamoDBServiceException).name).toBe('ValidationException')
+      expect((err as DynamoDBServiceException).message).toBe(
+        `1 validation error detected: Value '${'a'.repeat(256)}' at 'tableName' failed to satisfy constraint: Member must have length less than or equal to 255`,
+      )
+    }
   })
 
-  it('table name with invalid chars: "Member must satisfy regular expression pattern"', async () => {
-    await expectDynamoError(
-      () => ddb.send(
+  it('table name with invalid chars: regex pattern error', async () => {
+    try {
+      await ddb.send(
         new PutItemCommand({
           TableName: 'bad table!@#',
           Item: { pk: { S: 'test' } },
         }),
-      ),
-      'ValidationException',
-      /Member must satisfy regular expression pattern: \[a-zA-Z0-9_.\-\]\+/,
-    )
+      )
+      expect.unreachable('should have thrown')
+    } catch (err) {
+      expect(err).toBeInstanceOf(DynamoDBServiceException)
+      expect((err as DynamoDBServiceException).name).toBe('ValidationException')
+      expect((err as DynamoDBServiceException).message).toBe(
+        "1 validation error detected: Value 'bad table!@#' at 'tableName' failed to satisfy constraint: Member must satisfy regular expression pattern: [a-zA-Z0-9_.-]+",
+      )
+    }
   })
 
-  it('empty string set: "An string set  may not be empty"', async () => {
-    await expectDynamoError(
-      () => ddb.send(
+  it('empty string set: full parameter-values-invalid error', async () => {
+    try {
+      await ddb.send(
         new PutItemCommand({
           TableName: hashTableDef.name,
           Item: { pk: { S: 'test' }, bad: { SS: [] } },
         }),
-      ),
-      'ValidationException',
-      'An string set  may not be empty',
-    )
+      )
+      expect.unreachable('should have thrown')
+    } catch (err) {
+      expect(err).toBeInstanceOf(DynamoDBServiceException)
+      expect((err as DynamoDBServiceException).name).toBe('ValidationException')
+      expect((err as DynamoDBServiceException).message).toBe(
+        'One or more parameter values were invalid: An string set  may not be empty',
+      )
+    }
   })
 
-  it('empty number set: "An number set  may not be empty"', async () => {
-    await expectDynamoError(
-      () => ddb.send(
+  it('empty number set: full parameter-values-invalid error', async () => {
+    try {
+      await ddb.send(
         new PutItemCommand({
           TableName: hashTableDef.name,
           Item: { pk: { S: 'test' }, bad: { NS: [] } },
         }),
-      ),
-      'ValidationException',
-      'An number set  may not be empty',
-    )
+      )
+      expect.unreachable('should have thrown')
+    } catch (err) {
+      expect(err).toBeInstanceOf(DynamoDBServiceException)
+      expect((err as DynamoDBServiceException).name).toBe('ValidationException')
+      expect((err as DynamoDBServiceException).message).toBe(
+        'One or more parameter values were invalid: An number set  may not be empty',
+      )
+    }
   })
 
-  it('duplicate values in SS: "Input collection [x, x] contains duplicates"', async () => {
-    await expectDynamoError(
-      () => ddb.send(
+  it('duplicate values in SS: full duplicates error', async () => {
+    try {
+      await ddb.send(
         new PutItemCommand({
           TableName: hashTableDef.name,
           Item: { pk: { S: 'test' }, bad: { SS: ['a', 'a'] } },
         }),
-      ),
-      'ValidationException',
-      /Input collection.*contains duplicates/,
-    )
+      )
+      expect.unreachable('should have thrown')
+    } catch (err) {
+      expect(err).toBeInstanceOf(DynamoDBServiceException)
+      expect((err as DynamoDBServiceException).name).toBe('ValidationException')
+      expect((err as DynamoDBServiceException).message).toBe(
+        'One or more parameter values were invalid: Input collection [a, a] contains duplicates.',
+      )
+    }
   })
 
-  it('NULL attr with false: "Null attribute value types must have the value of true"', async () => {
-    await expectDynamoError(
-      () => ddb.send(
+  it('NULL attr with false: full null-attribute error', async () => {
+    try {
+      await ddb.send(
         new PutItemCommand({
           TableName: hashTableDef.name,
           Item: { pk: { S: 'em-put-null-false' }, attr1: { NULL: false } },
         }),
-      ),
-      'ValidationException',
-      'Null attribute value types must have the value of true',
-    )
+      )
+      expect.unreachable('should have thrown')
+    } catch (err) {
+      expect(err).toBeInstanceOf(DynamoDBServiceException)
+      expect((err as DynamoDBServiceException).name).toBe('ValidationException')
+      expect((err as DynamoDBServiceException).message).toBe(
+        'One or more parameter values were invalid: Null attribute value types must have the value of true',
+      )
+    }
   })
 
-  it('mixing expression and non-expression: exact message', async () => {
-    await expectDynamoError(
-      () => ddb.send(
+  it('mixing expression and non-expression: full conflict error', async () => {
+    try {
+      await ddb.send(
         new PutItemCommand({
           TableName: hashTableDef.name,
           Item: { pk: { S: 'test' } },
           Expected: { pk: { Exists: false } },
           ConditionExpression: 'attribute_not_exists(pk)',
         }),
-      ),
-      'ValidationException',
-      'Can not use both expression and non-expression parameters in the same request: Non-expression parameters: {Expected} Expression parameters: {ConditionExpression}',
-    )
+      )
+      expect.unreachable('should have thrown')
+    } catch (err) {
+      expect(err).toBeInstanceOf(DynamoDBServiceException)
+      expect((err as DynamoDBServiceException).name).toBe('ValidationException')
+      expect((err as DynamoDBServiceException).message).toBe(
+        'Can not use both expression and non-expression parameters in the same request: Non-expression parameters: {Expected} Expression parameters: {ConditionExpression}',
+      )
+    }
   })
 
-  it('ExpressionAttributeValues without expression: error message', async () => {
-    await expectDynamoError(
-      () => ddb.send(
+  it('ExpressionAttributeValues without expression: full unused-EAV error', async () => {
+    try {
+      await ddb.send(
         new PutItemCommand({
           TableName: hashTableDef.name,
           Item: { pk: { S: 'test' } },
           ExpressionAttributeValues: { ':v': { S: 'unused' } },
         }),
-      ),
-      'ValidationException',
-      'ExpressionAttributeValues can only be specified when using expressions',
-    )
+      )
+      expect.unreachable('should have thrown')
+    } catch (err) {
+      expect(err).toBeInstanceOf(DynamoDBServiceException)
+      expect((err as DynamoDBServiceException).name).toBe('ValidationException')
+      expect((err as DynamoDBServiceException).message).toBe(
+        'ExpressionAttributeValues can only be specified when using expressions: ConditionExpression is null',
+      )
+    }
   })
 })

--- a/tests/tier3/error-messages/query.test.ts
+++ b/tests/tier3/error-messages/query.test.ts
@@ -1,58 +1,74 @@
-import { QueryCommand } from '@aws-sdk/client-dynamodb'
+import {
+  QueryCommand,
+  DynamoDBServiceException,
+} from '@aws-sdk/client-dynamodb'
 import { ddb } from '../../../src/client.js'
 import {
-  hashTableDef,
   compositeTableDef,
-  expectDynamoError,
 } from '../../../src/helpers.js'
 
 describe('Query — exact error messages', () => {
   it('missing hash key in KeyConditionExpression', async () => {
-    await expectDynamoError(
-      () => ddb.send(
+    try {
+      await ddb.send(
         new QueryCommand({
           TableName: compositeTableDef.name,
           KeyConditionExpression: 'sk = :v',
           ExpressionAttributeValues: { ':v': { S: 'val' } },
         }),
-      ),
-      'ValidationException',
-      /[Kk]ey condition|Query condition missed key schema element/i,
-    )
+      )
+      expect.unreachable('should have thrown')
+    } catch (err) {
+      expect(err).toBeInstanceOf(DynamoDBServiceException)
+      expect((err as DynamoDBServiceException).name).toBe('ValidationException')
+      expect((err as DynamoDBServiceException).message).toBe(
+        'Query condition missed key schema element: pk',
+      )
+    }
   })
 
   it('non-key attribute in KeyConditionExpression', async () => {
-    await expectDynamoError(
-      () => ddb.send(
+    try {
+      await ddb.send(
         new QueryCommand({
           TableName: compositeTableDef.name,
           KeyConditionExpression: 'attr1 = :v',
           ExpressionAttributeValues: { ':v': { S: 'val' } },
         }),
-      ),
-      'ValidationException',
-      /[Kk]ey.*schema/i,
-    )
+      )
+      expect.unreachable('should have thrown')
+    } catch (err) {
+      expect(err).toBeInstanceOf(DynamoDBServiceException)
+      expect((err as DynamoDBServiceException).name).toBe('ValidationException')
+      expect((err as DynamoDBServiceException).message).toBe(
+        'Query condition missed key schema element: pk',
+      )
+    }
   })
 
   it('unused ExpressionAttributeNames', async () => {
-    await expectDynamoError(
-      () => ddb.send(
+    try {
+      await ddb.send(
         new QueryCommand({
           TableName: compositeTableDef.name,
           KeyConditionExpression: 'pk = :v',
           ExpressionAttributeValues: { ':v': { S: 'val' } },
           ExpressionAttributeNames: { '#unused': 'someattr' },
         }),
-      ),
-      'ValidationException',
-      'Value provided in ExpressionAttributeNames unused in expressions',
-    )
+      )
+      expect.unreachable('should have thrown')
+    } catch (err) {
+      expect(err).toBeInstanceOf(DynamoDBServiceException)
+      expect((err as DynamoDBServiceException).name).toBe('ValidationException')
+      expect((err as DynamoDBServiceException).message).toBe(
+        'Value provided in ExpressionAttributeNames unused in expressions: keys: {#unused}',
+      )
+    }
   })
 
   it('invalid Select value', async () => {
-    await expectDynamoError(
-      () => ddb.send(
+    try {
+      await ddb.send(
         new QueryCommand({
           TableName: compositeTableDef.name,
           KeyConditionExpression: 'pk = :v',
@@ -60,15 +76,20 @@ describe('Query — exact error messages', () => {
           // @ts-expect-error -- testing invalid Select
           Select: 'INVALID_VALUE',
         }),
-      ),
-      'ValidationException',
-      /Member must satisfy enum value set|Value .* at 'select' failed to satisfy/,
-    )
+      )
+      expect.unreachable('should have thrown')
+    } catch (err) {
+      expect(err).toBeInstanceOf(DynamoDBServiceException)
+      expect((err as DynamoDBServiceException).name).toBe('ValidationException')
+      expect((err as DynamoDBServiceException).message).toBe(
+        "1 validation error detected: Value 'INVALID_VALUE' at 'select' failed to satisfy constraint: Member must satisfy enum value set: [SPECIFIC_ATTRIBUTES, COUNT, ALL_ATTRIBUTES, ALL_PROJECTED_ATTRIBUTES]",
+      )
+    }
   })
 
   it('ConsistentRead on GSI', async () => {
-    await expectDynamoError(
-      () => ddb.send(
+    try {
+      await ddb.send(
         new QueryCommand({
           TableName: compositeTableDef.name,
           IndexName: 'gsi1',
@@ -77,53 +98,73 @@ describe('Query — exact error messages', () => {
           ExpressionAttributeValues: { ':v': { S: 'val' } },
           ConsistentRead: true,
         }),
-      ),
-      'ValidationException',
-      'Consistent reads are not supported on global secondary indexes',
-    )
+      )
+      expect.unreachable('should have thrown')
+    } catch (err) {
+      expect(err).toBeInstanceOf(DynamoDBServiceException)
+      expect((err as DynamoDBServiceException).name).toBe('ValidationException')
+      expect((err as DynamoDBServiceException).message).toBe(
+        'Consistent reads are not supported on global secondary indexes',
+      )
+    }
   })
 
   it('Limit of 0', async () => {
-    await expectDynamoError(
-      () => ddb.send(
+    try {
+      await ddb.send(
         new QueryCommand({
           TableName: compositeTableDef.name,
           KeyConditionExpression: 'pk = :v',
           ExpressionAttributeValues: { ':v': { S: 'val' } },
           Limit: 0,
         }),
-      ),
-      'ValidationException',
-      /[Ll]imit/,
-    )
+      )
+      expect.unreachable('should have thrown')
+    } catch (err) {
+      expect(err).toBeInstanceOf(DynamoDBServiceException)
+      expect((err as DynamoDBServiceException).name).toBe('ValidationException')
+      expect((err as DynamoDBServiceException).message).toBe(
+        "1 validation error detected: Value at 'Limit' failed to satisfy constraint: Member must have value greater than or equal to 1",
+      )
+    }
   })
 
   it('empty KeyConditionExpression', async () => {
-    await expectDynamoError(
-      () => ddb.send(
+    try {
+      await ddb.send(
         new QueryCommand({
           TableName: compositeTableDef.name,
           KeyConditionExpression: '',
           ExpressionAttributeValues: { ':v': { S: 'val' } },
         }),
-      ),
-      'ValidationException',
-      /expression/i,
-    )
+      )
+      expect.unreachable('should have thrown')
+    } catch (err) {
+      expect(err).toBeInstanceOf(DynamoDBServiceException)
+      expect((err as DynamoDBServiceException).name).toBe('ValidationException')
+      expect((err as DynamoDBServiceException).message).toBe(
+        'Invalid KeyConditionExpression: The expression can not be empty;',
+      )
+    }
   })
 
   it('filter references undefined ExpressionAttributeNames', async () => {
-    await expectDynamoError(
-      () => ddb.send(
+    try {
+      await ddb.send(
         new QueryCommand({
           TableName: compositeTableDef.name,
           KeyConditionExpression: 'pk = :pk',
           FilterExpression: '#missing = :fv',
           ExpressionAttributeValues: { ':pk': { S: 'val' }, ':fv': { S: 'x' } },
         }),
-      ),
-      'ValidationException',
-      /ExpressionAttributeNames|substitution.*not found|Invalid FilterExpression/,
-    )
+      )
+      expect.unreachable('should have thrown')
+    } catch (err) {
+      expect(err).toBeInstanceOf(DynamoDBServiceException)
+      expect((err as DynamoDBServiceException).name).toBe('ValidationException')
+      expect((err as DynamoDBServiceException).message).toBe(
+        'Invalid FilterExpression: An expression attribute name used in the document path is not defined; attribute name: #missing',
+      )
+    }
   })
 })

--- a/tests/tier3/error-messages/updateItem.test.ts
+++ b/tests/tier3/error-messages/updateItem.test.ts
@@ -1,10 +1,12 @@
-import { UpdateItemCommand, PutItemCommand } from '@aws-sdk/client-dynamodb'
+import {
+  UpdateItemCommand,
+  DynamoDBServiceException,
+} from '@aws-sdk/client-dynamodb'
 import { ddb } from '../../../src/client.js'
 import {
   hashTableDef,
   compositeTableDef,
   cleanupItems,
-  expectDynamoError,
 } from '../../../src/helpers.js'
 
 const hashKeys = [
@@ -23,38 +25,48 @@ afterAll(async () => {
 
 describe('UpdateItem — exact error messages', () => {
   it('cannot update hash key attribute', async () => {
-    await expectDynamoError(
-      () => ddb.send(
+    try {
+      await ddb.send(
         new UpdateItemCommand({
           TableName: hashTableDef.name,
           Key: { pk: { S: 'em-upd-key-mod' } },
           UpdateExpression: 'SET pk = :v',
           ExpressionAttributeValues: { ':v': { S: 'new-val' } },
         }),
-      ),
-      'ValidationException',
-      /Cannot update attribute.*key/i,
-    )
+      )
+      expect.unreachable('should have thrown')
+    } catch (err) {
+      expect(err).toBeInstanceOf(DynamoDBServiceException)
+      expect((err as DynamoDBServiceException).name).toBe('ValidationException')
+      expect((err as DynamoDBServiceException).message).toBe(
+        'One or more parameter values were invalid: Cannot update attribute pk. This attribute is part of the key',
+      )
+    }
   })
 
   it('invalid UpdateExpression syntax', async () => {
-    await expectDynamoError(
-      () => ddb.send(
+    try {
+      await ddb.send(
         new UpdateItemCommand({
           TableName: hashTableDef.name,
           Key: { pk: { S: 'em-upd-key-mod' } },
           UpdateExpression: 'INVALID SYNTAX HERE',
           ExpressionAttributeValues: { ':v': { S: 'val' } },
         }),
-      ),
-      'ValidationException',
-      'Invalid UpdateExpression',
-    )
+      )
+      expect.unreachable('should have thrown')
+    } catch (err) {
+      expect(err).toBeInstanceOf(DynamoDBServiceException)
+      expect((err as DynamoDBServiceException).name).toBe('ValidationException')
+      expect((err as DynamoDBServiceException).message).toBe(
+        'Invalid UpdateExpression: Syntax error; token: "INVALID", near: "INVALID SYNTAX"',
+      )
+    }
   })
 
   it('unused ExpressionAttributeNames', async () => {
-    await expectDynamoError(
-      () => ddb.send(
+    try {
+      await ddb.send(
         new UpdateItemCommand({
           TableName: hashTableDef.name,
           Key: { pk: { S: 'em-upd-key-mod' } },
@@ -62,44 +74,59 @@ describe('UpdateItem — exact error messages', () => {
           ExpressionAttributeValues: { ':v': { S: 'val' } },
           ExpressionAttributeNames: { '#unused': 'someattr' },
         }),
-      ),
-      'ValidationException',
-      'Value provided in ExpressionAttributeNames unused in expressions',
-    )
+      )
+      expect.unreachable('should have thrown')
+    } catch (err) {
+      expect(err).toBeInstanceOf(DynamoDBServiceException)
+      expect((err as DynamoDBServiceException).name).toBe('ValidationException')
+      expect((err as DynamoDBServiceException).message).toBe(
+        'Value provided in ExpressionAttributeNames unused in expressions: keys: {#unused}',
+      )
+    }
   })
 
   it('unused ExpressionAttributeValues', async () => {
-    await expectDynamoError(
-      () => ddb.send(
+    try {
+      await ddb.send(
         new UpdateItemCommand({
           TableName: hashTableDef.name,
           Key: { pk: { S: 'em-upd-key-mod' } },
           UpdateExpression: 'SET attr1 = :v',
           ExpressionAttributeValues: { ':v': { S: 'val' }, ':unused': { S: 'extra' } },
         }),
-      ),
-      'ValidationException',
-      'Value provided in ExpressionAttributeValues unused in expressions',
-    )
+      )
+      expect.unreachable('should have thrown')
+    } catch (err) {
+      expect(err).toBeInstanceOf(DynamoDBServiceException)
+      expect((err as DynamoDBServiceException).name).toBe('ValidationException')
+      expect((err as DynamoDBServiceException).message).toBe(
+        'Value provided in ExpressionAttributeValues unused in expressions: keys: {:unused}',
+      )
+    }
   })
 
   it('missing ExpressionAttributeValues reference', async () => {
-    await expectDynamoError(
-      () => ddb.send(
+    try {
+      await ddb.send(
         new UpdateItemCommand({
           TableName: hashTableDef.name,
           Key: { pk: { S: 'em-upd-key-mod' } },
           UpdateExpression: 'SET attr1 = :v',
         }),
-      ),
-      'ValidationException',
-      /was not substituted|not defined|expression attribute value|Value provided in ExpressionAttributeValues unused in expressions|ExpressionAttributeValues must not be empty/,
-    )
+      )
+      expect.unreachable('should have thrown')
+    } catch (err) {
+      expect(err).toBeInstanceOf(DynamoDBServiceException)
+      expect((err as DynamoDBServiceException).name).toBe('ValidationException')
+      expect((err as DynamoDBServiceException).message).toBe(
+        'Invalid UpdateExpression: An expression attribute value used in expression is not defined; attribute value: :v',
+      )
+    }
   })
 
   it('mixing UpdateExpression with AttributeUpdates', async () => {
-    await expectDynamoError(
-      () => ddb.send(
+    try {
+      await ddb.send(
         new UpdateItemCommand({
           TableName: hashTableDef.name,
           Key: { pk: { S: 'em-upd-key-mod' } },
@@ -109,38 +136,53 @@ describe('UpdateItem — exact error messages', () => {
             attr1: { Value: { S: 'val' }, Action: 'PUT' },
           },
         }),
-      ),
-      'ValidationException',
-      'Can not use both expression and non-expression',
-    )
+      )
+      expect.unreachable('should have thrown')
+    } catch (err) {
+      expect(err).toBeInstanceOf(DynamoDBServiceException)
+      expect((err as DynamoDBServiceException).name).toBe('ValidationException')
+      expect((err as DynamoDBServiceException).message).toBe(
+        'Can not use both expression and non-expression parameters in the same request: Non-expression parameters: {AttributeUpdates} Expression parameters: {UpdateExpression}',
+      )
+    }
   })
 
   it('empty UpdateExpression', async () => {
-    await expectDynamoError(
-      () => ddb.send(
+    try {
+      await ddb.send(
         new UpdateItemCommand({
           TableName: hashTableDef.name,
           Key: { pk: { S: 'em-upd-key-mod' } },
           UpdateExpression: '',
         }),
-      ),
-      'ValidationException',
-      'Invalid UpdateExpression',
-    )
+      )
+      expect.unreachable('should have thrown')
+    } catch (err) {
+      expect(err).toBeInstanceOf(DynamoDBServiceException)
+      expect((err as DynamoDBServiceException).name).toBe('ValidationException')
+      expect((err as DynamoDBServiceException).message).toBe(
+        'Invalid UpdateExpression: The expression can not be empty;',
+      )
+    }
   })
 
   it('cannot update range key attribute on composite table', async () => {
-    await expectDynamoError(
-      () => ddb.send(
+    try {
+      await ddb.send(
         new UpdateItemCommand({
           TableName: compositeTableDef.name,
           Key: { pk: { S: 'em-upd-range-mod' }, sk: { S: 'sk1' } },
           UpdateExpression: 'SET sk = :v',
           ExpressionAttributeValues: { ':v': { S: 'new-sk' } },
         }),
-      ),
-      'ValidationException',
-      /Cannot update attribute.*key/i,
-    )
+      )
+      expect.unreachable('should have thrown')
+    } catch (err) {
+      expect(err).toBeInstanceOf(DynamoDBServiceException)
+      expect((err as DynamoDBServiceException).name).toBe('ValidationException')
+      expect((err as DynamoDBServiceException).message).toBe(
+        'One or more parameter values were invalid: Cannot update attribute sk. This attribute is part of the key',
+      )
+    }
   })
 })


### PR DESCRIPTION
## What this changes

Pins the four `tests/tier3/error-messages/` operation files (putItem, updateItem, query, createTable) to exact-match assertions. They were calling `expectDynamoError`, which routes string messages to `toContain` (`src/helpers.ts:217-218`) - so the directory was matching substrings while looking like exact-match coverage. Migrated to the inline `try/catch + toBeInstanceOf + .toBe()` shape `conditionalCheck.test.ts` already uses. Test count stays at 34; every pinned message came from a real AWS run.

## Checklist

- [x] New or modified tests run against real AWS DynamoDB and pass
- [ ] ~~New or modified tests run against at least one emulator target and behave as expected~~
- [ ] ~~If AI tools drafted or materially shaped this change, disclosed in the description above~~
- [x] Linked issue or a short note explaining the motivation