### PR TITLE
Add negative-path validation coverage

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -87,6 +87,15 @@ Before opening a PR that adds or modifies a test:
    behaves across more than one emulator**, for example "passes on
    Dynoxide, fails on DynamoDB Local, matches real DynamoDB". This
    accelerates maintainer review.
+4. **Consider the rejection path, not just acceptance.** Where a
+   behaviour has inputs real DynamoDB rejects (a malformed expression,
+   an out-of-range parameter, a key that doesn't match the schema),
+   cover the rejection too, not only the accepted form. A target that is
+   too lenient passes acceptance-only tests while still diverging from
+   DynamoDB, so acceptance-only coverage of a feature with a validation
+   boundary is incomplete. Put the error-code assertion in the
+   operation's own tier (or `tests/tier3/validation-ordering/`) and the
+   exact message, where it's stable, in `tests/tier3/error-messages/`.
 
 Regenerating the published results table across all tracked targets
 (DynamoDB, Dynoxide, DynamoDB Local, Dynalite, LocalStack, ExtendDB) is a

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -38,6 +38,14 @@ Before opening a PR that adds or modifies a test:
    you have them to hand.
 3. **Optional but helpful:** note in the PR description how the test
    behaves across more than one emulator.
+4. **Consider the rejection path, not just acceptance.** If the
+   behaviour has inputs real DynamoDB rejects (a malformed expression,
+   an out-of-range parameter, a key that doesn't match the schema),
+   cover the rejection too, not only the accepted form. A target that
+   is too lenient passes acceptance-only tests while still diverging
+   from DynamoDB. Put the error-code check in the operation's own tier
+   (or `tests/tier3/validation-ordering/`) and the exact message, where
+   it's stable, in `tests/tier3/error-messages/`.
 
 Regenerating the published results table across every tracked target
 is a maintainer task and does not block your PR.

--- a/tests/tier1/deleteItem/conditionExpressionParens.test.ts
+++ b/tests/tier1/deleteItem/conditionExpressionParens.test.ts
@@ -127,4 +127,21 @@ describe('DeleteItem — ConditionExpression parens', () => {
     expect(check.Item).toBeDefined()
     expect(check.Item!.status.S).toBe('active')
   })
+
+  // Parse-time rejection, distinct from the ConditionalCheckFailedException
+  // above. A target that accepts redundant wrapping is too lenient.
+  it('rejects redundant parentheses in ConditionExpression', async () => {
+    await expectDynamoError(
+      () =>
+        ddb.send(
+          new DeleteItemCommand({
+            TableName: hashTableDef.name,
+            Key: { pk: { S: 'del-cep-percond' } },
+            ConditionExpression: '((attribute_exists(pk)))',
+          }),
+        ),
+      'ValidationException',
+      /redundant parentheses/,
+    )
+  })
 })

--- a/tests/tier1/putItem/conditionExpressionParens.test.ts
+++ b/tests/tier1/putItem/conditionExpressionParens.test.ts
@@ -114,4 +114,38 @@ describe('PutItem — ConditionExpression parens', () => {
       'ConditionalCheckFailedException',
     )
   })
+
+  // Structural rejections: a parse-time ValidationException, distinct from the
+  // ConditionalCheckFailedException above. A lenient target that accepts these
+  // is what this catches.
+  it('rejects redundant parentheses in ConditionExpression', async () => {
+    await expectDynamoError(
+      () =>
+        ddb.send(
+          new PutItemCommand({
+            TableName: hashTableDef.name,
+            Item: { pk: { S: 'put-cep-redundant' } },
+            ConditionExpression: '((attribute_not_exists(pk)))',
+          }),
+        ),
+      'ValidationException',
+      /redundant parentheses/,
+    )
+  })
+
+  it('rejects contains() with a duplicate path and operand', async () => {
+    await expectDynamoError(
+      () =>
+        ddb.send(
+          new PutItemCommand({
+            TableName: hashTableDef.name,
+            Item: { pk: { S: 'put-cep-contains' } },
+            ConditionExpression: 'contains(#a, #a)',
+            ExpressionAttributeNames: { '#a': 'data' },
+          }),
+        ),
+      'ValidationException',
+      /first operand must be distinct/,
+    )
+  })
 })

--- a/tests/tier1/query/basic.test.ts
+++ b/tests/tier1/query/basic.test.ts
@@ -6,7 +6,11 @@ import {
   type QueryCommandOutput,
 } from '@aws-sdk/client-dynamodb'
 import { ddb } from '../../../src/client.js'
-import { compositeTableDef, cleanupItems } from '../../../src/helpers.js'
+import {
+  compositeTableDef,
+  cleanupItems,
+  expectDynamoError,
+} from '../../../src/helpers.js'
 
 describe('Query — basic', () => {
   const pk = 'query-basic'
@@ -385,5 +389,42 @@ describe('Query — Limit + FilterExpression interaction', () => {
     expect(result.Count).toBe(1)
     expect(result.Items).toHaveLength(1)
     expect(result.LastEvaluatedKey).toBeDefined()
+  })
+
+  // Pagination tests above only ever feed back a well-formed LastEvaluatedKey.
+  // A target that does not validate ExclusiveStartKey against the schema is too
+  // lenient; real DynamoDB rejects a key that does not match.
+  it('rejects ExclusiveStartKey that does not match the table schema', async () => {
+    await expectDynamoError(
+      () =>
+        ddb.send(
+          new QueryCommand({
+            TableName: compositeTableDef.name,
+            KeyConditionExpression: 'pk = :pk',
+            ExpressionAttributeValues: { ':pk': { S: 'query-basic' } },
+            ExclusiveStartKey: { bad: { S: 'p' } },
+          }),
+        ),
+      'ValidationException',
+      /provided starting key is invalid/,
+    )
+  })
+
+  it('rejects ExclusiveStartKey missing the index key on a GSI query', async () => {
+    await expectDynamoError(
+      () =>
+        ddb.send(
+          new QueryCommand({
+            TableName: compositeTableDef.name,
+            IndexName: 'gsi1',
+            KeyConditionExpression: '#hk = :v',
+            ExpressionAttributeNames: { '#hk': 'lsi1sk' },
+            ExpressionAttributeValues: { ':v': { S: 'x' } },
+            ExclusiveStartKey: { pk: { S: 'x' } },
+          }),
+        ),
+      'ValidationException',
+      /provided starting key is invalid/,
+    )
   })
 })

--- a/tests/tier1/query/expressions.test.ts
+++ b/tests/tier1/query/expressions.test.ts
@@ -396,3 +396,64 @@ describe('Query — FilterExpression functions and operators', () => {
     expect(result.Items![0].sk.S).toBe('4')
   })
 })
+
+// size() on a string counts UTF-16 code units, not UTF-8 bytes. The operator
+// tests above use ASCII, where the two agree; this distinguishes them, and
+// also pins that size() of an absent attribute is undefined (no match), not 0.
+describe('Query — size() string encoding', () => {
+  const pk = 'size-enc'
+  // "é" (U+00E9) is 1 UTF-16 code unit; "𝄞" (U+1D11E) is a surrogate pair, 2
+  // code units. Total: 3 code units. UTF-8 byte length is 6.
+  const s = 'é\u{1d11e}'
+  const item = { pk: { S: pk }, sk: { S: '1' }, s: { S: s } }
+
+  beforeAll(async () => {
+    await ddb.send(
+      new PutItemCommand({ TableName: compositeTableDef.name, Item: item }),
+    )
+  })
+
+  afterAll(async () => {
+    await cleanupItems(compositeTableDef.name, [{ pk: item.pk, sk: item.sk }])
+  })
+
+  it('counts UTF-16 code units (3), not UTF-8 bytes (6)', async () => {
+    const match = await ddb.send(
+      new QueryCommand({
+        TableName: compositeTableDef.name,
+        KeyConditionExpression: '#pk = :pk',
+        FilterExpression: 'size(#s) = :three',
+        ExpressionAttributeNames: { '#pk': 'pk', '#s': 's' },
+        ExpressionAttributeValues: { ':pk': { S: pk }, ':three': { N: '3' } },
+        ConsistentRead: true,
+      }),
+    )
+    expect(match.Items).toHaveLength(1)
+
+    const noMatch = await ddb.send(
+      new QueryCommand({
+        TableName: compositeTableDef.name,
+        KeyConditionExpression: '#pk = :pk',
+        FilterExpression: 'size(#s) = :six',
+        ExpressionAttributeNames: { '#pk': 'pk', '#s': 's' },
+        ExpressionAttributeValues: { ':pk': { S: pk }, ':six': { N: '6' } },
+        ConsistentRead: true,
+      }),
+    )
+    expect(noMatch.Items).toHaveLength(0)
+  })
+
+  it('size() of a missing attribute does not match (undefined, not 0)', async () => {
+    const result = await ddb.send(
+      new QueryCommand({
+        TableName: compositeTableDef.name,
+        KeyConditionExpression: '#pk = :pk',
+        FilterExpression: 'size(#m) = :zero',
+        ExpressionAttributeNames: { '#pk': 'pk', '#m': 'no_such_attr' },
+        ExpressionAttributeValues: { ':pk': { S: pk }, ':zero': { N: '0' } },
+        ConsistentRead: true,
+      }),
+    )
+    expect(result.Items).toHaveLength(0)
+  })
+})

--- a/tests/tier1/query/keyConditionParens.test.ts
+++ b/tests/tier1/query/keyConditionParens.test.ts
@@ -3,7 +3,11 @@ import {
   QueryCommand,
 } from '@aws-sdk/client-dynamodb'
 import { ddb } from '../../../src/client.js'
-import { compositeTableDef, cleanupItems } from '../../../src/helpers.js'
+import {
+  compositeTableDef,
+  cleanupItems,
+  expectDynamoError,
+} from '../../../src/helpers.js'
 
 describe('Query — KeyConditionExpression with parentheses', () => {
   const pk = 'kce-parens'
@@ -82,5 +86,24 @@ describe('Query — KeyConditionExpression with parentheses', () => {
 
     expect(result.Items).toHaveLength(1)
     expect(result.Items![0].data?.S).toBe('c')
+  })
+
+  // The acceptance cases above deliberately avoid redundant wrapping. This is
+  // the matching rejection: a target that parses parens but does not reject the
+  // redundant form is too lenient. Real DynamoDB rejects it.
+  it('rejects redundant parentheses in KeyConditionExpression', async () => {
+    await expectDynamoError(
+      () =>
+        ddb.send(
+          new QueryCommand({
+            TableName: compositeTableDef.name,
+            KeyConditionExpression: '((#pk = :pk)) AND (#sk = :sk)',
+            ExpressionAttributeNames: { '#pk': 'pk', '#sk': 'sk' },
+            ExpressionAttributeValues: { ':pk': { S: pk }, ':sk': { S: '1' } },
+          }),
+        ),
+      'ValidationException',
+      /redundant parentheses/,
+    )
   })
 })

--- a/tests/tier1/scan/basic.test.ts
+++ b/tests/tier1/scan/basic.test.ts
@@ -6,7 +6,11 @@ import {
   type ScanCommandOutput,
 } from '@aws-sdk/client-dynamodb'
 import { ddb } from '../../../src/client.js'
-import { hashTableDef, cleanupItems } from '../../../src/helpers.js'
+import {
+  hashTableDef,
+  cleanupItems,
+  expectDynamoError,
+} from '../../../src/helpers.js'
 
 describe('Scan — basic', () => {
   const items = Array.from({ length: 5 }, (_, i) => ({
@@ -199,5 +203,21 @@ describe('Scan — ProjectionExpression', () => {
     expect(result.Items![0].a.S).toBe('alpha')
     expect(result.Items![0].b).toBeUndefined()
     expect(result.Items![0].pk).toBeUndefined()
+  })
+
+  // Pagination above only feeds back a well-formed LastEvaluatedKey. Real
+  // DynamoDB rejects an ExclusiveStartKey that does not match the schema.
+  it('rejects ExclusiveStartKey that does not match the table schema', async () => {
+    await expectDynamoError(
+      () =>
+        ddb.send(
+          new ScanCommand({
+            TableName: hashTableDef.name,
+            ExclusiveStartKey: { bad: { S: 'p' } },
+          }),
+        ),
+      'ValidationException',
+      /provided starting key is invalid/,
+    )
   })
 })

--- a/tests/tier1/scan/filterOperators.test.ts
+++ b/tests/tier1/scan/filterOperators.test.ts
@@ -3,7 +3,11 @@ import {
   ScanCommand,
 } from '@aws-sdk/client-dynamodb'
 import { ddb } from '../../../src/client.js'
-import { hashTableDef, cleanupItems } from '../../../src/helpers.js'
+import {
+  hashTableDef,
+  cleanupItems,
+  expectDynamoError,
+} from '../../../src/helpers.js'
 
 describe('Scan — filter operators on different types', () => {
   const items = [
@@ -309,5 +313,41 @@ describe('Scan — set equality', () => {
     expect(result.Items!.length).toBe(2)
     const pks = result.Items!.map((i) => i.pk.S).sort()
     expect(pks).toEqual(['fo-2', 'fo-3'])
+  })
+})
+
+// Structural validation of FilterExpression. The operator tests above only send
+// well-formed filters; these assert the rejection path a lenient target skips.
+describe('Scan — filter expression validation', () => {
+  it('rejects begins_with with a non-string/binary operand', async () => {
+    await expectDynamoError(
+      () =>
+        ddb.send(
+          new ScanCommand({
+            TableName: hashTableDef.name,
+            FilterExpression: 'begins_with(#a, :n)',
+            ExpressionAttributeNames: { '#a': 'strVal' },
+            ExpressionAttributeValues: { ':n': { N: '1' } },
+          }),
+        ),
+      'ValidationException',
+      /Incorrect operand type/,
+    )
+  })
+
+  it('rejects redundant parentheses in FilterExpression', async () => {
+    await expectDynamoError(
+      () =>
+        ddb.send(
+          new ScanCommand({
+            TableName: hashTableDef.name,
+            FilterExpression: '((#a = :v))',
+            ExpressionAttributeNames: { '#a': 'strVal' },
+            ExpressionAttributeValues: { ':v': { S: 'apple' } },
+          }),
+        ),
+      'ValidationException',
+      /redundant parentheses/,
+    )
   })
 })

--- a/tests/tier3/error-messages/putItem.test.ts
+++ b/tests/tier3/error-messages/putItem.test.ts
@@ -199,4 +199,43 @@ describe('PutItem — exact error messages', () => {
       )
     }
   })
+
+  it('redundant parentheses in ConditionExpression: full error string', async () => {
+    try {
+      await ddb.send(
+        new PutItemCommand({
+          TableName: hashTableDef.name,
+          Item: { pk: { S: 'em-put-redundant' } },
+          ConditionExpression: '((attribute_not_exists(pk)))',
+        }),
+      )
+      expect.unreachable('should have thrown')
+    } catch (err) {
+      expect(err).toBeInstanceOf(DynamoDBServiceException)
+      expect((err as DynamoDBServiceException).name).toBe('ValidationException')
+      expect((err as DynamoDBServiceException).message).toBe(
+        'Invalid ConditionExpression: The expression has redundant parentheses;',
+      )
+    }
+  })
+
+  it('contains() with duplicate path and operand: full distinct-operand error', async () => {
+    try {
+      await ddb.send(
+        new PutItemCommand({
+          TableName: hashTableDef.name,
+          Item: { pk: { S: 'em-put-contains-dup' } },
+          ConditionExpression: 'contains(#a, #a)',
+          ExpressionAttributeNames: { '#a': 'data' },
+        }),
+      )
+      expect.unreachable('should have thrown')
+    } catch (err) {
+      expect(err).toBeInstanceOf(DynamoDBServiceException)
+      expect((err as DynamoDBServiceException).name).toBe('ValidationException')
+      expect((err as DynamoDBServiceException).message).toBe(
+        'Invalid ConditionExpression: The first operand must be distinct from the remaining operands for this operator or function; operator: contains, first operand: [data]',
+      )
+    }
+  })
 })

--- a/tests/tier3/error-messages/query.test.ts
+++ b/tests/tier3/error-messages/query.test.ts
@@ -187,4 +187,26 @@ describe('Query — exact error messages', () => {
       )
     }
   })
+
+  // Query and Scan return different messages for the same malformed key: Query
+  // gives this short form, Scan gives a longer one (see scan.test.ts).
+  it('malformed ExclusiveStartKey: short invalid-starting-key error', async () => {
+    try {
+      await ddb.send(
+        new QueryCommand({
+          TableName: compositeTableDef.name,
+          KeyConditionExpression: 'pk = :v',
+          ExpressionAttributeValues: { ':v': { S: 'val' } },
+          ExclusiveStartKey: { bad: { S: 'p' } },
+        }),
+      )
+      expect.unreachable('should have thrown')
+    } catch (err) {
+      expect(err).toBeInstanceOf(DynamoDBServiceException)
+      expect((err as DynamoDBServiceException).name).toBe('ValidationException')
+      expect((err as DynamoDBServiceException).message).toBe(
+        'The provided starting key is invalid',
+      )
+    }
+  })
 })

--- a/tests/tier3/error-messages/query.test.ts
+++ b/tests/tier3/error-messages/query.test.ts
@@ -5,6 +5,7 @@ import {
 import { ddb } from '../../../src/client.js'
 import {
   compositeTableDef,
+  hashTableDef,
 } from '../../../src/helpers.js'
 
 describe('Query — exact error messages', () => {
@@ -164,6 +165,25 @@ describe('Query — exact error messages', () => {
       expect((err as DynamoDBServiceException).name).toBe('ValidationException')
       expect((err as DynamoDBServiceException).message).toBe(
         'Invalid FilterExpression: An expression attribute name used in the document path is not defined; attribute name: #missing',
+      )
+    }
+  })
+
+  it('redundant parentheses in KeyConditionExpression: full error string', async () => {
+    try {
+      await ddb.send(
+        new QueryCommand({
+          TableName: hashTableDef.name,
+          KeyConditionExpression: '((pk = :v))',
+          ExpressionAttributeValues: { ':v': { S: 'val' } },
+        }),
+      )
+      expect.unreachable('should have thrown')
+    } catch (err) {
+      expect(err).toBeInstanceOf(DynamoDBServiceException)
+      expect((err as DynamoDBServiceException).name).toBe('ValidationException')
+      expect((err as DynamoDBServiceException).message).toBe(
+        'Invalid KeyConditionExpression: The expression has redundant parentheses;',
       )
     }
   })

--- a/tests/tier3/error-messages/scan.test.ts
+++ b/tests/tier3/error-messages/scan.test.ts
@@ -138,4 +138,24 @@ describe('Scan — exact error messages', () => {
       )
     }
   })
+
+  // Scan returns the long form of the invalid-starting-key error; Query returns
+  // a shorter one (see query.test.ts). Pin each separately.
+  it('malformed ExclusiveStartKey: long schema-mismatch error', async () => {
+    try {
+      await ddb.send(
+        new ScanCommand({
+          TableName: hashTableDef.name,
+          ExclusiveStartKey: { bad: { S: 'p' } },
+        }),
+      )
+      expect.unreachable('should have thrown')
+    } catch (err) {
+      expect(err).toBeInstanceOf(DynamoDBServiceException)
+      expect((err as DynamoDBServiceException).name).toBe('ValidationException')
+      expect((err as DynamoDBServiceException).message).toBe(
+        'The provided starting key is invalid: The provided key element does not match the schema',
+      )
+    }
+  })
 })

--- a/tests/tier3/error-messages/scan.test.ts
+++ b/tests/tier3/error-messages/scan.test.ts
@@ -98,4 +98,44 @@ describe('Scan — exact error messages', () => {
       )
     }
   })
+
+  it('begins_with with non-string operand: full operand-type error', async () => {
+    try {
+      await ddb.send(
+        new ScanCommand({
+          TableName: hashTableDef.name,
+          FilterExpression: 'begins_with(#a, :n)',
+          ExpressionAttributeNames: { '#a': 'data' },
+          ExpressionAttributeValues: { ':n': { N: '1' } },
+        }),
+      )
+      expect.unreachable('should have thrown')
+    } catch (err) {
+      expect(err).toBeInstanceOf(DynamoDBServiceException)
+      expect((err as DynamoDBServiceException).name).toBe('ValidationException')
+      expect((err as DynamoDBServiceException).message).toBe(
+        'Invalid FilterExpression: Incorrect operand type for operator or function; operator or function: begins_with, operand type: N',
+      )
+    }
+  })
+
+  it('redundant parentheses in FilterExpression: full error string', async () => {
+    try {
+      await ddb.send(
+        new ScanCommand({
+          TableName: hashTableDef.name,
+          FilterExpression: '((#a = :v))',
+          ExpressionAttributeNames: { '#a': 'data' },
+          ExpressionAttributeValues: { ':v': { S: 'x' } },
+        }),
+      )
+      expect.unreachable('should have thrown')
+    } catch (err) {
+      expect(err).toBeInstanceOf(DynamoDBServiceException)
+      expect((err as DynamoDBServiceException).name).toBe('ValidationException')
+      expect((err as DynamoDBServiceException).message).toBe(
+        'Invalid FilterExpression: The expression has redundant parentheses;',
+      )
+    }
+  })
 })

--- a/tests/tier3/limits/itemSize.test.ts
+++ b/tests/tier3/limits/itemSize.test.ts
@@ -5,6 +5,7 @@ import {
 import { ddb } from '../../../src/client.js'
 import {
   hashTableDef,
+  hashNTableDef,
   cleanupItems,
 } from '../../../src/helpers.js'
 
@@ -197,6 +198,58 @@ describe('Item size limit (400KB)', () => {
         new PutItemCommand({
           TableName: hashTableDef.name,
           Item: { ...k, bindata: { B: buf } },
+        }),
+      )
+      expect.unreachable('should have thrown')
+    } catch (e: unknown) {
+      expect((e as any).name).toBe('ValidationException')
+      expect((e as any).message).toMatch(
+        /[Ii]tem size has exceeded the maximum allowed size|[Ii]tem size to update has exceeded the maximum allowed size/,
+      )
+    }
+  })
+})
+
+// The size tests above are dominated by strings and binary, where one byte of
+// payload is one byte of item size. Numbers are different: DynamoDB sizes a
+// number at roughly 1 byte per two significant digits plus 1, so a 38-digit
+// number is ~20 bytes, not 38. A target that sizes numbers by their string
+// length (or a fixed width) computes a very different total, which shifts the
+// 400KB boundary. With thousands of numbers, even a small per-number error
+// crosses the limit. Uses the on-demand table so writes are not throttled and
+// the only rejection cause is the size limit itself.
+describe('Item size limit — number sizing', () => {
+  const NUM = '9'.repeat(38) // 38 significant digits → ~20 bytes in DynamoDB.
+
+  afterAll(async () => {
+    await cleanupItems(hashNTableDef.name, [{ pk: { N: '1' } }])
+  })
+
+  it('a number-dominated item under 400KB succeeds (15000 numbers)', async () => {
+    const nums = { L: Array.from({ length: 15000 }, () => ({ N: NUM })) }
+    await ddb.send(
+      new PutItemCommand({
+        TableName: hashNTableDef.name,
+        Item: { pk: { N: '1' }, nums },
+      }),
+    )
+    const get = await ddb.send(
+      new GetItemCommand({
+        TableName: hashNTableDef.name,
+        Key: { pk: { N: '1' } },
+        ConsistentRead: true,
+      }),
+    )
+    expect(get.Item!.nums.L).toHaveLength(15000)
+  })
+
+  it('a number-dominated item over 400KB fails (21000 numbers)', async () => {
+    const nums = { L: Array.from({ length: 21000 }, () => ({ N: NUM })) }
+    try {
+      await ddb.send(
+        new PutItemCommand({
+          TableName: hashNTableDef.name,
+          Item: { pk: { N: '2' }, nums },
         }),
       )
       expect.unreachable('should have thrown')

--- a/tests/tier3/validation-ordering/createTable.test.ts
+++ b/tests/tier3/validation-ordering/createTable.test.ts
@@ -82,4 +82,76 @@ describe('CreateTable — validation ordering', () => {
       expect(err.message.length).toBeGreaterThan(0)
     }
   })
+
+  it('rejects a duplicate attribute in KeySchema', async () => {
+    try {
+      await ddb.send(
+        new CreateTableCommand({
+          TableName: '_conformance_dupkey',
+          AttributeDefinitions: [{ AttributeName: 'pk', AttributeType: 'S' }],
+          KeySchema: [
+            { AttributeName: 'pk', KeyType: 'HASH' },
+            { AttributeName: 'pk', KeyType: 'RANGE' },
+          ],
+          BillingMode: 'PAY_PER_REQUEST',
+        }),
+      )
+      expect.unreachable('should have thrown')
+    } catch (e: unknown) {
+      expect(e).toBeInstanceOf(DynamoDBServiceException)
+      const err = e as DynamoDBServiceException
+      expect(err.name).toBe('ValidationException')
+      expect(err.message).toContain('Invalid KeySchema')
+    }
+  })
+
+  it('rejects more than two KeySchema elements', async () => {
+    try {
+      await ddb.send(
+        new CreateTableCommand({
+          TableName: '_conformance_threekey',
+          AttributeDefinitions: [
+            { AttributeName: 'pk', AttributeType: 'S' },
+            { AttributeName: 'sk', AttributeType: 'S' },
+            { AttributeName: 'tk', AttributeType: 'S' },
+          ],
+          KeySchema: [
+            { AttributeName: 'pk', KeyType: 'HASH' },
+            { AttributeName: 'sk', KeyType: 'RANGE' },
+            { AttributeName: 'tk', KeyType: 'RANGE' },
+          ],
+          BillingMode: 'PAY_PER_REQUEST',
+        }),
+      )
+      expect.unreachable('should have thrown')
+    } catch (e: unknown) {
+      expect(e).toBeInstanceOf(DynamoDBServiceException)
+      const err = e as DynamoDBServiceException
+      expect(err.name).toBe('ValidationException')
+      // The full message echoes the KeySchema as a Java-style object dump
+      // (SDK-version-coupled), so assert only the stable constraint phrase.
+      expect(err.message).toContain('Member must have length less than or equal to 2')
+    }
+  })
+
+  it('rejects an invalid BillingMode on its own', async () => {
+    try {
+      await ddb.send(
+        new CreateTableCommand({
+          TableName: '_conformance_badbilling',
+          AttributeDefinitions: [{ AttributeName: 'pk', AttributeType: 'S' }],
+          KeySchema: [{ AttributeName: 'pk', KeyType: 'HASH' }],
+          // @ts-expect-error -- testing invalid BillingMode
+          BillingMode: 'INVALID_MODE',
+        }),
+      )
+      expect.unreachable('should have thrown')
+    } catch (e: unknown) {
+      expect(e).toBeInstanceOf(DynamoDBServiceException)
+      const err = e as DynamoDBServiceException
+      expect(err.name).toBe('ValidationException')
+      expect(err.message).toContain('billingMode')
+      expect(err.message).toContain('[PROVISIONED, PAY_PER_REQUEST]')
+    }
+  })
 })

--- a/tests/tier3/validation-ordering/scan.test.ts
+++ b/tests/tier3/validation-ordering/scan.test.ts
@@ -60,4 +60,23 @@ describe('Scan — validation ordering', () => {
       expect(err.message).toContain('TotalSegments')
     }
   })
+
+  it('rejects a negative Segment', async () => {
+    try {
+      await ddb.send(
+        new ScanCommand({
+          TableName: hashTableDef.name,
+          Segment: -1,
+          TotalSegments: 4,
+        }),
+      )
+      expect.unreachable('should have thrown')
+    } catch (e: unknown) {
+      expect(e).toBeInstanceOf(DynamoDBServiceException)
+      const err = e as DynamoDBServiceException
+      expect(err.name).toBe('ValidationException')
+      expect(err.message).toContain('segment')
+      expect(err.message).toContain('greater than or equal to 0')
+    }
+  })
 })


### PR DESCRIPTION
## What this changes

The suite only tested acceptance, so a target that is too lenient (accepts malformed expressions, mis-accounts sizes, skips structural validation) still scored well. This adds the matching rejection coverage: `begins_with` operand types, `contains()` duplicate operands, redundant parentheses, `size()` UTF-16 counting, number byte-sizing, `ExclusiveStartKey` and `Segment` validation, and a small control-plane sweep. Error codes sit in the operation's own tier, exact messages in tier3.

Tests drafted with AI assistance (Claude Opus 4.7), characterised and validated against real AWS DynamoDB.

Closes #16.

## Checklist

- [x] New or modified tests run against real AWS DynamoDB and pass
- [x] New or modified tests run against at least one emulator target and behave as expected
- [x] If AI tools drafted or materially shaped this change, disclosed in the description above
- [x] Linked issue or a short note explaining the motivation

## Tier and scope

No tier definitions or pipeline changes. When the results table is regenerated, lenient targets gain fails: that is expanded coverage, not a regression. Ran against Dynoxide 0.9.x, where 13 of the new tests fail (redundant parens across expression contexts, `contains()` self-operand, non-string `begins_with`, `size()` UTF-16 counting, negative `Segment`); the rest pass. Dynoxide fixes are tracked separately.
