### PR TITLE
Expand conformance coverage: pagination, write semantics, accounting, and more

### DIFF
--- a/tests/tier1/batchWriteItem/validation.test.ts
+++ b/tests/tier1/batchWriteItem/validation.test.ts
@@ -61,4 +61,25 @@ describe('BatchWriteItem — validation', () => {
       'ValidationException',
     )
   })
+
+  it('rejects a key-less item with a 400 ValidationException, not a 500', async () => {
+    try {
+      await ddb.send(
+        new BatchWriteItemCommand({
+          RequestItems: {
+            [hashTableDef.name]: [
+              { PutRequest: { Item: { notkey: { S: 'x' } } } },
+            ],
+          },
+        }),
+      )
+      expect.unreachable('should have thrown')
+    } catch (e) {
+      // A too-lenient target returns 500 InternalError here; AWS rejects with
+      // a 400 ValidationException for the schema-mismatched item.
+      const err = e as { name?: string; $metadata?: { httpStatusCode?: number } }
+      expect(err.name).toBe('ValidationException')
+      expect(err.$metadata?.httpStatusCode).toBe(400)
+    }
+  })
 })

--- a/tests/tier1/getItem/projection.test.ts
+++ b/tests/tier1/getItem/projection.test.ts
@@ -123,4 +123,32 @@ describe('Nested attribute projection', () => {
     expect(items[0].mymap.M!.nested.S).toBe('deep')
     expect(items[0].mymap.M!.other).toBeUndefined()
   })
+
+  it('GetItem ProjectionExpression with multiple sibling paths in one map keeps all of them', async () => {
+    const k = 'proj-multi'
+    await ddb.send(
+      new PutItemCommand({
+        TableName: hashTableDef.name,
+        Item: {
+          pk: { S: k },
+          m: { M: { a: { S: 'A' }, b: { S: 'B' }, c: { S: 'C' } } },
+        },
+      }),
+    )
+    const result = await ddb.send(
+      new GetItemCommand({
+        TableName: hashTableDef.name,
+        Key: { pk: { S: k } },
+        ProjectionExpression: '#m.#a, #m.#b',
+        ExpressionAttributeNames: { '#m': 'm', '#a': 'a', '#b': 'b' },
+        ConsistentRead: true,
+      }),
+    )
+    // Both projected siblings survive (not just the last), and the structure is
+    // preserved; the unprojected sibling is dropped.
+    expect(result.Item!.m.M!.a.S).toBe('A')
+    expect(result.Item!.m.M!.b.S).toBe('B')
+    expect(result.Item!.m.M!.c).toBeUndefined()
+    await cleanupItems(hashTableDef.name, [{ pk: { S: k } }])
+  })
 })

--- a/tests/tier1/putItem/conditions.test.ts
+++ b/tests/tier1/putItem/conditions.test.ts
@@ -1,6 +1,7 @@
 import {
   PutItemCommand,
   GetItemCommand,
+  ConditionalCheckFailedException,
 } from '@aws-sdk/client-dynamodb'
 import { ddb } from '../../../src/client.js'
 import { hashTableDef, expectDynamoError, cleanupItems } from '../../../src/helpers.js'
@@ -195,5 +196,35 @@ describe('PutItem — ConditionExpression', () => {
       ),
       'ConditionalCheckFailedException',
     )
+  })
+
+  it('returns the conflicting item via ReturnValuesOnConditionCheckFailure on a failed Put', async () => {
+    const k = 'put-rvcf'
+    await cleanupItems(hashTableDef.name, [{ pk: { S: k } }])
+    await ddb.send(
+      new PutItemCommand({
+        TableName: hashTableDef.name,
+        Item: { pk: { S: k }, val: { S: 'first' } },
+      }),
+    )
+
+    try {
+      await ddb.send(
+        new PutItemCommand({
+          TableName: hashTableDef.name,
+          Item: { pk: { S: k }, val: { S: 'second' } },
+          ConditionExpression: 'attribute_not_exists(pk)',
+          ReturnValuesOnConditionCheckFailure: 'ALL_OLD',
+        }),
+      )
+      expect.unreachable('should have thrown')
+    } catch (e) {
+      expect(e).toBeInstanceOf(ConditionalCheckFailedException)
+      const err = e as ConditionalCheckFailedException
+      expect(err.Item).toBeDefined()
+      expect(err.Item!.val.S).toBe('first')
+    }
+
+    await cleanupItems(hashTableDef.name, [{ pk: { S: k } }])
   })
 })

--- a/tests/tier1/putItem/validation.test.ts
+++ b/tests/tier1/putItem/validation.test.ts
@@ -76,6 +76,35 @@ describe('PutItem — validation', () => {
     )
   })
 
+  it('rejects duplicate values in number set', async () => {
+    await expectDynamoError(
+      () => ddb.send(
+        new PutItemCommand({
+          TableName: hashTableDef.name,
+          Item: { pk: { S: 'test' }, bad: { NS: ['1', '1', '2'] } },
+        }),
+      ),
+      'ValidationException',
+      'duplicates',
+    )
+  })
+
+  it('rejects duplicate values in binary set', async () => {
+    await expectDynamoError(
+      () => ddb.send(
+        new PutItemCommand({
+          TableName: hashTableDef.name,
+          Item: {
+            pk: { S: 'test' },
+            bad: { BS: [new Uint8Array([1]), new Uint8Array([1])] },
+          },
+        }),
+      ),
+      'ValidationException',
+      'duplicates',
+    )
+  })
+
   it('rejects invalid ReturnValues', async () => {
     await expectDynamoError(
       () => ddb.send(

--- a/tests/tier1/query/basic.test.ts
+++ b/tests/tier1/query/basic.test.ts
@@ -428,3 +428,58 @@ describe('Query — Limit + FilterExpression interaction', () => {
     )
   })
 })
+
+describe('Query — ExclusiveStartKey exclusivity', () => {
+  const pk = 'esk-excl'
+  const items = ['a', 'b', 'c', 'd', 'e'].map((s) => ({
+    pk: { S: pk },
+    sk: { S: s },
+  }))
+
+  beforeAll(async () => {
+    await Promise.all(
+      items.map((item) =>
+        ddb.send(
+          new PutItemCommand({ TableName: compositeTableDef.name, Item: item }),
+        ),
+      ),
+    )
+  })
+
+  afterAll(async () => {
+    await cleanupItems(
+      compositeTableDef.name,
+      items.map((i) => ({ pk: i.pk, sk: i.sk })),
+    )
+  })
+
+  it('does not repeat the item equal to ExclusiveStartKey', async () => {
+    const firstPage = await ddb.send(
+      new QueryCommand({
+        TableName: compositeTableDef.name,
+        KeyConditionExpression: 'pk = :pk',
+        ExpressionAttributeValues: { ':pk': { S: pk } },
+        ConsistentRead: true,
+        Limit: 2,
+      }),
+    )
+    expect(firstPage.Items).toHaveLength(2)
+    const startKey = firstPage.LastEvaluatedKey
+    expect(startKey).toBeDefined()
+
+    const secondPage = await ddb.send(
+      new QueryCommand({
+        TableName: compositeTableDef.name,
+        KeyConditionExpression: 'pk = :pk',
+        ExpressionAttributeValues: { ':pk': { S: pk } },
+        ConsistentRead: true,
+        ExclusiveStartKey: startKey,
+      }),
+    )
+    const secondSks = secondPage.Items!.map((i) => i.sk.S)
+    // The item equal to ExclusiveStartKey must not reappear.
+    expect(secondSks).not.toContain(startKey!.sk.S)
+    // Continues strictly after the start key (a, b on page 1 → c, d, e next).
+    expect(secondSks).toEqual(['c', 'd', 'e'])
+  })
+})

--- a/tests/tier1/query/gsi.test.ts
+++ b/tests/tier1/query/gsi.test.ts
@@ -2,6 +2,7 @@ import {
   PutItemCommand,
   QueryCommand,
   DeleteItemCommand,
+  type AttributeValue,
 } from '@aws-sdk/client-dynamodb'
 import { ddb } from '../../../src/client.js'
 import {
@@ -131,5 +132,83 @@ describe('Query — GSI', () => {
         Key: { pk: sparseItem.pk, sk: sparseItem.sk },
       }),
     )
+  })
+})
+
+describe('Query — GSI pagination across tied sort keys', () => {
+  // All items share both GSI keys (lsi1sk + lsi2sk), so the GSI cursor is
+  // ambiguous without the base-table key. Real AWS composes LastEvaluatedKey
+  // from the base key (pk, sk) AND the index keys (lsi1sk, lsi2sk) — captured
+  // against AWS as {pk, lsi1sk, sk, lsi2sk}. An emulator that returns only the
+  // index keys loops forever or drops rows on the tie.
+  const tied = [0, 1, 2, 3].map((i) => ({
+    pk: { S: `gsi-tie-${i}` },
+    sk: { S: `s-${i}` },
+    lsi1sk: { S: 'gsi-tie-hash' },
+    lsi2sk: { S: 'gsi-tie-range' },
+    data: { S: `d${i}` },
+  }))
+
+  beforeAll(async () => {
+    await Promise.all(
+      tied.map((item) =>
+        ddb.send(
+          new PutItemCommand({ TableName: compositeTableDef.name, Item: item }),
+        ),
+      ),
+    )
+    await waitForGsiConsistency({
+      tableName: compositeTableDef.name,
+      indexName: 'gsi2',
+      partitionKey: { name: 'lsi1sk', value: { S: 'gsi-tie-hash' } },
+      expectedCount: tied.length,
+    })
+  })
+
+  afterAll(async () => {
+    await cleanupItems(
+      compositeTableDef.name,
+      tied.map((item) => ({ pk: item.pk, sk: item.sk })),
+    )
+  })
+
+  it('composes LastEvaluatedKey from base and index keys and walks every tied item once', async () => {
+    const seen: string[] = []
+    let lastKey: Record<string, AttributeValue> | undefined
+    let pages = 0
+
+    do {
+      const page = await ddb.send(
+        new QueryCommand({
+          TableName: compositeTableDef.name,
+          IndexName: 'gsi2',
+          KeyConditionExpression: 'lsi1sk = :h AND lsi2sk = :r',
+          ExpressionAttributeValues: {
+            ':h': { S: 'gsi-tie-hash' },
+            ':r': { S: 'gsi-tie-range' },
+          },
+          Limit: 1,
+          ...(lastKey ? { ExclusiveStartKey: lastKey } : {}),
+        }),
+      )
+      pages++
+      for (const item of page.Items ?? []) seen.push(item.pk!.S!)
+      lastKey = page.LastEvaluatedKey
+      if (lastKey) {
+        // The continuation key must carry the base-table keys, not just the GSI keys.
+        expect(Object.keys(lastKey).sort()).toEqual([
+          'lsi1sk',
+          'lsi2sk',
+          'pk',
+          'sk',
+        ])
+      }
+      // Guard against the infinite-loop bug: a correct walk needs at most one
+      // page per item plus the terminating empty check.
+      expect(pages).toBeLessThanOrEqual(tied.length + 1)
+    } while (lastKey)
+
+    expect(seen.sort()).toEqual(tied.map((t) => t.pk.S).sort())
+    expect(new Set(seen).size).toBe(tied.length) // no repeats
   })
 })

--- a/tests/tier1/query/lsi.test.ts
+++ b/tests/tier1/query/lsi.test.ts
@@ -1,6 +1,7 @@
 import {
   PutItemCommand,
   QueryCommand,
+  type AttributeValue,
 } from '@aws-sdk/client-dynamodb'
 import { ddb } from '../../../src/client.js'
 import {
@@ -212,5 +213,67 @@ describe('Query — LSI', () => {
 
     expect(result.Items).toHaveLength(0)
     expect(result.Count).toBe(0)
+  })
+})
+
+describe('Query — LSI pagination across tied sort keys', () => {
+  // Items in one partition sharing the LSI sort key (lsi1sk), distinct base sk.
+  // The LSI continuation key must carry the base-table keys (pk, sk) alongside
+  // the index sort key, or a paged walk loops or drops rows on the tie.
+  const tied = [0, 1, 2, 3].map((i) => ({
+    pk: { S: 'lsi-tie' },
+    sk: { S: `s-${i}` },
+    lsi1sk: { S: 'lsi-tie-sk' },
+    data: { S: `d${i}` },
+  }))
+
+  beforeAll(async () => {
+    await Promise.all(
+      tied.map((item) =>
+        ddb.send(
+          new PutItemCommand({ TableName: compositeTableDef.name, Item: item }),
+        ),
+      ),
+    )
+  })
+
+  afterAll(async () => {
+    await cleanupItems(
+      compositeTableDef.name,
+      tied.map((item) => ({ pk: item.pk, sk: item.sk })),
+    )
+  })
+
+  it('composes LastEvaluatedKey from base and index keys and walks every tied item once', async () => {
+    const seen: string[] = []
+    let lastKey: Record<string, AttributeValue> | undefined
+    let pages = 0
+
+    do {
+      const page = await ddb.send(
+        new QueryCommand({
+          TableName: compositeTableDef.name,
+          IndexName: 'lsi1',
+          KeyConditionExpression: 'pk = :p AND lsi1sk = :v',
+          ExpressionAttributeValues: {
+            ':p': { S: 'lsi-tie' },
+            ':v': { S: 'lsi-tie-sk' },
+          },
+          ConsistentRead: true,
+          Limit: 1,
+          ...(lastKey ? { ExclusiveStartKey: lastKey } : {}),
+        }),
+      )
+      pages++
+      for (const item of page.Items ?? []) seen.push(item.sk!.S!)
+      lastKey = page.LastEvaluatedKey
+      if (lastKey) {
+        expect(Object.keys(lastKey).sort()).toEqual(['lsi1sk', 'pk', 'sk'])
+      }
+      expect(pages).toBeLessThanOrEqual(tied.length + 1)
+    } while (lastKey)
+
+    expect(seen.sort()).toEqual(tied.map((t) => t.sk.S).sort())
+    expect(new Set(seen).size).toBe(tied.length)
   })
 })

--- a/tests/tier1/scan/basic.test.ts
+++ b/tests/tier1/scan/basic.test.ts
@@ -221,3 +221,73 @@ describe('Scan — ProjectionExpression', () => {
     )
   })
 })
+
+describe('Scan — ExclusiveStartKey exclusivity and filtered Limit', () => {
+  const items = Array.from({ length: 4 }, (_, i) => ({
+    pk: { S: `sesk-${i}` },
+    val: { N: String(i) },
+  }))
+
+  beforeAll(async () => {
+    await Promise.all(
+      items.map((item) =>
+        ddb.send(
+          new PutItemCommand({ TableName: hashTableDef.name, Item: item }),
+        ),
+      ),
+    )
+  })
+
+  afterAll(async () => {
+    await cleanupItems(
+      hashTableDef.name,
+      items.map((item) => ({ pk: item.pk })),
+    )
+  })
+
+  it('does not repeat the item equal to ExclusiveStartKey', async () => {
+    const filter = {
+      FilterExpression: 'begins_with(pk, :p)',
+      ExpressionAttributeValues: { ':p': { S: 'sesk-' } },
+    }
+    const firstPage = await ddb.send(
+      new ScanCommand({
+        TableName: hashTableDef.name,
+        Limit: 1,
+        ConsistentRead: true,
+        ...filter,
+      }),
+    )
+    const startKey = firstPage.LastEvaluatedKey
+    expect(startKey).toBeDefined()
+
+    const secondPage = await ddb.send(
+      new ScanCommand({
+        TableName: hashTableDef.name,
+        ExclusiveStartKey: startKey,
+        ConsistentRead: true,
+        ...filter,
+      }),
+    )
+    const secondPks = secondPage.Items!.map((i) => i.pk.S)
+    // The item equal to ExclusiveStartKey must not reappear on the next page.
+    expect(secondPks).not.toContain(startKey!.pk.S)
+  })
+
+  it('returns LastEvaluatedKey while items remain, counting scanned-not-matched against Limit', async () => {
+    const result = await ddb.send(
+      new ScanCommand({
+        TableName: hashTableDef.name,
+        Limit: 1,
+        FilterExpression: 'val > :hi',
+        ExpressionAttributeValues: { ':hi': { N: '100' } }, // matches none of ours
+        ConsistentRead: true,
+      }),
+    )
+    // Limit caps scanned items, not matched items: one scanned, none matched,
+    // and a cursor is returned because the table is not exhausted.
+    expect(result.ScannedCount).toBe(1)
+    expect(result.Count).toBe(0)
+    expect(result.LastEvaluatedKey).toBeDefined()
+  })
+})

--- a/tests/tier1/scan/gsiPagination.test.ts
+++ b/tests/tier1/scan/gsiPagination.test.ts
@@ -133,3 +133,75 @@ describe('Scan — GSI pagination', () => {
     expect(allItems).toHaveLength(10)
   })
 })
+
+describe('Scan — GSI pagination across tied sort keys', () => {
+  // GSI range key distinct from the base key, so the GSI sort key can tie while
+  // base keys stay unique. Real AWS composes LastEvaluatedKey from the base key
+  // AND the index keys; an emulator that omits the base key loops or drops rows.
+  const tableDef: TestTableDef = {
+    name: uniqueTableName('gsi-tie-scan'),
+    hashKey: { name: 'ID', type: 'S' },
+    billingMode: 'PAY_PER_REQUEST',
+    gsis: [
+      {
+        indexName: 'TieIndex',
+        hashKey: { name: 'GType', type: 'S' },
+        rangeKey: { name: 'GSort', type: 'S' },
+        projectionType: 'ALL',
+      },
+    ],
+  }
+
+  const COUNT = 5
+
+  beforeAll(async () => {
+    await createTable(tableDef)
+    for (let i = 0; i < COUNT; i++) {
+      await ddb.send(
+        new PutItemCommand({
+          TableName: tableDef.name,
+          Item: { ID: { S: `id-${i}` }, GType: { S: 'tie' }, GSort: { S: 'same' } },
+        }),
+      )
+    }
+    await waitForGsiConsistency({
+      tableName: tableDef.name,
+      indexName: 'TieIndex',
+      partitionKey: { name: 'GType', value: { S: 'tie' } },
+      expectedCount: COUNT,
+    })
+  }, 30_000)
+
+  afterAll(async () => {
+    await deleteTable(tableDef.name)
+  })
+
+  it('walks every item once across a paged GSI scan with tied sort keys', async () => {
+    const seen: string[] = []
+    let lastKey: Record<string, AttributeValue> | undefined
+    let pages = 0
+
+    do {
+      const page = await ddb.send(
+        new ScanCommand({
+          TableName: tableDef.name,
+          IndexName: 'TieIndex',
+          Limit: 1,
+          ...(lastKey ? { ExclusiveStartKey: lastKey } : {}),
+        }),
+      )
+      pages++
+      for (const item of page.Items ?? []) seen.push(item.ID!.S!)
+      lastKey = page.LastEvaluatedKey
+      if (lastKey) {
+        expect(Object.keys(lastKey).sort()).toEqual(['GSort', 'GType', 'ID'])
+      }
+      expect(pages).toBeLessThanOrEqual(COUNT + 1)
+    } while (lastKey)
+
+    expect(seen.sort()).toEqual(
+      Array.from({ length: COUNT }, (_, i) => `id-${i}`).sort(),
+    )
+    expect(new Set(seen).size).toBe(COUNT)
+  })
+})

--- a/tests/tier1/updateItem/basic.test.ts
+++ b/tests/tier1/updateItem/basic.test.ts
@@ -675,3 +675,73 @@ describe('UpdateItem — SET evaluation semantics', () => {
     expect(result.Item!.vals.L).toEqual([{ S: 'a' }, { S: 'b' }, { S: 'c' }])
   })
 })
+
+describe('UpdateItem — ReturnValues granularity', () => {
+  const keys: { pk: { S: string } }[] = []
+  afterAll(async () => {
+    await cleanupItems(hashTableDef.name, keys)
+  })
+
+  it('UPDATED_NEW on a create returns the newly set attributes', async () => {
+    const pk = 'rv-create'
+    keys.push({ pk: { S: pk } })
+    const res = await ddb.send(
+      new UpdateItemCommand({
+        TableName: hashTableDef.name,
+        Key: { pk: { S: pk } },
+        UpdateExpression: 'SET a = :a',
+        ExpressionAttributeValues: { ':a': { S: 'x' } },
+        ReturnValues: 'UPDATED_NEW',
+      }),
+    )
+    // Even when the update creates the item, AWS returns the set attribute.
+    expect(res.Attributes).toBeDefined()
+    expect(res.Attributes!.a.S).toBe('x')
+  })
+
+  it('UPDATED_NEW on a nested SET returns only the changed fragment', async () => {
+    const pk = 'rv-nested'
+    keys.push({ pk: { S: pk } })
+    await ddb.send(
+      new PutItemCommand({
+        TableName: hashTableDef.name,
+        Item: {
+          pk: { S: pk },
+          parent: { M: { keep: { S: 'k' }, child: { S: 'old' } } },
+        },
+      }),
+    )
+    const res = await ddb.send(
+      new UpdateItemCommand({
+        TableName: hashTableDef.name,
+        Key: { pk: { S: pk } },
+        UpdateExpression: 'SET parent.child = :v',
+        ExpressionAttributeValues: { ':v': { S: 'new' } },
+        ReturnValues: 'UPDATED_NEW',
+      }),
+    )
+    // Only the changed path comes back, not the whole parent map.
+    expect(res.Attributes!.parent.M!.child.S).toBe('new')
+    expect(res.Attributes!.parent.M!.keep).toBeUndefined()
+  })
+
+  it('REMOVE with UPDATED_NEW omits Attributes (nothing was set to a new value)', async () => {
+    const pk = 'rv-remove'
+    keys.push({ pk: { S: pk } })
+    await ddb.send(
+      new PutItemCommand({
+        TableName: hashTableDef.name,
+        Item: { pk: { S: pk }, x: { S: 'keep' }, y: { S: 'drop' } },
+      }),
+    )
+    const res = await ddb.send(
+      new UpdateItemCommand({
+        TableName: hashTableDef.name,
+        Key: { pk: { S: pk } },
+        UpdateExpression: 'REMOVE y',
+        ReturnValues: 'UPDATED_NEW',
+      }),
+    )
+    expect(res.Attributes).toBeUndefined()
+  })
+})

--- a/tests/tier1/updateItem/basic.test.ts
+++ b/tests/tier1/updateItem/basic.test.ts
@@ -548,3 +548,130 @@ describe('UpdateItem — return values', () => {
     await cleanupItems(hashTableDef.name, [{ pk: { S: 'upd-ret3' } }])
   })
 })
+
+describe('UpdateItem — SET evaluation semantics', () => {
+  const keys: { pk: { S: string } }[] = []
+  afterAll(async () => {
+    await cleanupItems(hashTableDef.name, keys)
+  })
+
+  it('a second SET clause reads the pre-update value of another attribute', async () => {
+    const pk = 'upd-snapshot'
+    keys.push({ pk: { S: pk } })
+    await ddb.send(
+      new PutItemCommand({
+        TableName: hashTableDef.name,
+        Item: { pk: { S: pk }, a: { S: 'OLD' } },
+      }),
+    )
+    // DynamoDB evaluates the whole expression against the pre-update snapshot,
+    // so `b` gets the old value of `a`, not the value just assigned in the same call.
+    const res = await ddb.send(
+      new UpdateItemCommand({
+        TableName: hashTableDef.name,
+        Key: { pk: { S: pk } },
+        UpdateExpression: 'SET a = :v, b = a',
+        ExpressionAttributeValues: { ':v': { S: 'NEW' } },
+        ReturnValues: 'ALL_NEW',
+      }),
+    )
+    expect(res.Attributes!.a.S).toBe('NEW')
+    expect(res.Attributes!.b.S).toBe('OLD')
+  })
+
+  it('applies parenthesised arithmetic (SET c = (c - :v))', async () => {
+    const pk = 'upd-paren'
+    keys.push({ pk: { S: pk } })
+    await ddb.send(
+      new PutItemCommand({
+        TableName: hashTableDef.name,
+        Item: { pk: { S: pk }, c: { N: '10' } },
+      }),
+    )
+    const res = await ddb.send(
+      new UpdateItemCommand({
+        TableName: hashTableDef.name,
+        Key: { pk: { S: pk } },
+        UpdateExpression: 'SET c = (c - :v)',
+        ExpressionAttributeValues: { ':v': { N: '3' } },
+        ReturnValues: 'ALL_NEW',
+      }),
+    )
+    expect(res.Attributes!.c.N).toBe('7')
+  })
+
+  it('applies arithmetic around if_not_exists (SET v = if_not_exists(v, :d) - :amt)', async () => {
+    const pk = 'upd-ifnot-arith'
+    keys.push({ pk: { S: pk } })
+    await ddb.send(
+      new PutItemCommand({
+        TableName: hashTableDef.name,
+        Item: { pk: { S: pk }, v: { N: '10' } },
+      }),
+    )
+    const res = await ddb.send(
+      new UpdateItemCommand({
+        TableName: hashTableDef.name,
+        Key: { pk: { S: pk } },
+        UpdateExpression: 'SET v = if_not_exists(v, :d) - :amt',
+        ExpressionAttributeValues: { ':d': { N: '0' }, ':amt': { N: '3' } },
+        ReturnValues: 'ALL_NEW',
+      }),
+    )
+    expect(res.Attributes!.v.N).toBe('7')
+  })
+
+  it('composes nested functions: list_append(if_not_exists(list, :empty), :more) on a missing list', async () => {
+    const pk = 'upd-nested-fn'
+    keys.push({ pk: { S: pk } })
+    await ddb.send(
+      new PutItemCommand({
+        TableName: hashTableDef.name,
+        Item: { pk: { S: pk } },
+      }),
+    )
+    await ddb.send(
+      new UpdateItemCommand({
+        TableName: hashTableDef.name,
+        Key: { pk: { S: pk } },
+        UpdateExpression: 'SET mylist = list_append(if_not_exists(mylist, :empty), :more)',
+        ExpressionAttributeValues: { ':empty': { L: [] }, ':more': { L: [{ S: 'x' }] } },
+      }),
+    )
+    const result = await ddb.send(
+      new GetItemCommand({
+        TableName: hashTableDef.name,
+        Key: { pk: { S: pk } },
+        ConsistentRead: true,
+      }),
+    )
+    expect(result.Item!.mylist.L).toEqual([{ S: 'x' }])
+  })
+
+  it('list_append argument order controls prepend vs append', async () => {
+    const pk = 'upd-prepend'
+    keys.push({ pk: { S: pk } })
+    await ddb.send(
+      new PutItemCommand({
+        TableName: hashTableDef.name,
+        Item: { pk: { S: pk }, vals: { L: [{ S: 'b' }, { S: 'c' }] } },
+      }),
+    )
+    await ddb.send(
+      new UpdateItemCommand({
+        TableName: hashTableDef.name,
+        Key: { pk: { S: pk } },
+        UpdateExpression: 'SET vals = list_append(:new, vals)',
+        ExpressionAttributeValues: { ':new': { L: [{ S: 'a' }] } },
+      }),
+    )
+    const result = await ddb.send(
+      new GetItemCommand({
+        TableName: hashTableDef.name,
+        Key: { pk: { S: pk } },
+        ConsistentRead: true,
+      }),
+    )
+    expect(result.Item!.vals.L).toEqual([{ S: 'a' }, { S: 'b' }, { S: 'c' }])
+  })
+})

--- a/tests/tier1/updateItem/paths.test.ts
+++ b/tests/tier1/updateItem/paths.test.ts
@@ -370,4 +370,38 @@ describe('UpdateItem — nested path semantics', () => {
     expect(list).toHaveLength(1)
     expect(list[0].S).toBe('first')
   })
+
+  it('SET on a document path nests under an existing map without flattening', async () => {
+    const pkVal = 'path-map-nest'
+    keysToCleanup.push({ pk: { S: pkVal } })
+
+    await ddb.send(
+      new PutItemCommand({
+        TableName: hashTableDef.name,
+        Item: { pk: { S: pkVal }, parent: { M: { keep: { S: 'k' } } } },
+      }),
+    )
+
+    await ddb.send(
+      new UpdateItemCommand({
+        TableName: hashTableDef.name,
+        Key: { pk: { S: pkVal } },
+        UpdateExpression: 'SET parent.child = :v',
+        ExpressionAttributeValues: { ':v': { S: 'nested' } },
+      }),
+    )
+
+    const result = await ddb.send(
+      new GetItemCommand({
+        TableName: hashTableDef.name,
+        Key: { pk: { S: pkVal } },
+        ConsistentRead: true,
+      }),
+    )
+    // child nests under the existing map, the sibling survives, and no
+    // top-level attribute literally named "parent.child" is created.
+    expect(result.Item!.parent.M!.child.S).toBe('nested')
+    expect(result.Item!.parent.M!.keep.S).toBe('k')
+    expect(result.Item!['parent.child']).toBeUndefined()
+  })
 })

--- a/tests/tier2/partiql/executeStatement.test.ts
+++ b/tests/tier2/partiql/executeStatement.test.ts
@@ -385,6 +385,30 @@ describe('ExecuteStatement — PartiQL', () => {
     expect(res.ConsumedCapacity!.CapacityUnits).toBeGreaterThan(0)
   })
 
+  it('evaluates negated predicates (NOT begins_with, IS NOT MISSING)', async () => {
+    keysToCleanup.push({ pk: { S: 'pq-neg-a' } }, { pk: { S: 'pq-neg-b' } })
+    await ddb.send(new ExecuteStatementCommand({
+      Statement: `INSERT INTO "${hashTableDef.name}" VALUE { 'pk': 'pq-neg-a', 'kind': 'alpha' }`,
+    }))
+    await ddb.send(new ExecuteStatementCommand({
+      Statement: `INSERT INTO "${hashTableDef.name}" VALUE { 'pk': 'pq-neg-b', 'kind': 'beta' }`,
+    }))
+
+    // NOT begins_with must evaluate, not fail: only 'beta' does not begin with 'al'.
+    const notBw = await ddb.send(new ExecuteStatementCommand({
+      Statement: `SELECT * FROM "${hashTableDef.name}" WHERE pk IN ['pq-neg-a','pq-neg-b'] AND NOT begins_with("kind", 'al')`,
+    }))
+    expect(notBw.Items).toHaveLength(1)
+    expect(notBw.Items![0].pk.S).toBe('pq-neg-b')
+
+    // IS NOT MISSING must evaluate: 'kind' is present, so the row matches.
+    const notMissing = await ddb.send(new ExecuteStatementCommand({
+      Statement: `SELECT * FROM "${hashTableDef.name}" WHERE pk = 'pq-neg-a' AND "kind" IS NOT MISSING`,
+    }))
+    expect(notMissing.Items).toHaveLength(1)
+    expect(notMissing.Items![0].pk.S).toBe('pq-neg-a')
+  })
+
   // ── Error tests ───────────────────────────────────────────────────────
 
   it('rejects a statement with syntax error', async () => {

--- a/tests/tier2/partiql/executeStatement.test.ts
+++ b/tests/tier2/partiql/executeStatement.test.ts
@@ -366,6 +366,25 @@ describe('ExecuteStatement — PartiQL', () => {
     expect(result.Item!.keep.S).toBe('stay')
   })
 
+  it('returns a populated ConsumedCapacity block when requested', async () => {
+    const pk = 'partiql-cc'
+    keysToCleanup.push({ pk: { S: pk } })
+
+    await ddb.send(new ExecuteStatementCommand({
+      Statement: `INSERT INTO "${hashTableDef.name}" VALUE { 'pk': '${pk}', 'v': 1 }`,
+    }))
+
+    const res = await ddb.send(new ExecuteStatementCommand({
+      Statement: `SELECT * FROM "${hashTableDef.name}" WHERE pk = '${pk}'`,
+      ReturnConsumedCapacity: 'TOTAL',
+    }))
+
+    // PartiQL always returns the ConsumedCapacity block when asked; some
+    // emulators omit it entirely.
+    expect(res.ConsumedCapacity).toBeDefined()
+    expect(res.ConsumedCapacity!.CapacityUnits).toBeGreaterThan(0)
+  })
+
   // ── Error tests ───────────────────────────────────────────────────────
 
   it('rejects a statement with syntax error', async () => {

--- a/tests/tier2/transactions/transactGet.test.ts
+++ b/tests/tier2/transactions/transactGet.test.ts
@@ -302,3 +302,40 @@ describe('TransactGetItems — ConsumedCapacity', () => {
     expect(entry.Table?.ReadCapacityUnits).toBeGreaterThan(0)
   })
 })
+
+describe('TransactGetItems — projection matching nothing', () => {
+  const present = { pk: { S: 'tg-proj-present' } }
+
+  beforeAll(async () => {
+    await ddb.send(
+      new PutItemCommand({
+        TableName: hashTableDef.name,
+        Item: { ...present, real: { S: 'here' } },
+      }),
+    )
+  })
+
+  afterAll(async () => {
+    await cleanupItems(hashTableDef.name, [present])
+  })
+
+  it('omits Item when the projection matches no attribute on a present item', async () => {
+    const res = await ddb.send(
+      new TransactGetItemsCommand({
+        TransactItems: [
+          {
+            Get: {
+              TableName: hashTableDef.name,
+              Key: present,
+              ProjectionExpression: '#x',
+              ExpressionAttributeNames: { '#x': 'doesNotExist' },
+            },
+          },
+        ],
+      }),
+    )
+    // The item exists but the projection selects nothing, so AWS omits Item
+    // rather than returning an empty {} object.
+    expect(res.Responses![0].Item).toBeUndefined()
+  })
+})

--- a/tests/tier2/transactions/transactGet.test.ts
+++ b/tests/tier2/transactions/transactGet.test.ts
@@ -250,3 +250,55 @@ describe('TransactGetItems - validation', () => {
     )
   })
 })
+
+describe('TransactGetItems — ConsumedCapacity', () => {
+  const present = { pk: { S: 'tg-cap-present' } }
+
+  beforeAll(async () => {
+    await ddb.send(
+      new PutItemCommand({
+        TableName: hashTableDef.name,
+        Item: { ...present, v: { N: '1' } },
+      }),
+    )
+  })
+
+  afterAll(async () => {
+    await cleanupItems(hashTableDef.name, [present])
+  })
+
+  it('charges 2 read capacity units per item, including a missing item', async () => {
+    const res = await ddb.send(
+      new TransactGetItemsCommand({
+        ReturnConsumedCapacity: 'TOTAL',
+        TransactItems: [
+          { Get: { TableName: hashTableDef.name, Key: present } },
+          {
+            Get: {
+              TableName: hashTableDef.name,
+              Key: { pk: { S: 'tg-cap-missing' } },
+            },
+          },
+        ],
+      }),
+    )
+    const total = (res.ConsumedCapacity ?? []).reduce(
+      (sum, c) => sum + (c.CapacityUnits ?? 0),
+      0,
+    )
+    // 2 RCU per requested item, and a missing item is still charged: 4 total.
+    expect(total).toBe(4)
+  })
+
+  it('INDEXES breakdown includes the table read capacity units', async () => {
+    const res = await ddb.send(
+      new TransactGetItemsCommand({
+        ReturnConsumedCapacity: 'INDEXES',
+        TransactItems: [{ Get: { TableName: hashTableDef.name, Key: present } }],
+      }),
+    )
+    const entry = (res.ConsumedCapacity ?? [])[0]
+    expect(entry).toBeDefined()
+    expect(entry.Table?.ReadCapacityUnits).toBeGreaterThan(0)
+  })
+})

--- a/tests/tier2/transactions/transactWrite.test.ts
+++ b/tests/tier2/transactions/transactWrite.test.ts
@@ -1112,3 +1112,40 @@ describe('TransactWriteItems - ConditionExpression parens', () => {
     expect(check.Item!.status.S).toBe('active')
   })
 })
+
+describe('TransactWriteItems — ConsumedCapacity', () => {
+  const keys = [{ pk: { S: 'tw-cap-1' } }, { pk: { S: 'tw-cap-2' } }]
+
+  afterAll(async () => {
+    await cleanupItems(hashTableDef.name, keys)
+  })
+
+  it('charges 2 write capacity units per item', async () => {
+    const res = await ddb.send(
+      new TransactWriteItemsCommand({
+        ReturnConsumedCapacity: 'TOTAL',
+        TransactItems: [
+          {
+            Put: {
+              TableName: hashTableDef.name,
+              Item: { pk: { S: 'tw-cap-1' }, v: { N: '1' } },
+            },
+          },
+          {
+            Put: {
+              TableName: hashTableDef.name,
+              Item: { pk: { S: 'tw-cap-2' }, v: { N: '1' } },
+            },
+          },
+        ],
+      }),
+    )
+    const total = (res.ConsumedCapacity ?? []).reduce(
+      (sum, c) => sum + (c.CapacityUnits ?? 0),
+      0,
+    )
+    // Sub-1KB items cost 1 WCU each non-transactionally; a transaction doubles
+    // that to 2 per item, so two items total 4.
+    expect(total).toBe(4)
+  })
+})

--- a/tests/tier2/ttl/basic.test.ts
+++ b/tests/tier2/ttl/basic.test.ts
@@ -157,4 +157,17 @@ describe('TTL — validation', () => {
       'ResourceNotFoundException',
     )
   })
+
+  it('rejects DescribeTimeToLive on non-existent table', async () => {
+    // A too-lenient target returns a result for a missing table; AWS throws.
+    await expectDynamoError(
+      () =>
+        ddb.send(
+          new DescribeTimeToLiveCommand({
+            TableName: '_conformance_nonexistent_table',
+          }),
+        ),
+      'ResourceNotFoundException',
+    )
+  })
 })

--- a/tests/tier3/legacy-api/attributeUpdates.test.ts
+++ b/tests/tier3/legacy-api/attributeUpdates.test.ts
@@ -255,4 +255,25 @@ describe('Legacy API — AttributeUpdates (legacy UpdateExpression)', () => {
       'ValidationException',
     )
   })
+
+  it('AttributeUpdates with a Value and no Action defaults to PUT', async () => {
+    const k = 'attrupd-noaction'
+    await ddb.send(
+      new UpdateItemCommand({
+        TableName: hashTableDef.name,
+        Key: { pk: { S: k } },
+        // No Action specified — AWS defaults to PUT and writes the value.
+        AttributeUpdates: { col: { Value: { S: 'written' } } },
+      }),
+    )
+    const got = await ddb.send(
+      new GetItemCommand({
+        TableName: hashTableDef.name,
+        Key: { pk: { S: k } },
+        ConsistentRead: true,
+      }),
+    )
+    expect(got.Item!.col.S).toBe('written')
+    await cleanupItems(hashTableDef.name, [{ pk: { S: k } }])
+  })
 })

--- a/tests/tier3/legacy-api/queryFilter.test.ts
+++ b/tests/tier3/legacy-api/queryFilter.test.ts
@@ -203,4 +203,42 @@ describe('Legacy API — KeyConditions and QueryFilter', () => {
     const sortKeys = result.Items!.map((i) => i.sk.S)
     expect(sortKeys).toEqual(['gamma', 'epsilon', 'delta', 'beta', 'alpha'])
   })
+
+  it('QueryFilter with ComparisonOperator EQ on a BOOL attribute filters correctly', async () => {
+    const bpk = 'legacy-query-bool'
+    await ddb.send(
+      new PutItemCommand({
+        TableName: compositeTableDef.name,
+        Item: { pk: { S: bpk }, sk: { S: 'a' }, flag: { BOOL: true } },
+      }),
+    )
+    await ddb.send(
+      new PutItemCommand({
+        TableName: compositeTableDef.name,
+        Item: { pk: { S: bpk }, sk: { S: 'b' }, flag: { BOOL: false } },
+      }),
+    )
+
+    const result = await ddb.send(
+      new QueryCommand({
+        TableName: compositeTableDef.name,
+        KeyConditions: {
+          pk: { ComparisonOperator: 'EQ', AttributeValueList: [{ S: bpk }] },
+        },
+        QueryFilter: {
+          flag: { ComparisonOperator: 'EQ', AttributeValueList: [{ BOOL: true }] },
+        },
+        ConsistentRead: true,
+      }),
+    )
+
+    // EQ is valid on a BOOL attribute in real DynamoDB; only the true item matches.
+    expect(result.Count).toBe(1)
+    expect(result.Items![0].sk.S).toBe('a')
+
+    await cleanupItems(compositeTableDef.name, [
+      { pk: { S: bpk }, sk: { S: 'a' } },
+      { pk: { S: bpk }, sk: { S: 'b' } },
+    ])
+  })
 })

--- a/tests/tier3/limits/numberPrecision.test.ts
+++ b/tests/tier3/limits/numberPrecision.test.ts
@@ -2,6 +2,7 @@ import {
   PutItemCommand,
   GetItemCommand,
   QueryCommand,
+  UpdateItemCommand,
 } from '@aws-sdk/client-dynamodb'
 import { ddb } from '../../../src/client.js'
 import {
@@ -388,5 +389,27 @@ describe('Number precision — DynamoDB number limits and edge cases', () => {
     const sortKeys = result.Items!.map((i) => parseFloat(i.sk.N!))
     expect(sortKeys[0]).toBeLessThan(sortKeys[1])
     expect(sortKeys[1]).toBeLessThan(sortKeys[2])
+  })
+
+  it('rejects arithmetic that overflows the supported number magnitude', async () => {
+    // A too-lenient target stores the overflowed result; AWS rejects the
+    // arithmetic with a Number overflow ValidationException.
+    await expectDynamoError(
+      () =>
+        ddb.send(
+          new UpdateItemCommand({
+            TableName: hashTableDef.name,
+            Key: { pk: { S: 'np-overflow' } },
+            UpdateExpression: 'SET n = :a + :b',
+            ExpressionAttributeValues: {
+              ':a': { N: '9.9e125' },
+              ':b': { N: '9.9e125' },
+            },
+          }),
+        ),
+      'ValidationException',
+      'Number overflow',
+    )
+    await cleanupItems(hashTableDef.name, [{ pk: { S: 'np-overflow' } }])
   })
 })


### PR DESCRIPTION
Adds coverage for a set of real DynamoDB behaviours the suite did not previously probe. Each new test was characterised against real AWS first and passes against it, per the suite's standing invariant: if real DynamoDB rejects a test, the test is wrong.

## What's now covered

- **Pagination / `LastEvaluatedKey` composition.** Index pagination across items that share a sort-key value, where the continuation key must carry the base-table keys as well as the index keys or a paged walk loops or drops rows. Plus `ExclusiveStartKey` exclusivity and `Limit`-with-filter cursor behaviour.
- **UpdateExpression evaluation.** Pre-update reads (`SET a = :v, b = a`), parenthesised arithmetic, arithmetic around `if_not_exists`, nested `list_append(if_not_exists(...))`, map document-path nesting, and `list_append` argument order.
- **ReturnValues granularity.** `UPDATED_NEW` on a create and on a nested SET, `REMOVE` with `UPDATED_NEW`, and the conditional-failure item on `PutItem`.
- **ConsumedCapacity.** Transactional write and read capacity (two units per item, including missing items), the `INDEXES` breakdown, and the PartiQL capacity block.
- **Type and size.** Number-set and binary-set duplicate rejection, and arithmetic that overflows the supported number range.
- **Projection.** Multiple sibling paths in one map, and `Item` omission when a projection matches nothing.
- **Legacy API and error mapping.** `AttributeUpdates` default action, `QueryFilter` `EQ` on a boolean, the status code for a key-less batch write, and `DescribeTimeToLive` on a missing table.
- **PartiQL.** Negated predicates.

## Score movement

Several targets will show more failures on the next run. That is the coverage working, not a regression in any target: the suite now probes pagination composition, write semantics, and accounting it previously ignored, so a higher fail count reflects newly-visible pre-existing behaviour rather than a new defect. Real DynamoDB stays at 100%.
