### PR TITLE
test(tier3): pin DeleteItem/GetItem/BatchWriteItem/BatchGetItem exact error messages

### DIFF
--- a/tests/tier3/error-messages/batchGetItem.test.ts
+++ b/tests/tier3/error-messages/batchGetItem.test.ts
@@ -1,0 +1,89 @@
+import {
+  BatchGetItemCommand,
+  DynamoDBServiceException,
+  ResourceNotFoundException,
+} from '@aws-sdk/client-dynamodb'
+import { ddb } from '../../../src/client.js'
+import { hashTableDef } from '../../../src/helpers.js'
+
+describe('BatchGetItem — exact error messages', () => {
+  it('empty RequestItems: full required-parameter error', async () => {
+    try {
+      await ddb.send(new BatchGetItemCommand({ RequestItems: {} }))
+      expect.unreachable('should have thrown')
+    } catch (err) {
+      expect(err).toBeInstanceOf(DynamoDBServiceException)
+      expect((err as DynamoDBServiceException).name).toBe('ValidationException')
+      expect((err as DynamoDBServiceException).message).toBe(
+        'The requestItems parameter is required for BatchGetItem',
+      )
+    }
+  })
+
+  it('> 100 keys across all tables: interpolated full error', async () => {
+    // Only variable part is the table name (we own it via uniqueTableName),
+    // so we keep the exact-match rung and interpolate.
+    const keys = Array.from({ length: 101 }, (_, i) => ({ pk: { S: `bg-${i}` } }))
+    try {
+      await ddb.send(
+        new BatchGetItemCommand({
+          RequestItems: { [hashTableDef.name]: { Keys: keys } },
+        }),
+      )
+      expect.unreachable('should have thrown')
+    } catch (err) {
+      expect(err).toBeInstanceOf(DynamoDBServiceException)
+      expect((err as DynamoDBServiceException).name).toBe('ValidationException')
+      expect((err as DynamoDBServiceException).message).toBe(
+        `1 validation error detected: Value at 'RequestItems.${hashTableDef.name}.member.Keys' failed to satisfy constraint: Member must have length less than or equal to 100`,
+      )
+    }
+  })
+
+  it('non-existent table: full ResourceNotFoundException message', async () => {
+    try {
+      await ddb.send(
+        new BatchGetItemCommand({
+          RequestItems: {
+            '_conformance_does_not_exist_em_bg': {
+              Keys: [{ pk: { S: 'test' } }],
+            },
+          },
+        }),
+      )
+      expect.unreachable('should have thrown')
+    } catch (err) {
+      expect(err).toBeInstanceOf(ResourceNotFoundException)
+      expect((err as ResourceNotFoundException).name).toBe(
+        'ResourceNotFoundException',
+      )
+      expect((err as ResourceNotFoundException).message).toBe(
+        'Requested resource not found',
+      )
+    }
+  })
+
+  it('duplicate keys in one Keys array: full duplicate-keys error', async () => {
+    try {
+      await ddb.send(
+        new BatchGetItemCommand({
+          RequestItems: {
+            [hashTableDef.name]: {
+              Keys: [
+                { pk: { S: 'em-bg-dup' } },
+                { pk: { S: 'em-bg-dup' } },
+              ],
+            },
+          },
+        }),
+      )
+      expect.unreachable('should have thrown')
+    } catch (err) {
+      expect(err).toBeInstanceOf(DynamoDBServiceException)
+      expect((err as DynamoDBServiceException).name).toBe('ValidationException')
+      expect((err as DynamoDBServiceException).message).toBe(
+        'Provided list of item keys contains duplicates',
+      )
+    }
+  })
+})

--- a/tests/tier3/error-messages/batchWriteItem.test.ts
+++ b/tests/tier3/error-messages/batchWriteItem.test.ts
@@ -1,0 +1,106 @@
+import {
+  BatchWriteItemCommand,
+  DynamoDBServiceException,
+  ResourceNotFoundException,
+} from '@aws-sdk/client-dynamodb'
+import { ddb } from '../../../src/client.js'
+import { hashTableDef, cleanupItems } from '../../../src/helpers.js'
+
+const keysToCleanup = [
+  { pk: { S: 'em-bw-dup' } },
+]
+
+afterAll(async () => {
+  await cleanupItems(hashTableDef.name, keysToCleanup)
+})
+
+describe('BatchWriteItem — exact error messages', () => {
+  it('empty RequestItems: full required-parameter error', async () => {
+    try {
+      await ddb.send(new BatchWriteItemCommand({ RequestItems: {} }))
+      expect.unreachable('should have thrown')
+    } catch (err) {
+      expect(err).toBeInstanceOf(DynamoDBServiceException)
+      expect((err as DynamoDBServiceException).name).toBe('ValidationException')
+      expect((err as DynamoDBServiceException).message).toBe(
+        'The requestItems parameter is required for BatchWriteItem',
+      )
+    }
+  })
+
+  it('> 25 requests: anchored regex on the constraint phrase', async () => {
+    // AWS echoes the entire WriteRequest list into the validation message
+    // in a Java-toString format that includes every AttributeValue field
+    // (recently they added `workloadProfileName`). Pinning the echo verbatim
+    // with .toBe() would couple this assertion to the SDK's serialisation,
+    // which has changed before and will again. Anchored regex around the
+    // structural envelope (`{<table>=[<dump>]}`) and the constraint phrase
+    // at the end lets the dump vary without weakening what we actually
+    // care about: that the right validation fires.
+    const requests = Array.from({ length: 26 }, (_, i) => ({
+      PutRequest: { Item: { pk: { S: `bw-${i}` } } },
+    }))
+    const escapedName = hashTableDef.name.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+    const expectedPattern = new RegExp(
+      `^1 validation error detected: Value '\\{${escapedName}=\\[.+\\]\\}' at 'requestItems' failed to satisfy constraint: Map value must satisfy constraint: \\[Member must have length less than or equal to 25, Member must have length greater than or equal to 1\\]$`,
+      's',
+    )
+    try {
+      await ddb.send(
+        new BatchWriteItemCommand({
+          RequestItems: { [hashTableDef.name]: requests },
+        }),
+      )
+      expect.unreachable('should have thrown')
+    } catch (err) {
+      expect(err).toBeInstanceOf(DynamoDBServiceException)
+      expect((err as DynamoDBServiceException).name).toBe('ValidationException')
+      expect((err as DynamoDBServiceException).message).toMatch(expectedPattern)
+    }
+  })
+
+  it('same key Put and Delete in one batch: full duplicate-keys error', async () => {
+    try {
+      await ddb.send(
+        new BatchWriteItemCommand({
+          RequestItems: {
+            [hashTableDef.name]: [
+              { PutRequest: { Item: { pk: { S: 'em-bw-dup' } } } },
+              { DeleteRequest: { Key: { pk: { S: 'em-bw-dup' } } } },
+            ],
+          },
+        }),
+      )
+      expect.unreachable('should have thrown')
+    } catch (err) {
+      expect(err).toBeInstanceOf(DynamoDBServiceException)
+      expect((err as DynamoDBServiceException).name).toBe('ValidationException')
+      expect((err as DynamoDBServiceException).message).toBe(
+        'Provided list of item keys contains duplicates',
+      )
+    }
+  })
+
+  it('non-existent table: full ResourceNotFoundException message', async () => {
+    try {
+      await ddb.send(
+        new BatchWriteItemCommand({
+          RequestItems: {
+            '_conformance_does_not_exist_em_bw': [
+              { PutRequest: { Item: { pk: { S: 'test' } } } },
+            ],
+          },
+        }),
+      )
+      expect.unreachable('should have thrown')
+    } catch (err) {
+      expect(err).toBeInstanceOf(ResourceNotFoundException)
+      expect((err as ResourceNotFoundException).name).toBe(
+        'ResourceNotFoundException',
+      )
+      expect((err as ResourceNotFoundException).message).toBe(
+        'Requested resource not found',
+      )
+    }
+  })
+})

--- a/tests/tier3/error-messages/deleteItem.test.ts
+++ b/tests/tier3/error-messages/deleteItem.test.ts
@@ -1,0 +1,50 @@
+import {
+  DeleteItemCommand,
+  DynamoDBServiceException,
+  ResourceNotFoundException,
+} from '@aws-sdk/client-dynamodb'
+import { ddb } from '../../../src/client.js'
+import { compositeTableDef } from '../../../src/helpers.js'
+
+// Conditional-check failures for DeleteItem live in conditionalCheck.test.ts —
+// that file owns the conditional-check error family across operations.
+
+describe('DeleteItem — exact error messages', () => {
+  it('non-existent table: full ResourceNotFoundException message', async () => {
+    try {
+      await ddb.send(
+        new DeleteItemCommand({
+          TableName: '_conformance_does_not_exist_em_delete',
+          Key: { pk: { S: 'test' } },
+        }),
+      )
+      expect.unreachable('should have thrown')
+    } catch (err) {
+      expect(err).toBeInstanceOf(ResourceNotFoundException)
+      expect((err as ResourceNotFoundException).name).toBe(
+        'ResourceNotFoundException',
+      )
+      expect((err as ResourceNotFoundException).message).toBe(
+        'Requested resource not found',
+      )
+    }
+  })
+
+  it('malformed Key (missing range key on composite table): full schema-mismatch error', async () => {
+    try {
+      await ddb.send(
+        new DeleteItemCommand({
+          TableName: compositeTableDef.name,
+          Key: { pk: { S: 'test' } },
+        }),
+      )
+      expect.unreachable('should have thrown')
+    } catch (err) {
+      expect(err).toBeInstanceOf(DynamoDBServiceException)
+      expect((err as DynamoDBServiceException).name).toBe('ValidationException')
+      expect((err as DynamoDBServiceException).message).toBe(
+        'The provided key element does not match the schema',
+      )
+    }
+  })
+})

--- a/tests/tier3/error-messages/getItem.test.ts
+++ b/tests/tier3/error-messages/getItem.test.ts
@@ -1,0 +1,69 @@
+import {
+  GetItemCommand,
+  DynamoDBServiceException,
+  ResourceNotFoundException,
+} from '@aws-sdk/client-dynamodb'
+import { ddb } from '../../../src/client.js'
+import {
+  hashTableDef,
+  compositeTableDef,
+} from '../../../src/helpers.js'
+
+describe('GetItem — exact error messages', () => {
+  it('non-existent table: full ResourceNotFoundException message', async () => {
+    try {
+      await ddb.send(
+        new GetItemCommand({
+          TableName: '_conformance_does_not_exist_em_get',
+          Key: { pk: { S: 'test' } },
+        }),
+      )
+      expect.unreachable('should have thrown')
+    } catch (err) {
+      expect(err).toBeInstanceOf(ResourceNotFoundException)
+      expect((err as ResourceNotFoundException).name).toBe(
+        'ResourceNotFoundException',
+      )
+      expect((err as ResourceNotFoundException).message).toBe(
+        'Requested resource not found',
+      )
+    }
+  })
+
+  it('malformed Key (missing range key on composite table): full schema-mismatch error', async () => {
+    try {
+      await ddb.send(
+        new GetItemCommand({
+          TableName: compositeTableDef.name,
+          Key: { pk: { S: 'test' } },
+        }),
+      )
+      expect.unreachable('should have thrown')
+    } catch (err) {
+      expect(err).toBeInstanceOf(DynamoDBServiceException)
+      expect((err as DynamoDBServiceException).name).toBe('ValidationException')
+      expect((err as DynamoDBServiceException).message).toBe(
+        'The provided key element does not match the schema',
+      )
+    }
+  })
+
+  it('invalid ProjectionExpression syntax: full parser error', async () => {
+    try {
+      await ddb.send(
+        new GetItemCommand({
+          TableName: hashTableDef.name,
+          Key: { pk: { S: 'test' } },
+          ProjectionExpression: '!!! INVALID !!!',
+        }),
+      )
+      expect.unreachable('should have thrown')
+    } catch (err) {
+      expect(err).toBeInstanceOf(DynamoDBServiceException)
+      expect((err as DynamoDBServiceException).name).toBe('ValidationException')
+      expect((err as DynamoDBServiceException).message).toBe(
+        'Invalid ProjectionExpression: Syntax error; token: "!", near: "!!"',
+      )
+    }
+  })
+})

--- a/tests/tier3/error-messages/scan.test.ts
+++ b/tests/tier3/error-messages/scan.test.ts
@@ -1,0 +1,101 @@
+import {
+  ScanCommand,
+  DynamoDBServiceException,
+  ResourceNotFoundException,
+} from '@aws-sdk/client-dynamodb'
+import { ddb } from '../../../src/client.js'
+import { hashTableDef } from '../../../src/helpers.js'
+
+describe('Scan — exact error messages', () => {
+  it('Segment without TotalSegments: full required-parameter error', async () => {
+    try {
+      await ddb.send(
+        new ScanCommand({
+          TableName: hashTableDef.name,
+          Segment: 0,
+        }),
+      )
+      expect.unreachable('should have thrown')
+    } catch (err) {
+      expect(err).toBeInstanceOf(DynamoDBServiceException)
+      expect((err as DynamoDBServiceException).name).toBe('ValidationException')
+      expect((err as DynamoDBServiceException).message).toBe(
+        'The TotalSegments parameter is required but was not present in the request when Segment parameter is present',
+      )
+    }
+  })
+
+  it('Segment >= TotalSegments: full out-of-range error', async () => {
+    try {
+      await ddb.send(
+        new ScanCommand({
+          TableName: hashTableDef.name,
+          Segment: 5,
+          TotalSegments: 5,
+        }),
+      )
+      expect.unreachable('should have thrown')
+    } catch (err) {
+      expect(err).toBeInstanceOf(DynamoDBServiceException)
+      expect((err as DynamoDBServiceException).name).toBe('ValidationException')
+      expect((err as DynamoDBServiceException).message).toBe(
+        'The Segment parameter is zero-based and must be less than parameter TotalSegments: Segment: 5 is not less than TotalSegments: 5',
+      )
+    }
+  })
+
+  it('TotalSegments without Segment: full required-parameter error', async () => {
+    try {
+      await ddb.send(
+        new ScanCommand({
+          TableName: hashTableDef.name,
+          TotalSegments: 4,
+        }),
+      )
+      expect.unreachable('should have thrown')
+    } catch (err) {
+      expect(err).toBeInstanceOf(DynamoDBServiceException)
+      expect((err as DynamoDBServiceException).name).toBe('ValidationException')
+      expect((err as DynamoDBServiceException).message).toBe(
+        'The Segment parameter is required but was not present in the request when parameter TotalSegments is present',
+      )
+    }
+  })
+
+  it('Limit of 0: full minimum-value error', async () => {
+    try {
+      await ddb.send(
+        new ScanCommand({
+          TableName: hashTableDef.name,
+          Limit: 0,
+        }),
+      )
+      expect.unreachable('should have thrown')
+    } catch (err) {
+      expect(err).toBeInstanceOf(DynamoDBServiceException)
+      expect((err as DynamoDBServiceException).name).toBe('ValidationException')
+      expect((err as DynamoDBServiceException).message).toBe(
+        "1 validation error detected: Value '0' at 'limit' failed to satisfy constraint: Member must have value greater than or equal to 1",
+      )
+    }
+  })
+
+  it('non-existent table: full ResourceNotFoundException message', async () => {
+    try {
+      await ddb.send(
+        new ScanCommand({
+          TableName: '_conformance_does_not_exist_em_scan',
+        }),
+      )
+      expect.unreachable('should have thrown')
+    } catch (err) {
+      expect(err).toBeInstanceOf(ResourceNotFoundException)
+      expect((err as ResourceNotFoundException).name).toBe(
+        'ResourceNotFoundException',
+      )
+      expect((err as ResourceNotFoundException).message).toBe(
+        'Requested resource not found',
+      )
+    }
+  })
+})


### PR DESCRIPTION
## What this changes

Adds four new files to `tests/tier3/error-messages/` covering the CRUD + batch operations: `deleteItem.test.ts`, `getItem.test.ts`, `batchWriteItem.test.ts`, `batchGetItem.test.ts`. 13 scenarios in total, all pinned from real AWS runs.

| File | Scenarios |
|---|---|
| `deleteItem.test.ts` | 2 (non-existent table, malformed Key on composite) |
| `getItem.test.ts` | 3 (non-existent table, malformed Key, invalid ProjectionExpression syntax) |
| `batchWriteItem.test.ts` | 4 (empty RequestItems, > 25 requests, same key Put + Delete in one batch, non-existent table) |
| `batchGetItem.test.ts` | 4 (empty RequestItems, > 100 keys, non-existent table, duplicate keys in one Keys array) |

Conditional-check failures for `DeleteItem` aren't here - they live in `conditionalCheck.test.ts`, which owns the conditional-check error family across operations. Per-operation files don't duplicate that coverage.

The `BatchWriteItem` > 25 case uses an anchored regex rather than a literal `.toBe()`. AWS echoes the entire `WriteRequest` list back in a Java-toString format that includes every `AttributeValue` field (recently they added `workloadProfileName`), so pinning the echo verbatim would couple the assertion to current SDK serialisation and break for irrelevant reasons next time AWS adds a field. The regex pins the structural envelope around the dump and the constraint phrase at the end - strict where it matters, vary where it doesn't.

Part of the response to #3. Transactional operations still to come.

## Stacked on #5

Base branch is `feat/error-messages-scan-coverage` (PR #5), not `main`. When #5 merges, GitHub auto-retargets this PR to `main` and the diff cleans up to just the four new files in this PR.

## Checklist

- [x] New or modified tests run against real AWS DynamoDB and pass
- [ ] ~~New or modified tests run against at least one emulator target and behave as expected~~
- [ ] ~~If AI tools drafted or materially shaped this change, disclosed in the description above~~
- [x] Linked issue or a short note explaining the motivation