### PR TITLE
docs: add CHANGELOG.md tracking test-suite expansion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,32 @@
+# Conformance suite history
+
+A dated log of how the conformance test suite has grown: tests added, tiers
+broadened, and targets brought into the run. Newest first.
+
+## 2026-05-24
+
+Grew to 625 tests, up 24 on the previous run: eleven more in Tier 1 and
+thirteen more in Tier 3, tightening coverage of core operations and the strict
+edge cases.
+
+## 2026-05-23
+
+ExtendDB joined the run as a target. The suite itself held steady at 601 tests.
+
+## 2026-04-27
+
+Grew to 601 tests, up 29, and every new test landed in Tier 3: a broader strict
+surface spanning validation ordering, exact error messages, service limits, and
+the legacy request shapes. Floci and Ministack were added to the run as targets
+the same day.
+
+## 2026-04-24
+
+Grew to 572 tests, up 46 on the first run: thirty-six more in Tier 1 and ten
+more in Tier 2, deepening coverage of the core and complete-feature behaviour.
+
+## 2026-03-23
+
+The suite was established with 526 tests across the three tiers (267 Tier 1, 93
+Tier 2, 166 Tier 3), run against Dynalite, DynamoDB Local, Dynoxide, and
+LocalStack, with live AWS DynamoDB as the baseline.


### PR DESCRIPTION
## What this changes

Adds a CHANGELOG.md recording how the test suite has grown: suite size at each
expansion, which tiers gained tests, and when targets joined the run. Dated,
newest first, no semver. Figures track the published results: 526 tests at the
first run in March 2026, up to 625 on 24 May (Tier 1 +47, Tier 2 +10, Tier 3 +42).

## Checklist

- ~~New or modified tests run against real AWS DynamoDB and pass~~ — docs only.
- ~~New or modified tests run against at least one emulator target and behave as expected~~ — docs only.
- ~~If AI tools drafted or materially shaped this change, disclosed in the description above~~
- [x] Short note explaining the motivation — see above.
