### PR TITLE
fix: let GSI scan pagination setup inherit the global hook timeout

### DIFF
--- a/tests/tier1/scan/gsiPagination.test.ts
+++ b/tests/tier1/scan/gsiPagination.test.ts
@@ -54,7 +54,7 @@ describe('Scan — GSI pagination', () => {
       partitionKey: { name: 'Type', value: { S: 'widget' } },
       expectedCount: ITEM_COUNT,
     })
-  }, 30_000)
+  })
 
   afterAll(async () => {
     await deleteTable(tableDef.name)
@@ -170,7 +170,7 @@ describe('Scan — GSI pagination across tied sort keys', () => {
       partitionKey: { name: 'GType', value: { S: 'tie' } },
       expectedCount: COUNT,
     })
-  }, 30_000)
+  })
 
   afterAll(async () => {
     await deleteTable(tableDef.name)


### PR DESCRIPTION
## What this changes

`tests/tier1/scan/gsiPagination.test.ts` was the only file capping its `beforeAll` at 30s with a positional override, while every other file inherits the 120s global from `vitest.config.ts`. Against real AWS the setup (create a table with a creation-time GSI, 50 sequential puts, wait for GSI consistency) ran past 30s and the hook timed out, reddening the [ground-truth job](https://github.com/nubo-db/dynamodb-conformance/actions/runs/26398676307/job/77705353703). The 30s cap was also below `waitUntilActive`'s own 60s internal limit, so it could never let table creation run to completion. Dropping both overrides lets the hooks inherit the global budget.

This stays in `test:quick`. The quick/full split excludes only the `UpdateTable` GSI *lifecycle* tests, where adding a GSI to an existing table triggers a multi-minute backfill. A GSI defined at table-creation time goes ACTIVE with the table in seconds, so this suite has the same cost profile as any other table-creating test already in quick.

## Checklist

- [x] New or modified tests run against real AWS DynamoDB and pass
- ~~New or modified tests run against at least one emulator target and behave as expected~~ - timeout-only change; the test logic and assertions are untouched and the emulator jobs were already green on this suite in the failed run (only the ground-truth job was red)
- [ ] If AI tools drafted or materially shaped this change, disclosed in the description above
- [x] Linked issue or a short note explaining the motivation - fixes the CI failure linked above

## Tier and scope (delete if not applicable)

No tier definitions, results pipeline, or target config change. The suite remains in `test:quick`; the rationale is in the description.