### PR TITLE
test(tier3): pin TransactWriteItems/TransactGetItems exact error messages

### DIFF
--- a/tests/tier3/error-messages/batchGetItem.test.ts
+++ b/tests/tier3/error-messages/batchGetItem.test.ts
@@ -1,0 +1,89 @@
+import {
+  BatchGetItemCommand,
+  DynamoDBServiceException,
+  ResourceNotFoundException,
+} from '@aws-sdk/client-dynamodb'
+import { ddb } from '../../../src/client.js'
+import { hashTableDef } from '../../../src/helpers.js'
+
+describe('BatchGetItem — exact error messages', () => {
+  it('empty RequestItems: full required-parameter error', async () => {
+    try {
+      await ddb.send(new BatchGetItemCommand({ RequestItems: {} }))
+      expect.unreachable('should have thrown')
+    } catch (err) {
+      expect(err).toBeInstanceOf(DynamoDBServiceException)
+      expect((err as DynamoDBServiceException).name).toBe('ValidationException')
+      expect((err as DynamoDBServiceException).message).toBe(
+        'The requestItems parameter is required for BatchGetItem',
+      )
+    }
+  })
+
+  it('> 100 keys across all tables: interpolated full error', async () => {
+    // Only variable part is the table name (we own it via uniqueTableName),
+    // so we keep the exact-match rung and interpolate.
+    const keys = Array.from({ length: 101 }, (_, i) => ({ pk: { S: `bg-${i}` } }))
+    try {
+      await ddb.send(
+        new BatchGetItemCommand({
+          RequestItems: { [hashTableDef.name]: { Keys: keys } },
+        }),
+      )
+      expect.unreachable('should have thrown')
+    } catch (err) {
+      expect(err).toBeInstanceOf(DynamoDBServiceException)
+      expect((err as DynamoDBServiceException).name).toBe('ValidationException')
+      expect((err as DynamoDBServiceException).message).toBe(
+        `1 validation error detected: Value at 'RequestItems.${hashTableDef.name}.member.Keys' failed to satisfy constraint: Member must have length less than or equal to 100`,
+      )
+    }
+  })
+
+  it('non-existent table: full ResourceNotFoundException message', async () => {
+    try {
+      await ddb.send(
+        new BatchGetItemCommand({
+          RequestItems: {
+            '_conformance_does_not_exist_em_bg': {
+              Keys: [{ pk: { S: 'test' } }],
+            },
+          },
+        }),
+      )
+      expect.unreachable('should have thrown')
+    } catch (err) {
+      expect(err).toBeInstanceOf(ResourceNotFoundException)
+      expect((err as ResourceNotFoundException).name).toBe(
+        'ResourceNotFoundException',
+      )
+      expect((err as ResourceNotFoundException).message).toBe(
+        'Requested resource not found',
+      )
+    }
+  })
+
+  it('duplicate keys in one Keys array: full duplicate-keys error', async () => {
+    try {
+      await ddb.send(
+        new BatchGetItemCommand({
+          RequestItems: {
+            [hashTableDef.name]: {
+              Keys: [
+                { pk: { S: 'em-bg-dup' } },
+                { pk: { S: 'em-bg-dup' } },
+              ],
+            },
+          },
+        }),
+      )
+      expect.unreachable('should have thrown')
+    } catch (err) {
+      expect(err).toBeInstanceOf(DynamoDBServiceException)
+      expect((err as DynamoDBServiceException).name).toBe('ValidationException')
+      expect((err as DynamoDBServiceException).message).toBe(
+        'Provided list of item keys contains duplicates',
+      )
+    }
+  })
+})

--- a/tests/tier3/error-messages/batchWriteItem.test.ts
+++ b/tests/tier3/error-messages/batchWriteItem.test.ts
@@ -1,0 +1,106 @@
+import {
+  BatchWriteItemCommand,
+  DynamoDBServiceException,
+  ResourceNotFoundException,
+} from '@aws-sdk/client-dynamodb'
+import { ddb } from '../../../src/client.js'
+import { hashTableDef, cleanupItems } from '../../../src/helpers.js'
+
+const keysToCleanup = [
+  { pk: { S: 'em-bw-dup' } },
+]
+
+afterAll(async () => {
+  await cleanupItems(hashTableDef.name, keysToCleanup)
+})
+
+describe('BatchWriteItem — exact error messages', () => {
+  it('empty RequestItems: full required-parameter error', async () => {
+    try {
+      await ddb.send(new BatchWriteItemCommand({ RequestItems: {} }))
+      expect.unreachable('should have thrown')
+    } catch (err) {
+      expect(err).toBeInstanceOf(DynamoDBServiceException)
+      expect((err as DynamoDBServiceException).name).toBe('ValidationException')
+      expect((err as DynamoDBServiceException).message).toBe(
+        'The requestItems parameter is required for BatchWriteItem',
+      )
+    }
+  })
+
+  it('> 25 requests: anchored regex on the constraint phrase', async () => {
+    // AWS echoes the entire WriteRequest list into the validation message
+    // in a Java-toString format that includes every AttributeValue field
+    // (recently they added `workloadProfileName`). Pinning the echo verbatim
+    // with .toBe() would couple this assertion to the SDK's serialisation,
+    // which has changed before and will again. Anchored regex around the
+    // structural envelope (`{<table>=[<dump>]}`) and the constraint phrase
+    // at the end lets the dump vary without weakening what we actually
+    // care about: that the right validation fires.
+    const requests = Array.from({ length: 26 }, (_, i) => ({
+      PutRequest: { Item: { pk: { S: `bw-${i}` } } },
+    }))
+    const escapedName = hashTableDef.name.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+    const expectedPattern = new RegExp(
+      `^1 validation error detected: Value '\\{${escapedName}=\\[.+\\]\\}' at 'requestItems' failed to satisfy constraint: Map value must satisfy constraint: \\[Member must have length less than or equal to 25, Member must have length greater than or equal to 1\\]$`,
+      's',
+    )
+    try {
+      await ddb.send(
+        new BatchWriteItemCommand({
+          RequestItems: { [hashTableDef.name]: requests },
+        }),
+      )
+      expect.unreachable('should have thrown')
+    } catch (err) {
+      expect(err).toBeInstanceOf(DynamoDBServiceException)
+      expect((err as DynamoDBServiceException).name).toBe('ValidationException')
+      expect((err as DynamoDBServiceException).message).toMatch(expectedPattern)
+    }
+  })
+
+  it('same key Put and Delete in one batch: full duplicate-keys error', async () => {
+    try {
+      await ddb.send(
+        new BatchWriteItemCommand({
+          RequestItems: {
+            [hashTableDef.name]: [
+              { PutRequest: { Item: { pk: { S: 'em-bw-dup' } } } },
+              { DeleteRequest: { Key: { pk: { S: 'em-bw-dup' } } } },
+            ],
+          },
+        }),
+      )
+      expect.unreachable('should have thrown')
+    } catch (err) {
+      expect(err).toBeInstanceOf(DynamoDBServiceException)
+      expect((err as DynamoDBServiceException).name).toBe('ValidationException')
+      expect((err as DynamoDBServiceException).message).toBe(
+        'Provided list of item keys contains duplicates',
+      )
+    }
+  })
+
+  it('non-existent table: full ResourceNotFoundException message', async () => {
+    try {
+      await ddb.send(
+        new BatchWriteItemCommand({
+          RequestItems: {
+            '_conformance_does_not_exist_em_bw': [
+              { PutRequest: { Item: { pk: { S: 'test' } } } },
+            ],
+          },
+        }),
+      )
+      expect.unreachable('should have thrown')
+    } catch (err) {
+      expect(err).toBeInstanceOf(ResourceNotFoundException)
+      expect((err as ResourceNotFoundException).name).toBe(
+        'ResourceNotFoundException',
+      )
+      expect((err as ResourceNotFoundException).message).toBe(
+        'Requested resource not found',
+      )
+    }
+  })
+})

--- a/tests/tier3/error-messages/conditionalCheck.test.ts
+++ b/tests/tier3/error-messages/conditionalCheck.test.ts
@@ -153,12 +153,18 @@ describe('Conditional check — exact error messages', () => {
     } catch (err) {
       expect(err).toBeInstanceOf(TransactionCanceledException)
       const txErr = err as TransactionCanceledException
-      expect(txErr.message).toContain('Transaction cancelled')
-      expect(txErr.CancellationReasons).toBeDefined()
-      expect(txErr.CancellationReasons!.length).toBe(1)
-      expect(txErr.CancellationReasons![0].Code).toBe(
-        'ConditionalCheckFailed',
+      // Build the expected message and the structural cross-check from a
+      // single source of truth — the reasons array we drive via the failing
+      // ConditionExpression. AWS's cancellation-reasons summary is fully
+      // deterministic given known inputs, so this is exact-match on both
+      // the message and the parsed structure, not a regex tolerance.
+      const expectedReasons = ['ConditionalCheckFailed'] as const
+      expect(txErr.message).toBe(
+        `Transaction cancelled, please refer cancellation reasons for specific reasons [${expectedReasons.join(', ')}]`,
       )
+      expect(txErr.CancellationReasons?.map((r) => r.Code)).toEqual([
+        ...expectedReasons,
+      ])
     }
   })
 

--- a/tests/tier3/error-messages/deleteItem.test.ts
+++ b/tests/tier3/error-messages/deleteItem.test.ts
@@ -1,0 +1,50 @@
+import {
+  DeleteItemCommand,
+  DynamoDBServiceException,
+  ResourceNotFoundException,
+} from '@aws-sdk/client-dynamodb'
+import { ddb } from '../../../src/client.js'
+import { compositeTableDef } from '../../../src/helpers.js'
+
+// Conditional-check failures for DeleteItem live in conditionalCheck.test.ts —
+// that file owns the conditional-check error family across operations.
+
+describe('DeleteItem — exact error messages', () => {
+  it('non-existent table: full ResourceNotFoundException message', async () => {
+    try {
+      await ddb.send(
+        new DeleteItemCommand({
+          TableName: '_conformance_does_not_exist_em_delete',
+          Key: { pk: { S: 'test' } },
+        }),
+      )
+      expect.unreachable('should have thrown')
+    } catch (err) {
+      expect(err).toBeInstanceOf(ResourceNotFoundException)
+      expect((err as ResourceNotFoundException).name).toBe(
+        'ResourceNotFoundException',
+      )
+      expect((err as ResourceNotFoundException).message).toBe(
+        'Requested resource not found',
+      )
+    }
+  })
+
+  it('malformed Key (missing range key on composite table): full schema-mismatch error', async () => {
+    try {
+      await ddb.send(
+        new DeleteItemCommand({
+          TableName: compositeTableDef.name,
+          Key: { pk: { S: 'test' } },
+        }),
+      )
+      expect.unreachable('should have thrown')
+    } catch (err) {
+      expect(err).toBeInstanceOf(DynamoDBServiceException)
+      expect((err as DynamoDBServiceException).name).toBe('ValidationException')
+      expect((err as DynamoDBServiceException).message).toBe(
+        'The provided key element does not match the schema',
+      )
+    }
+  })
+})

--- a/tests/tier3/error-messages/getItem.test.ts
+++ b/tests/tier3/error-messages/getItem.test.ts
@@ -1,0 +1,69 @@
+import {
+  GetItemCommand,
+  DynamoDBServiceException,
+  ResourceNotFoundException,
+} from '@aws-sdk/client-dynamodb'
+import { ddb } from '../../../src/client.js'
+import {
+  hashTableDef,
+  compositeTableDef,
+} from '../../../src/helpers.js'
+
+describe('GetItem — exact error messages', () => {
+  it('non-existent table: full ResourceNotFoundException message', async () => {
+    try {
+      await ddb.send(
+        new GetItemCommand({
+          TableName: '_conformance_does_not_exist_em_get',
+          Key: { pk: { S: 'test' } },
+        }),
+      )
+      expect.unreachable('should have thrown')
+    } catch (err) {
+      expect(err).toBeInstanceOf(ResourceNotFoundException)
+      expect((err as ResourceNotFoundException).name).toBe(
+        'ResourceNotFoundException',
+      )
+      expect((err as ResourceNotFoundException).message).toBe(
+        'Requested resource not found',
+      )
+    }
+  })
+
+  it('malformed Key (missing range key on composite table): full schema-mismatch error', async () => {
+    try {
+      await ddb.send(
+        new GetItemCommand({
+          TableName: compositeTableDef.name,
+          Key: { pk: { S: 'test' } },
+        }),
+      )
+      expect.unreachable('should have thrown')
+    } catch (err) {
+      expect(err).toBeInstanceOf(DynamoDBServiceException)
+      expect((err as DynamoDBServiceException).name).toBe('ValidationException')
+      expect((err as DynamoDBServiceException).message).toBe(
+        'The provided key element does not match the schema',
+      )
+    }
+  })
+
+  it('invalid ProjectionExpression syntax: full parser error', async () => {
+    try {
+      await ddb.send(
+        new GetItemCommand({
+          TableName: hashTableDef.name,
+          Key: { pk: { S: 'test' } },
+          ProjectionExpression: '!!! INVALID !!!',
+        }),
+      )
+      expect.unreachable('should have thrown')
+    } catch (err) {
+      expect(err).toBeInstanceOf(DynamoDBServiceException)
+      expect((err as DynamoDBServiceException).name).toBe('ValidationException')
+      expect((err as DynamoDBServiceException).message).toBe(
+        'Invalid ProjectionExpression: Syntax error; token: "!", near: "!!"',
+      )
+    }
+  })
+})

--- a/tests/tier3/error-messages/scan.test.ts
+++ b/tests/tier3/error-messages/scan.test.ts
@@ -1,0 +1,101 @@
+import {
+  ScanCommand,
+  DynamoDBServiceException,
+  ResourceNotFoundException,
+} from '@aws-sdk/client-dynamodb'
+import { ddb } from '../../../src/client.js'
+import { hashTableDef } from '../../../src/helpers.js'
+
+describe('Scan — exact error messages', () => {
+  it('Segment without TotalSegments: full required-parameter error', async () => {
+    try {
+      await ddb.send(
+        new ScanCommand({
+          TableName: hashTableDef.name,
+          Segment: 0,
+        }),
+      )
+      expect.unreachable('should have thrown')
+    } catch (err) {
+      expect(err).toBeInstanceOf(DynamoDBServiceException)
+      expect((err as DynamoDBServiceException).name).toBe('ValidationException')
+      expect((err as DynamoDBServiceException).message).toBe(
+        'The TotalSegments parameter is required but was not present in the request when Segment parameter is present',
+      )
+    }
+  })
+
+  it('Segment >= TotalSegments: full out-of-range error', async () => {
+    try {
+      await ddb.send(
+        new ScanCommand({
+          TableName: hashTableDef.name,
+          Segment: 5,
+          TotalSegments: 5,
+        }),
+      )
+      expect.unreachable('should have thrown')
+    } catch (err) {
+      expect(err).toBeInstanceOf(DynamoDBServiceException)
+      expect((err as DynamoDBServiceException).name).toBe('ValidationException')
+      expect((err as DynamoDBServiceException).message).toBe(
+        'The Segment parameter is zero-based and must be less than parameter TotalSegments: Segment: 5 is not less than TotalSegments: 5',
+      )
+    }
+  })
+
+  it('TotalSegments without Segment: full required-parameter error', async () => {
+    try {
+      await ddb.send(
+        new ScanCommand({
+          TableName: hashTableDef.name,
+          TotalSegments: 4,
+        }),
+      )
+      expect.unreachable('should have thrown')
+    } catch (err) {
+      expect(err).toBeInstanceOf(DynamoDBServiceException)
+      expect((err as DynamoDBServiceException).name).toBe('ValidationException')
+      expect((err as DynamoDBServiceException).message).toBe(
+        'The Segment parameter is required but was not present in the request when parameter TotalSegments is present',
+      )
+    }
+  })
+
+  it('Limit of 0: full minimum-value error', async () => {
+    try {
+      await ddb.send(
+        new ScanCommand({
+          TableName: hashTableDef.name,
+          Limit: 0,
+        }),
+      )
+      expect.unreachable('should have thrown')
+    } catch (err) {
+      expect(err).toBeInstanceOf(DynamoDBServiceException)
+      expect((err as DynamoDBServiceException).name).toBe('ValidationException')
+      expect((err as DynamoDBServiceException).message).toBe(
+        "1 validation error detected: Value '0' at 'limit' failed to satisfy constraint: Member must have value greater than or equal to 1",
+      )
+    }
+  })
+
+  it('non-existent table: full ResourceNotFoundException message', async () => {
+    try {
+      await ddb.send(
+        new ScanCommand({
+          TableName: '_conformance_does_not_exist_em_scan',
+        }),
+      )
+      expect.unreachable('should have thrown')
+    } catch (err) {
+      expect(err).toBeInstanceOf(ResourceNotFoundException)
+      expect((err as ResourceNotFoundException).name).toBe(
+        'ResourceNotFoundException',
+      )
+      expect((err as ResourceNotFoundException).message).toBe(
+        'Requested resource not found',
+      )
+    }
+  })
+})

--- a/tests/tier3/error-messages/transactGetItems.test.ts
+++ b/tests/tier3/error-messages/transactGetItems.test.ts
@@ -1,0 +1,130 @@
+import {
+  TransactGetItemsCommand,
+  DynamoDBServiceException,
+  ResourceNotFoundException,
+  TransactionCanceledException,
+} from '@aws-sdk/client-dynamodb'
+import { ddb } from '../../../src/client.js'
+import { hashTableDef } from '../../../src/helpers.js'
+
+describe('TransactGetItems — exact error messages', () => {
+  it('empty TransactItems: full minimum-length error', async () => {
+    try {
+      await ddb.send(new TransactGetItemsCommand({ TransactItems: [] }))
+      expect.unreachable('should have thrown')
+    } catch (err) {
+      expect(err).toBeInstanceOf(DynamoDBServiceException)
+      expect((err as DynamoDBServiceException).name).toBe('ValidationException')
+      expect((err as DynamoDBServiceException).message).toBe(
+        "1 validation error detected: Value '[]' at 'transactItems' failed to satisfy constraint: Member must have length greater than or equal to 1",
+      )
+    }
+  })
+
+  it('> 100 gets: anchored regex on the constraint phrase', async () => {
+    // Same Java-toString dump shape as TransactWriteItems / BatchWriteItem;
+    // anchor around the dump rather than pinning it verbatim.
+    const items = Array.from({ length: 101 }, (_, i) => ({
+      Get: {
+        TableName: hashTableDef.name,
+        Key: { pk: { S: `tgi-${i}` } },
+      },
+    }))
+    const expectedPattern = new RegExp(
+      `^1 validation error detected: Value '\\[.+\\]' at 'transactItems' failed to satisfy constraint: Member must have length less than or equal to 100$`,
+      's',
+    )
+    try {
+      await ddb.send(new TransactGetItemsCommand({ TransactItems: items }))
+      expect.unreachable('should have thrown')
+    } catch (err) {
+      expect(err).toBeInstanceOf(DynamoDBServiceException)
+      expect((err as DynamoDBServiceException).name).toBe('ValidationException')
+      expect((err as DynamoDBServiceException).message).toMatch(expectedPattern)
+    }
+  })
+
+  it('non-existent table: full ResourceNotFoundException message', async () => {
+    try {
+      await ddb.send(
+        new TransactGetItemsCommand({
+          TransactItems: [
+            {
+              Get: {
+                TableName: '_conformance_does_not_exist_em_tgi',
+                Key: { pk: { S: 'x' } },
+              },
+            },
+          ],
+        }),
+      )
+      expect.unreachable('should have thrown')
+    } catch (err) {
+      expect(err).toBeInstanceOf(ResourceNotFoundException)
+      expect((err as ResourceNotFoundException).name).toBe(
+        'ResourceNotFoundException',
+      )
+      expect((err as ResourceNotFoundException).message).toBe(
+        'Requested resource not found',
+      )
+    }
+  })
+
+  it('invalid ProjectionExpression syntax: full parser error', async () => {
+    // Request-level ValidationException — the parser rejects the expression
+    // before any per-action processing runs.
+    try {
+      await ddb.send(
+        new TransactGetItemsCommand({
+          TransactItems: [
+            {
+              Get: {
+                TableName: hashTableDef.name,
+                Key: { pk: { S: 'tgi-pe' } },
+                ProjectionExpression: '!!!',
+              },
+            },
+          ],
+        }),
+      )
+      expect.unreachable('should have thrown')
+    } catch (err) {
+      expect(err).toBeInstanceOf(DynamoDBServiceException)
+      expect((err as DynamoDBServiceException).name).toBe('ValidationException')
+      expect((err as DynamoDBServiceException).message).toBe(
+        'Invalid ProjectionExpression: Syntax error; token: "!", near: "!!"',
+      )
+    }
+  })
+
+  it('missing key attribute: action-level ValidationError surfaces as TransactionCanceledException', async () => {
+    // Per-action validation (here: an empty Key) is reported through the
+    // cancellation channel rather than as a request-level ValidationException.
+    // The reason code is 'ValidationError', not 'ConditionalCheckFailed'.
+    try {
+      await ddb.send(
+        new TransactGetItemsCommand({
+          TransactItems: [
+            {
+              Get: {
+                TableName: hashTableDef.name,
+                Key: {},
+              },
+            },
+          ],
+        }),
+      )
+      expect.unreachable('should have thrown')
+    } catch (err) {
+      expect(err).toBeInstanceOf(TransactionCanceledException)
+      const txErr = err as TransactionCanceledException
+      const expectedReasons = ['ValidationError'] as const
+      expect(txErr.message).toBe(
+        `Transaction cancelled, please refer cancellation reasons for specific reasons [${expectedReasons.join(', ')}]`,
+      )
+      expect(txErr.CancellationReasons?.map((r) => r.Code)).toEqual([
+        ...expectedReasons,
+      ])
+    }
+  })
+})

--- a/tests/tier3/error-messages/transactWriteItems.test.ts
+++ b/tests/tier3/error-messages/transactWriteItems.test.ts
@@ -1,0 +1,226 @@
+import {
+  TransactWriteItemsCommand,
+  PutItemCommand,
+  DynamoDBServiceException,
+  ResourceNotFoundException,
+  TransactionCanceledException,
+} from '@aws-sdk/client-dynamodb'
+import { ddb } from '../../../src/client.js'
+import { hashTableDef, cleanupItems } from '../../../src/helpers.js'
+
+const keysToCleanup = [
+  { pk: { S: 'em-twi-dup' } },
+  { pk: { S: 'em-twi-multi-1' } },
+  { pk: { S: 'em-twi-multi-2' } },
+  { pk: { S: 'em-twi-pos' } },
+  { pk: { S: 'em-twi-pos-new' } },
+]
+
+afterAll(async () => {
+  await cleanupItems(hashTableDef.name, keysToCleanup)
+})
+
+describe('TransactWriteItems — exact error messages', () => {
+  it('empty TransactItems: full minimum-length error', async () => {
+    try {
+      await ddb.send(new TransactWriteItemsCommand({ TransactItems: [] }))
+      expect.unreachable('should have thrown')
+    } catch (err) {
+      expect(err).toBeInstanceOf(DynamoDBServiceException)
+      expect((err as DynamoDBServiceException).name).toBe('ValidationException')
+      expect((err as DynamoDBServiceException).message).toBe(
+        "1 validation error detected: Value '[]' at 'transactItems' failed to satisfy constraint: Member must have length greater than or equal to 1",
+      )
+    }
+  })
+
+  it('> 100 actions: anchored regex on the constraint phrase', async () => {
+    // AWS echoes the entire TransactItems list into the validation message in
+    // the same Java-toString shape used for BatchWriteItem. Pinning the dump
+    // verbatim with .toBe() couples the assertion to SDK serialisation, which
+    // has changed before. Anchored regex around the structural envelope
+    // (`[<dump>]`) and the constraint phrase at the end lets the dump vary
+    // without weakening what we actually care about.
+    const items = Array.from({ length: 101 }, (_, i) => ({
+      Put: {
+        TableName: hashTableDef.name,
+        Item: { pk: { S: `twi-${i}` } },
+      },
+    }))
+    const expectedPattern = new RegExp(
+      `^1 validation error detected: Value '\\[.+\\]' at 'transactItems' failed to satisfy constraint: Member must have length less than or equal to 100$`,
+      's',
+    )
+    try {
+      await ddb.send(new TransactWriteItemsCommand({ TransactItems: items }))
+      expect.unreachable('should have thrown')
+    } catch (err) {
+      expect(err).toBeInstanceOf(DynamoDBServiceException)
+      expect((err as DynamoDBServiceException).name).toBe('ValidationException')
+      expect((err as DynamoDBServiceException).message).toMatch(expectedPattern)
+    }
+  })
+
+  it('duplicate target keys in same transaction: full multi-op error', async () => {
+    try {
+      await ddb.send(
+        new TransactWriteItemsCommand({
+          TransactItems: [
+            {
+              Put: {
+                TableName: hashTableDef.name,
+                Item: { pk: { S: 'em-twi-dup' } },
+              },
+            },
+            {
+              Put: {
+                TableName: hashTableDef.name,
+                Item: { pk: { S: 'em-twi-dup' } },
+              },
+            },
+          ],
+        }),
+      )
+      expect.unreachable('should have thrown')
+    } catch (err) {
+      expect(err).toBeInstanceOf(DynamoDBServiceException)
+      expect((err as DynamoDBServiceException).name).toBe('ValidationException')
+      expect((err as DynamoDBServiceException).message).toBe(
+        'Transaction request cannot include multiple operations on one item',
+      )
+    }
+  })
+
+  it('non-existent table: full ResourceNotFoundException message', async () => {
+    try {
+      await ddb.send(
+        new TransactWriteItemsCommand({
+          TransactItems: [
+            {
+              Put: {
+                TableName: '_conformance_does_not_exist_em_twi',
+                Item: { pk: { S: 'x' } },
+              },
+            },
+          ],
+        }),
+      )
+      expect.unreachable('should have thrown')
+    } catch (err) {
+      expect(err).toBeInstanceOf(ResourceNotFoundException)
+      expect((err as ResourceNotFoundException).name).toBe(
+        'ResourceNotFoundException',
+      )
+      expect((err as ResourceNotFoundException).message).toBe(
+        'Requested resource not found',
+      )
+    }
+  })
+
+  it('two failing actions: multi-reason TransactionCanceledException', async () => {
+    // Integration: both actions in the transaction violate their conditions.
+    // The cancellation summary lists every action's reason code in order, so
+    // we can build the expected message from the same array we cross-check
+    // against `CancellationReasons[].Code` — fully deterministic, no regex.
+    await ddb.send(
+      new PutItemCommand({
+        TableName: hashTableDef.name,
+        Item: { pk: { S: 'em-twi-multi-1' }, attr1: { S: 'exists' } },
+      }),
+    )
+    await ddb.send(
+      new PutItemCommand({
+        TableName: hashTableDef.name,
+        Item: { pk: { S: 'em-twi-multi-2' }, attr1: { S: 'exists' } },
+      }),
+    )
+
+    try {
+      await ddb.send(
+        new TransactWriteItemsCommand({
+          TransactItems: [
+            {
+              Put: {
+                TableName: hashTableDef.name,
+                Item: { pk: { S: 'em-twi-multi-1' }, attr1: { S: 'over' } },
+                ConditionExpression: 'attribute_not_exists(pk)',
+              },
+            },
+            {
+              Put: {
+                TableName: hashTableDef.name,
+                Item: { pk: { S: 'em-twi-multi-2' }, attr1: { S: 'over' } },
+                ConditionExpression: 'attribute_not_exists(pk)',
+              },
+            },
+          ],
+        }),
+      )
+      expect.unreachable('should have thrown')
+    } catch (err) {
+      expect(err).toBeInstanceOf(TransactionCanceledException)
+      const txErr = err as TransactionCanceledException
+      const expectedReasons = [
+        'ConditionalCheckFailed',
+        'ConditionalCheckFailed',
+      ] as const
+      expect(txErr.message).toBe(
+        `Transaction cancelled, please refer cancellation reasons for specific reasons [${expectedReasons.join(', ')}]`,
+      )
+      expect(txErr.CancellationReasons?.map((r) => r.Code)).toEqual([
+        ...expectedReasons,
+      ])
+    }
+  })
+
+  it('one passing, one failing: positional reason codes (None for the survivor)', async () => {
+    // The cancellation summary reports a code per action *positionally* —
+    // 'None' for actions that would have succeeded, the actual failure code
+    // for actions that did not. Pin the full message and structure so the
+    // suite catches emulators that emit a flat 'ConditionalCheckFailed' list
+    // without per-action accounting.
+    await ddb.send(
+      new PutItemCommand({
+        TableName: hashTableDef.name,
+        Item: { pk: { S: 'em-twi-pos' }, attr1: { S: 'exists' } },
+      }),
+    )
+
+    try {
+      await ddb.send(
+        new TransactWriteItemsCommand({
+          TransactItems: [
+            {
+              Put: {
+                TableName: hashTableDef.name,
+                Item: { pk: { S: 'em-twi-pos-new' }, attr1: { S: 'fresh' } },
+                ConditionExpression: 'attribute_not_exists(pk)',
+              },
+            },
+            {
+              Put: {
+                TableName: hashTableDef.name,
+                Item: { pk: { S: 'em-twi-pos' }, attr1: { S: 'over' } },
+                ConditionExpression: 'attribute_not_exists(pk)',
+              },
+            },
+          ],
+        }),
+      )
+      expect.unreachable('should have thrown')
+    } catch (err) {
+      expect(err).toBeInstanceOf(TransactionCanceledException)
+      const txErr = err as TransactionCanceledException
+      const expectedReasons = ['None', 'ConditionalCheckFailed'] as const
+      expect(txErr.message).toBe(
+        `Transaction cancelled, please refer cancellation reasons for specific reasons [${expectedReasons.join(', ')}]`,
+      )
+      expect(txErr.CancellationReasons?.map((r) => r.Code)).toEqual([
+        ...expectedReasons,
+      ])
+      expect(txErr.CancellationReasons?.[1].Message).toBe(
+        'The conditional request failed',
+      )
+    }
+  })
+})


### PR DESCRIPTION
## What this changes

`tests/tier3/error-messages/` had no exact-message coverage for `TransactWriteItems` or `TransactGetItems`. This adds it: 6 tests for the write side and 5 for the read side, all pinned to the strings real AWS returns.

Two of the write-side assertions pin the multi-reason `TransactionCanceledException` summary and structurally cross-check `CancellationReasons[].Code` against the same array used to build the expected message. That catches emulators that flatten the per-action positional accounting - returning a flat `[ConditionalCheckFailed]` when the right answer is `[None, ConditionalCheckFailed]`.

The `TransactGetItems` missing-key test pins a quirk: per-action validation surfaces through the cancellation channel as `TransactionCanceledException` with `[ValidationError]`, not a request-level `ValidationException`.

## Stacked on #8

Base branch is `feat/error-messages-variable-suffix` (PR #8), not `main`. When #8 merges, GitHub auto-retargets this PR to `main`.

## Checklist

- [x] New or modified tests run against real AWS DynamoDB and pass
- [ ] ~~New or modified tests run against at least one emulator target and behave as expected~~
- [ ] ~~If AI tools drafted or materially shaped this change, disclosed in the description above~~
- [ ] ~~Linked issue or a short note explaining the motivation~~