### PR TITLE
fix(ci): write live vitest result artifacts

### DIFF
--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -47,6 +47,7 @@ jobs:
 
       - name: Run conformance suite (excludes GSI lifecycle — see README)
         env:
+          CONFORMANCE_TARGET: dynamodb
           AWS_REGION: eu-west-2
         run: npm run test:quick
 
@@ -91,6 +92,7 @@ jobs:
       - name: Run conformance suite
         continue-on-error: true # Emulators have known conformance gaps
         env:
+          CONFORMANCE_TARGET: dynamodb-local
           DYNAMODB_ENDPOINT: http://localhost:8000
           AWS_ACCESS_KEY_ID: fakeAccessKeyId
           AWS_SECRET_ACCESS_KEY: fakeSecretAccessKey
@@ -132,6 +134,7 @@ jobs:
       - name: Run conformance suite
         continue-on-error: true
         env:
+          CONFORMANCE_TARGET: localstack
           DYNAMODB_ENDPOINT: http://localhost:4566
           AWS_ACCESS_KEY_ID: fakeAccessKeyId
           AWS_SECRET_ACCESS_KEY: fakeSecretAccessKey
@@ -167,6 +170,7 @@ jobs:
       - name: Run conformance suite
         continue-on-error: true
         env:
+          CONFORMANCE_TARGET: dynoxide
           DYNAMODB_ENDPOINT: http://localhost:8001
           AWS_ACCESS_KEY_ID: fakeAccessKeyId
           AWS_SECRET_ACCESS_KEY: fakeSecretAccessKey
@@ -202,6 +206,7 @@ jobs:
       - name: Run conformance suite
         continue-on-error: true
         env:
+          CONFORMANCE_TARGET: floci
           DYNAMODB_ENDPOINT: http://localhost:4566
           AWS_ACCESS_KEY_ID: fakeAccessKeyId
           AWS_SECRET_ACCESS_KEY: fakeSecretAccessKey
@@ -237,6 +242,7 @@ jobs:
       - name: Run conformance suite
         continue-on-error: true
         env:
+          CONFORMANCE_TARGET: ministack
           DYNAMODB_ENDPOINT: http://localhost:4566
           AWS_ACCESS_KEY_ID: fakeAccessKeyId
           AWS_SECRET_ACCESS_KEY: fakeSecretAccessKey
@@ -272,6 +278,7 @@ jobs:
       - name: Run conformance suite
         continue-on-error: true
         env:
+          CONFORMANCE_TARGET: dynalite
           DYNAMODB_ENDPOINT: http://localhost:8002
           AWS_ACCESS_KEY_ID: fakeAccessKeyId
           AWS_SECRET_ACCESS_KEY: fakeSecretAccessKey

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,5 +1,9 @@
 import { defineConfig } from 'vitest/config'
 
+const resultTarget =
+  process.env.CONFORMANCE_TARGET ??
+  (process.env.DYNAMODB_ENDPOINT ? 'local' : 'dynamodb')
+
 export default defineConfig({
   test: {
     globals: true,
@@ -13,7 +17,8 @@ export default defineConfig({
       forks: { singleFork: true },
     },
     setupFiles: ['./src/setup.ts'],
-    reporters: ['verbose'],
+    reporters: ['verbose', 'json'],
+    outputFile: `results/${resultTarget}.json`,
     include: ['tests/**/*.test.ts'],
   },
 })


### PR DESCRIPTION
## What this changes

Adds Vitest JSON reporting to the shared config so CI uploads result artifacts generated by the current run instead of stale committed snapshots. Each conformance job now sets `CONFORMANCE_TARGET`, which drives the `results/<target>.json` output file.

AI-assisted contribution: created with OpenAI Codex and manually reviewed.

Closes #6

## Checklist

- [ ] New or modified tests run against real AWS DynamoDB and pass. Not run locally, no AWS credentials available and this change does not add conformance assertions.
- [ ] New or modified tests run against at least one emulator target and behave as expected. Not run locally, no emulator target started for this workflow/reporting-only change.
- [x] If AI tools drafted or materially shaped this change, disclosed in the description above.
- [x] Linked issue or a short note explaining the motivation.

## Tier and scope

Touches the results pipeline only. Expected regenerated artifacts are the per-target JSON files under `results/` for each CI job: `dynamodb`, `dynamodb-local`, `localstack`, `dynoxide`, `floci`, `ministack`, and `dynalite`.

Validation:

- `npm ci` completed.
- `npx tsc --noEmit` passed.
- `git diff --check` passed.
- `CONFORMANCE_TARGET=codex-smoke npx vitest run 'tests/__no_such__/**/*.test.ts' --passWithNoTests` passed and wrote `results/codex-smoke.json`; the generated smoke file was removed before commit.\n