### PR TITLE
test(tier3): pin Scan exact error messages

### DIFF
--- a/tests/tier3/error-messages/scan.test.ts
+++ b/tests/tier3/error-messages/scan.test.ts
@@ -1,0 +1,101 @@
+import {
+  ScanCommand,
+  DynamoDBServiceException,
+  ResourceNotFoundException,
+} from '@aws-sdk/client-dynamodb'
+import { ddb } from '../../../src/client.js'
+import { hashTableDef } from '../../../src/helpers.js'
+
+describe('Scan — exact error messages', () => {
+  it('Segment without TotalSegments: full required-parameter error', async () => {
+    try {
+      await ddb.send(
+        new ScanCommand({
+          TableName: hashTableDef.name,
+          Segment: 0,
+        }),
+      )
+      expect.unreachable('should have thrown')
+    } catch (err) {
+      expect(err).toBeInstanceOf(DynamoDBServiceException)
+      expect((err as DynamoDBServiceException).name).toBe('ValidationException')
+      expect((err as DynamoDBServiceException).message).toBe(
+        'The TotalSegments parameter is required but was not present in the request when Segment parameter is present',
+      )
+    }
+  })
+
+  it('Segment >= TotalSegments: full out-of-range error', async () => {
+    try {
+      await ddb.send(
+        new ScanCommand({
+          TableName: hashTableDef.name,
+          Segment: 5,
+          TotalSegments: 5,
+        }),
+      )
+      expect.unreachable('should have thrown')
+    } catch (err) {
+      expect(err).toBeInstanceOf(DynamoDBServiceException)
+      expect((err as DynamoDBServiceException).name).toBe('ValidationException')
+      expect((err as DynamoDBServiceException).message).toBe(
+        'The Segment parameter is zero-based and must be less than parameter TotalSegments: Segment: 5 is not less than TotalSegments: 5',
+      )
+    }
+  })
+
+  it('TotalSegments without Segment: full required-parameter error', async () => {
+    try {
+      await ddb.send(
+        new ScanCommand({
+          TableName: hashTableDef.name,
+          TotalSegments: 4,
+        }),
+      )
+      expect.unreachable('should have thrown')
+    } catch (err) {
+      expect(err).toBeInstanceOf(DynamoDBServiceException)
+      expect((err as DynamoDBServiceException).name).toBe('ValidationException')
+      expect((err as DynamoDBServiceException).message).toBe(
+        'The Segment parameter is required but was not present in the request when parameter TotalSegments is present',
+      )
+    }
+  })
+
+  it('Limit of 0: full minimum-value error', async () => {
+    try {
+      await ddb.send(
+        new ScanCommand({
+          TableName: hashTableDef.name,
+          Limit: 0,
+        }),
+      )
+      expect.unreachable('should have thrown')
+    } catch (err) {
+      expect(err).toBeInstanceOf(DynamoDBServiceException)
+      expect((err as DynamoDBServiceException).name).toBe('ValidationException')
+      expect((err as DynamoDBServiceException).message).toBe(
+        "1 validation error detected: Value '0' at 'limit' failed to satisfy constraint: Member must have value greater than or equal to 1",
+      )
+    }
+  })
+
+  it('non-existent table: full ResourceNotFoundException message', async () => {
+    try {
+      await ddb.send(
+        new ScanCommand({
+          TableName: '_conformance_does_not_exist_em_scan',
+        }),
+      )
+      expect.unreachable('should have thrown')
+    } catch (err) {
+      expect(err).toBeInstanceOf(ResourceNotFoundException)
+      expect((err as ResourceNotFoundException).name).toBe(
+        'ResourceNotFoundException',
+      )
+      expect((err as ResourceNotFoundException).message).toBe(
+        'Requested resource not found',
+      )
+    }
+  })
+})


### PR DESCRIPTION
## What this changes

Adds `tests/tier3/error-messages/scan.test.ts` covering the five Scan validation errors that didn't have exact-message coverage: Segment without TotalSegments, Segment >= TotalSegments, TotalSegments without Segment, Limit of 0, and a Scan against a non-existent table. Pinned messages from real AWS runs. Uses the inline `try/catch + toBeInstanceOf + .toBe()` shape the rest of `error-messages/` already uses.

Part of the response to #3. The remaining gaps that issue calls out (BatchWriteItem, BatchGetItem, TransactWriteItems, TransactGetItems) follow in their own PRs.

## Checklist

- [x] New or modified tests run against real AWS DynamoDB and pass
- [ ] ~~New or modified tests run against at least one emulator target and behave as expected~~
- [ ] ~~If AI tools drafted or materially shaped this change, disclosed in the description above~~
- [x] Linked issue or a short note explaining the motivation