### PR TITLE
feat(client): forward AWS_SESSION_TOKEN to the SDK client

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -7,20 +7,22 @@ import { DynamoDBStreamsClient } from '@aws-sdk/client-dynamodb-streams'
 const endpoint = process.env.DYNAMODB_ENDPOINT
 const region = process.env.AWS_REGION || 'us-east-1'
 
-const commonConfig = {
-  ...(endpoint ? { endpoint } : {}),
-  region,
-  // For local endpoints, any credentials work
-  ...(endpoint
-    ? {
-        credentials: {
-          accessKeyId: process.env.AWS_ACCESS_KEY_ID || 'fakeAccessKeyId',
-          secretAccessKey:
-            process.env.AWS_SECRET_ACCESS_KEY || 'fakeSecretAccessKey',
-        },
-      }
-    : {}),
-}
+// Used only when DYNAMODB_ENDPOINT is set (local emulator targets).
+const accessKeyId = process.env.AWS_ACCESS_KEY_ID || 'fakeAccessKeyId'
+const secretAccessKey =
+  process.env.AWS_SECRET_ACCESS_KEY || 'fakeSecretAccessKey'
+const sessionToken = process.env.AWS_SESSION_TOKEN
+
+// Local endpoints accept any credentials. AWS_SESSION_TOKEN is forwarded
+// when set so emulators that authenticate via the SigV4 session-token
+// header can be exercised.
+const credentials = sessionToken
+  ? { accessKeyId, secretAccessKey, sessionToken }
+  : { accessKeyId, secretAccessKey }
+
+const commonConfig = endpoint
+  ? { endpoint, region, credentials }
+  : { region }
 
 /** Low-level DynamoDB client */
 export const ddb = new DynamoDBClient(commonConfig)


### PR DESCRIPTION
Add support for `AWS_SESSION_TOKEN` so the SDK emit
`X-Amz-Security-Token` against emulators that authenticate via that
header.

The explicit `credentials` object in `src/client.ts` replaces the SDK's
default credential provider chain, so `AWS_SESSION_TOKEN` was silently
dropped. Spread `sessionToken` only when the env var is set so
emulators that ignore it stay unaffected.

Tested: `npx tsc --noEmit` clean; end-to-end against a local emulator
that reads the session-token header — tier1 went from 0/303 passed
(all pending at auth) to 248/303 passed.

AI assistance: drafted with Claude Code, reviewed and tsc-checked by hand.