### PR TITLE
Tier 3: assert the error contract structurally, not byte-exact prose

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,24 @@
 A dated log of how the conformance test suite has grown: tests added, tiers
 broadened, and targets brought into the run. Newest first.
 
+## 2026-06-09
+
+Real DynamoDB in eu-west-2 reworded a chunk of its validation errors, and the
+Tier 3 error-message tests moved with it. They now assert the contract the error
+carries - its type, the field it objects to, and the constraint - rather than the
+exact prose, because AWS varies the wrapper, the echoed input value and the field
+casing from one region to the next. A four-region capture in June found eu-west-2
+and eu-central-1 on the new wording and us-east-1 and ap-southeast-2 still on the
+old, so the line between contract and cosmetic is drawn from what is invariant
+across all four.
+
+This moves some Tier 3 numbers. Targets that were only ever marked down for
+wording DynamoDB itself renders inconsistently now pass those checks, so their
+Tier 3 scores rise: the suite has stopped counting a cosmetic difference as a
+behavioural one. Genuine behavioural divergences are still pinned exactly, for
+example PutItem with a { NULL: false } attribute, which DynamoDB now accepts in
+eu-west-2 and normalises to { NULL: true }.
+
 ## 2026-05-28
 
 Grew to 699 tests, up 15 on the previous run: seven more in Tier 1 and eight

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -74,17 +74,31 @@ which validation fired or which error code came back, put it in
 `tests/tier3/legacy-api/`.
 
 `error-messages/` uses inline `try/catch` with
-`expect(err).toBeInstanceOf(...)` and `expect(err.message).toBe(...)`.
-Don't use `expectDynamoError` there - it routes string messages
-through `toContain`, which is the right behaviour for
-`validation-ordering/` but the wrong one for exact-match tests.
+`expect(err).toBeInstanceOf(...)`, an exact `expect(err.name).toBe(...)`,
+and a message assertion whose strictness fits the message:
+
+- **Exact** (`expect(err.message).toBe(...)`) when the whole string is
+  stable across regions and over time. Most messages are, so this stays
+  the default.
+- **Structural** (`expect(err.message).toContain(...)` on the contractual
+  core - the field and the constraint phrase) when AWS's rendering is
+  non-deterministic. The `N validation error detected:` envelope, the
+  echoed input value, and field-name casing all vary by region (see the
+  2026-06 four-region capture) and are not part of the contract the API
+  model defines, so don't pin them. Pin what is invariant across regions
+  and float the rest. This is the same idea as `createTable.test.ts`'s
+  backend-variant handling.
+
+Don't use the `expectDynamoError` helper in `error-messages/` - it always
+routes the message through `toContain`, so it can't express the exact
+rung; use it (or a direct `toContain`) in `validation-ordering/`.
 
 For error messages with a stable prefix and a variable reason or
 identifier suffix (`TransactionCanceledException` is the obvious
 case), build the expected message from a known reasons array and
 structurally cross-check `CancellationReasons[].Code` against the
 same array. See `tests/tier3/error-messages/conditionalCheck.test.ts`
-for the pattern. Don't use `toContain` inside `error-messages/`.
+for the pattern.
 
 ## Commit style
 

--- a/captures/2026-06-09-validation-rewording.json
+++ b/captures/2026-06-09-validation-rewording.json
@@ -1,0 +1,1324 @@
+{
+  "capturedAt": "2026-06-09",
+  "note": "One-off four-region capture of DynamoDB validation behaviour during the 2026-06 rewording. eu-west-2 + eu-central-1 carry the new wording; us-east-1 + ap-southeast-2 still carry the old. See CHANGELOG 2026-06-09.",
+  "regions": {
+    "eu-west-2": {
+      "probes": [
+        {
+          "id": "s_put_table_null",
+          "family": "echo-scalar",
+          "note": "PutItem TableName=undefined",
+          "threw": true,
+          "name": "ValidationException",
+          "message": "1 validation error detected: Value null at 'tableName' failed to satisfy constraint: Member must not be null",
+          "n": 1,
+          "fields": [
+            "tableName"
+          ]
+        },
+        {
+          "id": "s_put_table_empty",
+          "family": "echo-scalar",
+          "note": "PutItem TableName='' (empty echo)",
+          "threw": true,
+          "name": "ValidationException",
+          "message": "1 validation error detected: Value at 'TableName' failed to satisfy constraint: Member must have length greater than or equal to 1",
+          "n": 1,
+          "fields": [
+            "TableName"
+          ]
+        },
+        {
+          "id": "s_put_table_long",
+          "family": "echo-scalar",
+          "note": "PutItem TableName='a'*256",
+          "threw": true,
+          "name": "ValidationException",
+          "message": "1 validation error detected: Value 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa' at 'tableName' failed to satisfy constraint: Member must have length less than or equal to 255",
+          "n": 1,
+          "fields": [
+            "tableName"
+          ]
+        },
+        {
+          "id": "s_put_table_badchars",
+          "family": "echo-scalar",
+          "note": "PutItem TableName='bad table!@#'",
+          "threw": true,
+          "name": "ValidationException",
+          "message": "1 validation error detected: Value 'bad table!@#' at 'tableName' failed to satisfy constraint: Member must satisfy regular expression pattern: [a-zA-Z0-9_.-]+",
+          "n": 1,
+          "fields": [
+            "tableName"
+          ]
+        },
+        {
+          "id": "s_ct_table_short",
+          "family": "echo-scalar",
+          "note": "CreateTable TableName='ab'",
+          "threw": true,
+          "name": "ValidationException",
+          "message": "1 validation error detected: Value 'ab' at 'tableName' failed to satisfy constraint: Member must have length greater than or equal to 3",
+          "n": 1,
+          "fields": [
+            "tableName"
+          ]
+        },
+        {
+          "id": "c_bw_over25",
+          "family": "echo-collection",
+          "note": "BatchWrite 26 requests",
+          "threw": true,
+          "name": "ValidationException",
+          "message": "1 validation error detected: Value '{_conformance_capdrift_h_1780928016596754425=[WriteRequest(putRequest=PutRequest(item={pk=AttributeValue(s=bw-0, n=null, b=null, iNT=null, dECIMAL=null, dOUBLE=null, sS=null, nS=null, bS=null, iNTSET=null, dECIMALSET=null, dOUBLESET=null, m=null, l=null, nULL=null, bOOL=null)}, workloadProfileName=null), deleteRequest=null), WriteRequest(putRequest=PutRequest(item={pk=AttributeValue(s=bw-1, n=null, b=null, iNT=null, dECIMAL=null, dOUBLE=null, sS=null, nS=null, bS=null, iNTSET=null, dECIMALSET=null, dOUBLESET=null, m=null, l=null, nULL=null, bOOL=null)}, workloadProfileName=null), deleteRequest=null), WriteRequest(putRequest=PutRequest(item={pk=AttributeValue(s=bw-2, n=null, b=null, iNT=null, dECIMAL=null, dOUBLE=null, sS=null, nS=null, bS=null, iNTSET=null, dECIMALSET=null, dOUBLESET=null, m=null, l=null, nULL=null, bOOL=null)}, workloadProfileName=null), deleteRequest=null), WriteRequest(putRequest=PutRequest(item={pk=AttributeValue(s=bw-3, n=null, b=null, iNT=null, dECIMAL=null, dOUBLE=null, sS=null, nS=null, bS=null, iNTSET=null, dECIMALSET=null, dOUBLESET=null, m=null, l=null, nULL=null, bOOL=null)}, workloadProfileName=null), deleteRequest=null), WriteRequest(putRequest=PutRequest(item={pk=AttributeValue(s=bw-4, n=null, b=null, iNT=null, dECIMAL=null, dOUBLE=null, sS=null, nS=null, bS=null, iNTSET=null, dECIMALSET=null, dOUBLESET=null, m=null, l=null, nULL=null, bOOL=null)}, workloadProfileName=null), deleteRequest=null), WriteRequest(putRequest=PutRequest(item={pk=AttributeValue(s=bw-5, n=null, b=null, iNT=null, dECIMAL=null, dOUBLE=null, sS=null, nS=null, bS=null, iNTSET=null, dECIMALSET=null, dOUBLESET=null, m=null, l=null, nULL=null, bOOL=null)}, workloadProfileName=null), deleteRequest=null), WriteRequest(putRequest=PutRequest(item={pk=AttributeValue(s=bw-6, n=null, b=null, iNT=null, dECIMAL=null, dOUBLE=null, sS=null, nS=null, bS=null, iNTSET=null, dECIMALSET=null, dOUBLESET=null, m=null, l=null, nULL=null, bOOL=null)}, workloadProfileName=null), deleteRequest=null), WriteRequest(putRequest=PutRequest(item={pk=AttributeValue(s=bw-7, n=null, b=null, iNT=null, dECIMAL=null, dOUBLE=null, sS=null, nS=null, bS=null, iNTSET=null, dECIMALSET=null, dOUBLESET=null, m=null, l=null, nULL=null, bOOL=null)}, workloadProfileName=null), deleteRequest=null), WriteRequest(putRequest=PutRequest(item={pk=AttributeValue(s=bw-8, n=null, b=null, iNT=null, dECIMAL=null, dOUBLE=null, sS=null, nS=null, bS=null, iNTSET=null, dECIMALSET=null, dOUBLESET=null, m=null, l=null, nULL=null, bOOL=null)}, workloadProfileName=null), deleteRequest=null), WriteRequest(putRequest=PutRequest(item={pk=AttributeValue(s=bw-9, n=null, b=null, iNT=null, dECIMAL=null, dOUBLE=null, sS=null, nS=null, bS=null, iNTSET=null, dECIMALSET=null, dOUBLESET=null, m=null, l=null, nULL=null, bOOL=null)}, workloadProfileName=null), deleteRequest=null), WriteRequest(putRequest=PutRequest(item={pk=AttributeValue(s=bw-10, n=null, b=null, iNT=null, dECIMAL=null, dOUBLE=null, sS=null, nS=null, bS=null, iNTSET=null, dECIMALSET=null, dOUBLESET=null, m=null, l=null, nULL=null, bOOL=null)}, workloadProfileName=null), deleteRequest=null), WriteRequest(putRequest=PutRequest(item={pk=AttributeValue(s=bw-11, n=null, b=null, iNT=null, dECIMAL=null, dOUBLE=null, sS=null, nS=null, bS=null, iNTSET=null, dECIMALSET=null, dOUBLESET=null, m=null, l=null, nULL=null, bOOL=null)}, workloadProfileName=null), deleteRequest=null), WriteRequest(putRequest=PutRequest(item={pk=AttributeValue(s=bw-12, n=null, b=null, iNT=null, dECIMAL=null, dOUBLE=null, sS=null, nS=null, bS=null, iNTSET=null, dECIMALSET=null, dOUBLESET=null, m=null, l=null, nULL=null, bOOL=null)}, workloadProfileName=null), deleteRequest=null), WriteRequest(putRequest=PutRequest(item={pk=AttributeValue(s=bw-13, n=null, b=null, iNT=null, dECIMAL=null, dOUBLE=null, sS=null, nS=null, bS=null, iNTSET=null, dECIMALSET=null, dOUBLESET=null, m=null, l=null, nULL=null, bOOL=null)}, workloadProfileName=null), deleteRequest=null), WriteRequest(putRequest=PutRequest(item={pk=AttributeValue(s=bw-14, n=null, b=null, iNT=null, dECIMAL=null, dOUBLE=null, sS=null, nS=null, bS=null, iNTSET=null, dECIMALSET=null, dOUBLESET=null, m=null, l=null, nULL=null, bOOL=null)}, workloadProfileName=null), deleteRequest=null), WriteRequest(putRequest=PutRequest(item={pk=AttributeValue(s=bw-15, n=null, b=null, iNT=null, dECIMAL=null, dOUBLE=null, sS=null, nS=null, bS=null, iNTSET=null, dECIMALSET=null, dOUBLESET=null, m=null, l=null, nULL=null, bOOL=null)}, workloadProfileName=null), deleteRequest=null), WriteRequest(putRequest=PutRequest(item={pk=AttributeValue(s=bw-16, n=null, b=null, iNT=null, dECIMAL=null, dOUBLE=null, sS=null, nS=null, bS=null, iNTSET=null, dECIMALSET=null, dOUBLESET=null, m=null, l=null, nULL=null, bOOL=null)}, workloadProfileName=null), deleteRequest=null), WriteRequest(putRequest=PutRequest(item={pk=AttributeValue(s=bw-17, n=null, b=null, iNT=null, dECIMAL=null, dOUBLE=null, sS=null, nS=null, bS=null, iNTSET=null, dECIMALSET=null, dOUBLESET=null, m=null, l=null, nULL=null, bOOL=null)}, workloadProfileName=null), deleteRequest=null), WriteRequest(putRequest=PutRequest(item={pk=AttributeValue(s=bw-18, n=null, b=null, iNT=null, dECIMAL=null, dOUBLE=null, sS=null, nS=null, bS=null, iNTSET=null, dECIMALSET=null, dOUBLESET=null, m=null, l=null, nULL=null, bOOL=null)}, workloadProfileName=null), deleteRequest=null), WriteRequest(putRequest=PutRequest(item={pk=AttributeValue(s=bw-19, n=null, b=null, iNT=null, dECIMAL=null, dOUBLE=null, sS=null, nS=null, bS=null, iNTSET=null, dECIMALSET=null, dOUBLESET=null, m=null, l=null, nULL=null, bOOL=null)}, workloadProfileName=null), deleteRequest=null), WriteRequest(putRequest=PutRequest(item={pk=AttributeValue(s=bw-20, n=null, b=null, iNT=null, dECIMAL=null, dOUBLE=null, sS=null, nS=null, bS=null, iNTSET=null, dECIMALSET=null, dOUBLESET=null, m=null, l=null, nULL=null, bOOL=null)}, workloadProfileName=null), deleteRequest=null), WriteRequest(putRequest=PutRequest(item={pk=AttributeValue(s=bw-21, n=null, b=null, iNT=null, dECIMAL=null, dOUBLE=null, sS=null, nS=null, bS=null, iNTSET=null, dECIMALSET=null, dOUBLESET=null, m=null, l=null, nULL=null, bOOL=null)}, workloadProfileName=null), deleteRequest=null), WriteRequest(putRequest=PutRequest(item={pk=AttributeValue(s=bw-22, n=null, b=null, iNT=null, dECIMAL=null, dOUBLE=null, sS=null, nS=null, bS=null, iNTSET=null, dECIMALSET=null, dOUBLESET=null, m=null, l=null, nULL=null, bOOL=null)}, workloadProfileName=null), deleteRequest=null), WriteRequest(putRequest=PutRequest(item={pk=AttributeValue(s=bw-23, n=null, b=null, iNT=null, dECIMAL=null, dOUBLE=null, sS=null, nS=null, bS=null, iNTSET=null, dECIMALSET=null, dOUBLESET=null, m=null, l=null, nULL=null, bOOL=null)}, workloadProfileName=null), deleteRequest=null), WriteRequest(putRequest=PutRequest(item={pk=AttributeValue(s=bw-24, n=null, b=null, iNT=null, dECIMAL=null, dOUBLE=null, sS=null, nS=null, bS=null, iNTSET=null, dECIMALSET=null, dOUBLESET=null, m=null, l=null, nULL=null, bOOL=null)}, workloadProfileName=null), deleteRequest=null), WriteRequest(putRequest=PutRequest(item={pk=AttributeValue(s=bw-25, n=null, b=null, iNT=null, dECIMAL=null, dOUBLE=null, sS=null, nS=null, bS=null, iNTSET=null, dECIMALSET=null, dOUBLESET=null, m=null, l=null, nULL=null, bOOL=null)}, workloadProfileName=null), deleteRequest=null)]}' at 'requestItems' failed to satisfy constraint: Map value must satisfy constraint: [Member must have length less than or equal to 25, Member must have length greater than or equal to 1]",
+          "n": 1,
+          "fields": [
+            "requestItems"
+          ]
+        },
+        {
+          "id": "c_ct_3keys",
+          "family": "echo-collection",
+          "note": "CreateTable 3 keySchema",
+          "threw": true,
+          "name": "ValidationException",
+          "message": "One or more parameter values were invalid: ReadCapacityUnits and WriteCapacityUnits must both be specified when BillingMode is PROVISIONED",
+          "n": null,
+          "fields": []
+        },
+        {
+          "id": "b_put_empty_ss",
+          "family": "bespoke",
+          "note": "empty string set",
+          "threw": true,
+          "name": "ValidationException",
+          "message": "1 validation error detected: One or more parameter values were invalid: An string set  may not be empty",
+          "n": 1,
+          "fields": []
+        },
+        {
+          "id": "b_put_empty_ns",
+          "family": "bespoke",
+          "note": "empty number set",
+          "threw": true,
+          "name": "ValidationException",
+          "message": "1 validation error detected: One or more parameter values were invalid: An number set  may not be empty",
+          "n": 1,
+          "fields": []
+        },
+        {
+          "id": "b_put_dup_ss",
+          "family": "bespoke",
+          "note": "duplicate SS",
+          "threw": true,
+          "name": "ValidationException",
+          "message": "1 validation error detected: One or more parameter values were invalid: Input collection [\"a\", \"a\"] contains duplicates.",
+          "n": 1,
+          "fields": []
+        },
+        {
+          "id": "b_put_mix_expr",
+          "family": "bespoke",
+          "note": "mixing expression and non-expression",
+          "threw": true,
+          "name": "ValidationException",
+          "message": "1 validation error detected: Can not use both expression and non-expression parameters in the same request: Non-expression parameters: {Expected} Expression parameters: {ConditionExpression}",
+          "n": 1,
+          "fields": []
+        },
+        {
+          "id": "b_put_eav_no_expr",
+          "family": "bespoke",
+          "note": "EAV without expression",
+          "threw": true,
+          "name": "ValidationException",
+          "message": "1 validation error detected: ExpressionAttributeValues can only be specified when using expressions",
+          "n": 1,
+          "fields": []
+        },
+        {
+          "id": "b_put_redundant_parens",
+          "family": "bespoke",
+          "note": "redundant parentheses",
+          "threw": true,
+          "name": "ValidationException",
+          "message": "1 validation error detected: Invalid ConditionExpression: The expression has redundant parentheses;",
+          "n": 1,
+          "fields": []
+        },
+        {
+          "id": "b_put_contains_dup",
+          "family": "bespoke",
+          "note": "contains distinct operand",
+          "threw": true,
+          "name": "ValidationException",
+          "message": "1 validation error detected: Invalid ConditionExpression: The first operand must be distinct from the remaining operands for this operator or function; operator: contains, first operand: [data]",
+          "n": 1,
+          "fields": []
+        },
+        {
+          "id": "u_upd_hashkey",
+          "family": "bespoke",
+          "note": "cannot update hash key",
+          "threw": true,
+          "name": "ValidationException",
+          "message": "One or more parameter values were invalid: Cannot update attribute pk. This attribute is part of the key",
+          "n": null,
+          "fields": []
+        },
+        {
+          "id": "u_upd_syntax",
+          "family": "bespoke",
+          "note": "invalid UpdateExpression syntax",
+          "threw": true,
+          "name": "ValidationException",
+          "message": "1 validation error detected: Invalid UpdateExpression: Syntax error; token: \"INVALID\", near: \"INVALID SYNTAX\"",
+          "n": 1,
+          "fields": []
+        },
+        {
+          "id": "u_upd_unused_ean",
+          "family": "bespoke",
+          "note": "unused EAN",
+          "threw": true,
+          "name": "ValidationException",
+          "message": "1 validation error detected: Value provided in ExpressionAttributeNames unused in expressions: keys: {#unused}",
+          "n": 1,
+          "fields": []
+        },
+        {
+          "id": "u_upd_unused_eav",
+          "family": "bespoke",
+          "note": "unused EAV",
+          "threw": true,
+          "name": "ValidationException",
+          "message": "1 validation error detected: Value provided in ExpressionAttributeValues unused in expressions: keys: {:unused}",
+          "n": 1,
+          "fields": []
+        },
+        {
+          "id": "u_upd_missing_eav",
+          "family": "bespoke",
+          "note": "missing EAV ref",
+          "threw": true,
+          "name": "ValidationException",
+          "message": "1 validation error detected: Invalid UpdateExpression: An expression attribute value used in expression is not defined; attribute value: :v",
+          "n": 1,
+          "fields": []
+        },
+        {
+          "id": "u_upd_mix",
+          "family": "bespoke",
+          "note": "mixing UpdateExpression + AttributeUpdates",
+          "threw": true,
+          "name": "ValidationException",
+          "message": "1 validation error detected: Can not use both expression and non-expression parameters in the same request: Non-expression parameters: {AttributeUpdates} Expression parameters: {UpdateExpression}",
+          "n": 1,
+          "fields": []
+        },
+        {
+          "id": "u_upd_empty",
+          "family": "bespoke",
+          "note": "empty UpdateExpression",
+          "threw": true,
+          "name": "ValidationException",
+          "message": "1 validation error detected: Invalid UpdateExpression: The expression can not be empty;",
+          "n": 1,
+          "fields": []
+        },
+        {
+          "id": "u_upd_rangekey",
+          "family": "bespoke",
+          "note": "cannot update range key",
+          "threw": true,
+          "name": "ValidationException",
+          "message": "One or more parameter values were invalid: Cannot update attribute sk. This attribute is part of the key",
+          "n": null,
+          "fields": []
+        },
+        {
+          "id": "o_put_empty_table_empty_item",
+          "family": "ordering",
+          "note": "PutItem TableName='' Item={}",
+          "threw": true,
+          "name": "ValidationException",
+          "message": "1 validation error detected: Value at 'TableName' failed to satisfy constraint: Member must have length greater than or equal to 1",
+          "n": 1,
+          "fields": [
+            "TableName"
+          ]
+        },
+        {
+          "id": "o_put_empty_table_bad_rv",
+          "family": "ordering",
+          "note": "PutItem TableName='' ReturnValues=INVALID Item={}",
+          "threw": true,
+          "name": "ValidationException",
+          "message": "1 validation error detected: Value at 'TableName' failed to satisfy constraint: Member must have length greater than or equal to 1",
+          "n": 1,
+          "fields": [
+            "TableName"
+          ]
+        },
+        {
+          "id": "o_put_three_bad_enums",
+          "family": "ordering",
+          "note": "PutItem 3 invalid enums on valid table name",
+          "threw": true,
+          "name": "ValidationException",
+          "message": "3 validation errors detected: Value 'INVALID' at 'returnConsumedCapacity' failed to satisfy constraint: Member must satisfy enum value set: [INDEXES, TOTAL, NONE]; Failed to satisfy constraint: Member must satisfy enum value set: [ALL_OLD, UPDATED_OLD, ALL_NEW, UPDATE_NEW, NONE]; ReturnItemCollectionMetrics can only be SIZE or NONE",
+          "n": 3,
+          "fields": [
+            "returnConsumedCapacity"
+          ]
+        },
+        {
+          "id": "o_del_empty_table",
+          "family": "ordering",
+          "note": "DeleteItem TableName='' Key={}",
+          "threw": true,
+          "name": "ValidationException",
+          "message": "1 validation error detected: Value at 'TableName' failed to satisfy constraint: Member must have length greater than or equal to 1",
+          "n": 1,
+          "fields": [
+            "TableName"
+          ]
+        },
+        {
+          "id": "o_del_two_bad_enums",
+          "family": "ordering",
+          "note": "DeleteItem 2 invalid enums",
+          "threw": true,
+          "name": "ValidationException",
+          "message": "2 validation errors detected: Value 'INVALID' at 'returnConsumedCapacity' failed to satisfy constraint: Member must satisfy enum value set: [INDEXES, TOTAL, NONE]; Failed to satisfy constraint: Member must satisfy enum value set: [ALL_OLD, UPDATED_OLD, ALL_NEW, UPDATE_NEW, NONE]",
+          "n": 2,
+          "fields": [
+            "returnConsumedCapacity"
+          ]
+        },
+        {
+          "id": "o_upd_empty_table",
+          "family": "ordering",
+          "note": "UpdateItem TableName='' Key={}",
+          "threw": true,
+          "name": "ValidationException",
+          "message": "1 validation error detected: Value at 'TableName' failed to satisfy constraint: Member must have length greater than or equal to 1",
+          "n": 1,
+          "fields": [
+            "TableName"
+          ]
+        },
+        {
+          "id": "o_upd_two_bad_enums",
+          "family": "ordering",
+          "note": "UpdateItem 2 invalid enums",
+          "threw": true,
+          "name": "ValidationException",
+          "message": "1 validation error detected: Failed to satisfy constraint: Member must satisfy enum value set: [ALL_OLD, UPDATED_OLD, ALL_NEW, UPDATE_NEW, NONE]",
+          "n": 1,
+          "fields": []
+        }
+      ],
+      "nullRoundTrip": {
+        "put": "accepted",
+        "returnedItem": {
+          "pk": {
+            "S": "em-put-null-false"
+          },
+          "attr1": {
+            "NULL": true
+          }
+        }
+      }
+    },
+    "eu-central-1": {
+      "probes": [
+        {
+          "id": "s_put_table_null",
+          "family": "echo-scalar",
+          "note": "PutItem TableName=undefined",
+          "threw": true,
+          "name": "ValidationException",
+          "message": "1 validation error detected: Value null at 'tableName' failed to satisfy constraint: Member must not be null",
+          "n": 1,
+          "fields": [
+            "tableName"
+          ]
+        },
+        {
+          "id": "s_put_table_empty",
+          "family": "echo-scalar",
+          "note": "PutItem TableName='' (empty echo)",
+          "threw": true,
+          "name": "ValidationException",
+          "message": "1 validation error detected: Value at 'TableName' failed to satisfy constraint: Member must have length greater than or equal to 1",
+          "n": 1,
+          "fields": [
+            "TableName"
+          ]
+        },
+        {
+          "id": "s_put_table_long",
+          "family": "echo-scalar",
+          "note": "PutItem TableName='a'*256",
+          "threw": true,
+          "name": "ValidationException",
+          "message": "1 validation error detected: Value 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa' at 'tableName' failed to satisfy constraint: Member must have length less than or equal to 255",
+          "n": 1,
+          "fields": [
+            "tableName"
+          ]
+        },
+        {
+          "id": "s_put_table_badchars",
+          "family": "echo-scalar",
+          "note": "PutItem TableName='bad table!@#'",
+          "threw": true,
+          "name": "ValidationException",
+          "message": "1 validation error detected: Value 'bad table!@#' at 'tableName' failed to satisfy constraint: Member must satisfy regular expression pattern: [a-zA-Z0-9_.-]+",
+          "n": 1,
+          "fields": [
+            "tableName"
+          ]
+        },
+        {
+          "id": "s_ct_table_short",
+          "family": "echo-scalar",
+          "note": "CreateTable TableName='ab'",
+          "threw": true,
+          "name": "ValidationException",
+          "message": "1 validation error detected: Value 'ab' at 'tableName' failed to satisfy constraint: Member must have length greater than or equal to 3",
+          "n": 1,
+          "fields": [
+            "tableName"
+          ]
+        },
+        {
+          "id": "c_bw_over25",
+          "family": "echo-collection",
+          "note": "BatchWrite 26 requests",
+          "threw": true,
+          "name": "ValidationException",
+          "message": "1 validation error detected: Value '{_conformance_capdrift_h_178092814461159127=[WriteRequest(putRequest=PutRequest(item={pk=AttributeValue(s=bw-0, n=null, b=null, iNT=null, dECIMAL=null, dOUBLE=null, sS=null, nS=null, bS=null, iNTSET=null, dECIMALSET=null, dOUBLESET=null, m=null, l=null, nULL=null, bOOL=null)}, workloadProfileName=null), deleteRequest=null), WriteRequest(putRequest=PutRequest(item={pk=AttributeValue(s=bw-1, n=null, b=null, iNT=null, dECIMAL=null, dOUBLE=null, sS=null, nS=null, bS=null, iNTSET=null, dECIMALSET=null, dOUBLESET=null, m=null, l=null, nULL=null, bOOL=null)}, workloadProfileName=null), deleteRequest=null), WriteRequest(putRequest=PutRequest(item={pk=AttributeValue(s=bw-2, n=null, b=null, iNT=null, dECIMAL=null, dOUBLE=null, sS=null, nS=null, bS=null, iNTSET=null, dECIMALSET=null, dOUBLESET=null, m=null, l=null, nULL=null, bOOL=null)}, workloadProfileName=null), deleteRequest=null), WriteRequest(putRequest=PutRequest(item={pk=AttributeValue(s=bw-3, n=null, b=null, iNT=null, dECIMAL=null, dOUBLE=null, sS=null, nS=null, bS=null, iNTSET=null, dECIMALSET=null, dOUBLESET=null, m=null, l=null, nULL=null, bOOL=null)}, workloadProfileName=null), deleteRequest=null), WriteRequest(putRequest=PutRequest(item={pk=AttributeValue(s=bw-4, n=null, b=null, iNT=null, dECIMAL=null, dOUBLE=null, sS=null, nS=null, bS=null, iNTSET=null, dECIMALSET=null, dOUBLESET=null, m=null, l=null, nULL=null, bOOL=null)}, workloadProfileName=null), deleteRequest=null), WriteRequest(putRequest=PutRequest(item={pk=AttributeValue(s=bw-5, n=null, b=null, iNT=null, dECIMAL=null, dOUBLE=null, sS=null, nS=null, bS=null, iNTSET=null, dECIMALSET=null, dOUBLESET=null, m=null, l=null, nULL=null, bOOL=null)}, workloadProfileName=null), deleteRequest=null), WriteRequest(putRequest=PutRequest(item={pk=AttributeValue(s=bw-6, n=null, b=null, iNT=null, dECIMAL=null, dOUBLE=null, sS=null, nS=null, bS=null, iNTSET=null, dECIMALSET=null, dOUBLESET=null, m=null, l=null, nULL=null, bOOL=null)}, workloadProfileName=null), deleteRequest=null), WriteRequest(putRequest=PutRequest(item={pk=AttributeValue(s=bw-7, n=null, b=null, iNT=null, dECIMAL=null, dOUBLE=null, sS=null, nS=null, bS=null, iNTSET=null, dECIMALSET=null, dOUBLESET=null, m=null, l=null, nULL=null, bOOL=null)}, workloadProfileName=null), deleteRequest=null), WriteRequest(putRequest=PutRequest(item={pk=AttributeValue(s=bw-8, n=null, b=null, iNT=null, dECIMAL=null, dOUBLE=null, sS=null, nS=null, bS=null, iNTSET=null, dECIMALSET=null, dOUBLESET=null, m=null, l=null, nULL=null, bOOL=null)}, workloadProfileName=null), deleteRequest=null), WriteRequest(putRequest=PutRequest(item={pk=AttributeValue(s=bw-9, n=null, b=null, iNT=null, dECIMAL=null, dOUBLE=null, sS=null, nS=null, bS=null, iNTSET=null, dECIMALSET=null, dOUBLESET=null, m=null, l=null, nULL=null, bOOL=null)}, workloadProfileName=null), deleteRequest=null), WriteRequest(putRequest=PutRequest(item={pk=AttributeValue(s=bw-10, n=null, b=null, iNT=null, dECIMAL=null, dOUBLE=null, sS=null, nS=null, bS=null, iNTSET=null, dECIMALSET=null, dOUBLESET=null, m=null, l=null, nULL=null, bOOL=null)}, workloadProfileName=null), deleteRequest=null), WriteRequest(putRequest=PutRequest(item={pk=AttributeValue(s=bw-11, n=null, b=null, iNT=null, dECIMAL=null, dOUBLE=null, sS=null, nS=null, bS=null, iNTSET=null, dECIMALSET=null, dOUBLESET=null, m=null, l=null, nULL=null, bOOL=null)}, workloadProfileName=null), deleteRequest=null), WriteRequest(putRequest=PutRequest(item={pk=AttributeValue(s=bw-12, n=null, b=null, iNT=null, dECIMAL=null, dOUBLE=null, sS=null, nS=null, bS=null, iNTSET=null, dECIMALSET=null, dOUBLESET=null, m=null, l=null, nULL=null, bOOL=null)}, workloadProfileName=null), deleteRequest=null), WriteRequest(putRequest=PutRequest(item={pk=AttributeValue(s=bw-13, n=null, b=null, iNT=null, dECIMAL=null, dOUBLE=null, sS=null, nS=null, bS=null, iNTSET=null, dECIMALSET=null, dOUBLESET=null, m=null, l=null, nULL=null, bOOL=null)}, workloadProfileName=null), deleteRequest=null), WriteRequest(putRequest=PutRequest(item={pk=AttributeValue(s=bw-14, n=null, b=null, iNT=null, dECIMAL=null, dOUBLE=null, sS=null, nS=null, bS=null, iNTSET=null, dECIMALSET=null, dOUBLESET=null, m=null, l=null, nULL=null, bOOL=null)}, workloadProfileName=null), deleteRequest=null), WriteRequest(putRequest=PutRequest(item={pk=AttributeValue(s=bw-15, n=null, b=null, iNT=null, dECIMAL=null, dOUBLE=null, sS=null, nS=null, bS=null, iNTSET=null, dECIMALSET=null, dOUBLESET=null, m=null, l=null, nULL=null, bOOL=null)}, workloadProfileName=null), deleteRequest=null), WriteRequest(putRequest=PutRequest(item={pk=AttributeValue(s=bw-16, n=null, b=null, iNT=null, dECIMAL=null, dOUBLE=null, sS=null, nS=null, bS=null, iNTSET=null, dECIMALSET=null, dOUBLESET=null, m=null, l=null, nULL=null, bOOL=null)}, workloadProfileName=null), deleteRequest=null), WriteRequest(putRequest=PutRequest(item={pk=AttributeValue(s=bw-17, n=null, b=null, iNT=null, dECIMAL=null, dOUBLE=null, sS=null, nS=null, bS=null, iNTSET=null, dECIMALSET=null, dOUBLESET=null, m=null, l=null, nULL=null, bOOL=null)}, workloadProfileName=null), deleteRequest=null), WriteRequest(putRequest=PutRequest(item={pk=AttributeValue(s=bw-18, n=null, b=null, iNT=null, dECIMAL=null, dOUBLE=null, sS=null, nS=null, bS=null, iNTSET=null, dECIMALSET=null, dOUBLESET=null, m=null, l=null, nULL=null, bOOL=null)}, workloadProfileName=null), deleteRequest=null), WriteRequest(putRequest=PutRequest(item={pk=AttributeValue(s=bw-19, n=null, b=null, iNT=null, dECIMAL=null, dOUBLE=null, sS=null, nS=null, bS=null, iNTSET=null, dECIMALSET=null, dOUBLESET=null, m=null, l=null, nULL=null, bOOL=null)}, workloadProfileName=null), deleteRequest=null), WriteRequest(putRequest=PutRequest(item={pk=AttributeValue(s=bw-20, n=null, b=null, iNT=null, dECIMAL=null, dOUBLE=null, sS=null, nS=null, bS=null, iNTSET=null, dECIMALSET=null, dOUBLESET=null, m=null, l=null, nULL=null, bOOL=null)}, workloadProfileName=null), deleteRequest=null), WriteRequest(putRequest=PutRequest(item={pk=AttributeValue(s=bw-21, n=null, b=null, iNT=null, dECIMAL=null, dOUBLE=null, sS=null, nS=null, bS=null, iNTSET=null, dECIMALSET=null, dOUBLESET=null, m=null, l=null, nULL=null, bOOL=null)}, workloadProfileName=null), deleteRequest=null), WriteRequest(putRequest=PutRequest(item={pk=AttributeValue(s=bw-22, n=null, b=null, iNT=null, dECIMAL=null, dOUBLE=null, sS=null, nS=null, bS=null, iNTSET=null, dECIMALSET=null, dOUBLESET=null, m=null, l=null, nULL=null, bOOL=null)}, workloadProfileName=null), deleteRequest=null), WriteRequest(putRequest=PutRequest(item={pk=AttributeValue(s=bw-23, n=null, b=null, iNT=null, dECIMAL=null, dOUBLE=null, sS=null, nS=null, bS=null, iNTSET=null, dECIMALSET=null, dOUBLESET=null, m=null, l=null, nULL=null, bOOL=null)}, workloadProfileName=null), deleteRequest=null), WriteRequest(putRequest=PutRequest(item={pk=AttributeValue(s=bw-24, n=null, b=null, iNT=null, dECIMAL=null, dOUBLE=null, sS=null, nS=null, bS=null, iNTSET=null, dECIMALSET=null, dOUBLESET=null, m=null, l=null, nULL=null, bOOL=null)}, workloadProfileName=null), deleteRequest=null), WriteRequest(putRequest=PutRequest(item={pk=AttributeValue(s=bw-25, n=null, b=null, iNT=null, dECIMAL=null, dOUBLE=null, sS=null, nS=null, bS=null, iNTSET=null, dECIMALSET=null, dOUBLESET=null, m=null, l=null, nULL=null, bOOL=null)}, workloadProfileName=null), deleteRequest=null)]}' at 'requestItems' failed to satisfy constraint: Map value must satisfy constraint: [Member must have length less than or equal to 25, Member must have length greater than or equal to 1]",
+          "n": 1,
+          "fields": [
+            "requestItems"
+          ]
+        },
+        {
+          "id": "c_ct_3keys",
+          "family": "echo-collection",
+          "note": "CreateTable 3 keySchema",
+          "threw": true,
+          "name": "ValidationException",
+          "message": "One or more parameter values were invalid: ReadCapacityUnits and WriteCapacityUnits must both be specified when BillingMode is PROVISIONED",
+          "n": null,
+          "fields": []
+        },
+        {
+          "id": "b_put_empty_ss",
+          "family": "bespoke",
+          "note": "empty string set",
+          "threw": true,
+          "name": "ValidationException",
+          "message": "1 validation error detected: One or more parameter values were invalid: An string set  may not be empty",
+          "n": 1,
+          "fields": []
+        },
+        {
+          "id": "b_put_empty_ns",
+          "family": "bespoke",
+          "note": "empty number set",
+          "threw": true,
+          "name": "ValidationException",
+          "message": "1 validation error detected: One or more parameter values were invalid: An number set  may not be empty",
+          "n": 1,
+          "fields": []
+        },
+        {
+          "id": "b_put_dup_ss",
+          "family": "bespoke",
+          "note": "duplicate SS",
+          "threw": true,
+          "name": "ValidationException",
+          "message": "1 validation error detected: One or more parameter values were invalid: Input collection [\"a\", \"a\"] contains duplicates.",
+          "n": 1,
+          "fields": []
+        },
+        {
+          "id": "b_put_mix_expr",
+          "family": "bespoke",
+          "note": "mixing expression and non-expression",
+          "threw": true,
+          "name": "ValidationException",
+          "message": "1 validation error detected: Can not use both expression and non-expression parameters in the same request: Non-expression parameters: {Expected} Expression parameters: {ConditionExpression}",
+          "n": 1,
+          "fields": []
+        },
+        {
+          "id": "b_put_eav_no_expr",
+          "family": "bespoke",
+          "note": "EAV without expression",
+          "threw": true,
+          "name": "ValidationException",
+          "message": "1 validation error detected: ExpressionAttributeValues can only be specified when using expressions",
+          "n": 1,
+          "fields": []
+        },
+        {
+          "id": "b_put_redundant_parens",
+          "family": "bespoke",
+          "note": "redundant parentheses",
+          "threw": true,
+          "name": "ValidationException",
+          "message": "1 validation error detected: Invalid ConditionExpression: The expression has redundant parentheses;",
+          "n": 1,
+          "fields": []
+        },
+        {
+          "id": "b_put_contains_dup",
+          "family": "bespoke",
+          "note": "contains distinct operand",
+          "threw": true,
+          "name": "ValidationException",
+          "message": "1 validation error detected: Invalid ConditionExpression: The first operand must be distinct from the remaining operands for this operator or function; operator: contains, first operand: [data]",
+          "n": 1,
+          "fields": []
+        },
+        {
+          "id": "u_upd_hashkey",
+          "family": "bespoke",
+          "note": "cannot update hash key",
+          "threw": true,
+          "name": "ValidationException",
+          "message": "One or more parameter values were invalid: Cannot update attribute pk. This attribute is part of the key",
+          "n": null,
+          "fields": []
+        },
+        {
+          "id": "u_upd_syntax",
+          "family": "bespoke",
+          "note": "invalid UpdateExpression syntax",
+          "threw": true,
+          "name": "ValidationException",
+          "message": "1 validation error detected: Invalid UpdateExpression: Syntax error; token: \"INVALID\", near: \"INVALID SYNTAX\"",
+          "n": 1,
+          "fields": []
+        },
+        {
+          "id": "u_upd_unused_ean",
+          "family": "bespoke",
+          "note": "unused EAN",
+          "threw": true,
+          "name": "ValidationException",
+          "message": "1 validation error detected: Value provided in ExpressionAttributeNames unused in expressions: keys: {#unused}",
+          "n": 1,
+          "fields": []
+        },
+        {
+          "id": "u_upd_unused_eav",
+          "family": "bespoke",
+          "note": "unused EAV",
+          "threw": true,
+          "name": "ValidationException",
+          "message": "1 validation error detected: Value provided in ExpressionAttributeValues unused in expressions: keys: {:unused}",
+          "n": 1,
+          "fields": []
+        },
+        {
+          "id": "u_upd_missing_eav",
+          "family": "bespoke",
+          "note": "missing EAV ref",
+          "threw": true,
+          "name": "ValidationException",
+          "message": "1 validation error detected: Invalid UpdateExpression: An expression attribute value used in expression is not defined; attribute value: :v",
+          "n": 1,
+          "fields": []
+        },
+        {
+          "id": "u_upd_mix",
+          "family": "bespoke",
+          "note": "mixing UpdateExpression + AttributeUpdates",
+          "threw": true,
+          "name": "ValidationException",
+          "message": "1 validation error detected: Can not use both expression and non-expression parameters in the same request: Non-expression parameters: {AttributeUpdates} Expression parameters: {UpdateExpression}",
+          "n": 1,
+          "fields": []
+        },
+        {
+          "id": "u_upd_empty",
+          "family": "bespoke",
+          "note": "empty UpdateExpression",
+          "threw": true,
+          "name": "ValidationException",
+          "message": "1 validation error detected: Invalid UpdateExpression: The expression can not be empty;",
+          "n": 1,
+          "fields": []
+        },
+        {
+          "id": "u_upd_rangekey",
+          "family": "bespoke",
+          "note": "cannot update range key",
+          "threw": true,
+          "name": "ValidationException",
+          "message": "One or more parameter values were invalid: Cannot update attribute sk. This attribute is part of the key",
+          "n": null,
+          "fields": []
+        },
+        {
+          "id": "o_put_empty_table_empty_item",
+          "family": "ordering",
+          "note": "PutItem TableName='' Item={}",
+          "threw": true,
+          "name": "ValidationException",
+          "message": "1 validation error detected: Value at 'TableName' failed to satisfy constraint: Member must have length greater than or equal to 1",
+          "n": 1,
+          "fields": [
+            "TableName"
+          ]
+        },
+        {
+          "id": "o_put_empty_table_bad_rv",
+          "family": "ordering",
+          "note": "PutItem TableName='' ReturnValues=INVALID Item={}",
+          "threw": true,
+          "name": "ValidationException",
+          "message": "1 validation error detected: Value at 'TableName' failed to satisfy constraint: Member must have length greater than or equal to 1",
+          "n": 1,
+          "fields": [
+            "TableName"
+          ]
+        },
+        {
+          "id": "o_put_three_bad_enums",
+          "family": "ordering",
+          "note": "PutItem 3 invalid enums on valid table name",
+          "threw": true,
+          "name": "ValidationException",
+          "message": "3 validation errors detected: Value 'INVALID' at 'returnConsumedCapacity' failed to satisfy constraint: Member must satisfy enum value set: [INDEXES, TOTAL, NONE]; Failed to satisfy constraint: Member must satisfy enum value set: [ALL_OLD, UPDATED_OLD, ALL_NEW, UPDATE_NEW, NONE]; ReturnItemCollectionMetrics can only be SIZE or NONE",
+          "n": 3,
+          "fields": [
+            "returnConsumedCapacity"
+          ]
+        },
+        {
+          "id": "o_del_empty_table",
+          "family": "ordering",
+          "note": "DeleteItem TableName='' Key={}",
+          "threw": true,
+          "name": "ValidationException",
+          "message": "1 validation error detected: Value at 'TableName' failed to satisfy constraint: Member must have length greater than or equal to 1",
+          "n": 1,
+          "fields": [
+            "TableName"
+          ]
+        },
+        {
+          "id": "o_del_two_bad_enums",
+          "family": "ordering",
+          "note": "DeleteItem 2 invalid enums",
+          "threw": true,
+          "name": "ValidationException",
+          "message": "2 validation errors detected: Value 'INVALID' at 'returnConsumedCapacity' failed to satisfy constraint: Member must satisfy enum value set: [INDEXES, TOTAL, NONE]; Failed to satisfy constraint: Member must satisfy enum value set: [ALL_OLD, UPDATED_OLD, ALL_NEW, UPDATE_NEW, NONE]",
+          "n": 2,
+          "fields": [
+            "returnConsumedCapacity"
+          ]
+        },
+        {
+          "id": "o_upd_empty_table",
+          "family": "ordering",
+          "note": "UpdateItem TableName='' Key={}",
+          "threw": true,
+          "name": "ValidationException",
+          "message": "1 validation error detected: Value at 'TableName' failed to satisfy constraint: Member must have length greater than or equal to 1",
+          "n": 1,
+          "fields": [
+            "TableName"
+          ]
+        },
+        {
+          "id": "o_upd_two_bad_enums",
+          "family": "ordering",
+          "note": "UpdateItem 2 invalid enums",
+          "threw": true,
+          "name": "ValidationException",
+          "message": "1 validation error detected: Failed to satisfy constraint: Member must satisfy enum value set: [ALL_OLD, UPDATED_OLD, ALL_NEW, UPDATE_NEW, NONE]",
+          "n": 1,
+          "fields": []
+        }
+      ],
+      "nullRoundTrip": {
+        "put": "accepted",
+        "returnedItem": {
+          "pk": {
+            "S": "em-put-null-false"
+          },
+          "attr1": {
+            "NULL": true
+          }
+        }
+      }
+    },
+    "us-east-1": {
+      "probes": [
+        {
+          "id": "s_put_table_null",
+          "family": "echo-scalar",
+          "note": "PutItem TableName=undefined",
+          "threw": true,
+          "name": "ValidationException",
+          "message": "1 validation error detected: Value null at 'tableName' failed to satisfy constraint: Member must not be null",
+          "n": 1,
+          "fields": [
+            "tableName"
+          ]
+        },
+        {
+          "id": "s_put_table_empty",
+          "family": "echo-scalar",
+          "note": "PutItem TableName='' (empty echo)",
+          "threw": true,
+          "name": "ValidationException",
+          "message": "1 validation error detected: Value '' at 'tableName' failed to satisfy constraint: Member must have length greater than or equal to 1",
+          "n": 1,
+          "fields": [
+            "tableName"
+          ]
+        },
+        {
+          "id": "s_put_table_long",
+          "family": "echo-scalar",
+          "note": "PutItem TableName='a'*256",
+          "threw": true,
+          "name": "ValidationException",
+          "message": "1 validation error detected: Value 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa' at 'tableName' failed to satisfy constraint: Member must have length less than or equal to 255",
+          "n": 1,
+          "fields": [
+            "tableName"
+          ]
+        },
+        {
+          "id": "s_put_table_badchars",
+          "family": "echo-scalar",
+          "note": "PutItem TableName='bad table!@#'",
+          "threw": true,
+          "name": "ValidationException",
+          "message": "1 validation error detected: Value 'bad table!@#' at 'tableName' failed to satisfy constraint: Member must satisfy regular expression pattern: [a-zA-Z0-9_.-]+",
+          "n": 1,
+          "fields": [
+            "tableName"
+          ]
+        },
+        {
+          "id": "s_ct_table_short",
+          "family": "echo-scalar",
+          "note": "CreateTable TableName='ab'",
+          "threw": true,
+          "name": "ValidationException",
+          "message": "1 validation error detected: Value 'ab' at 'tableName' failed to satisfy constraint: Member must have length greater than or equal to 3",
+          "n": 1,
+          "fields": [
+            "tableName"
+          ]
+        },
+        {
+          "id": "c_bw_over25",
+          "family": "echo-collection",
+          "note": "BatchWrite 26 requests",
+          "threw": true,
+          "name": "ValidationException",
+          "message": "1 validation error detected: Value '{_conformance_capdrift_h_1780928121410175759=[WriteRequest(putRequest=PutRequest(item={pk=AttributeValue(s=bw-0, n=null, b=null, iNT=null, dECIMAL=null, dOUBLE=null, sS=null, nS=null, bS=null, iNTSET=null, dECIMALSET=null, dOUBLESET=null, m=null, l=null, nULL=null, bOOL=null)}, workloadProfileName=null), deleteRequest=null), WriteRequest(putRequest=PutRequest(item={pk=AttributeValue(s=bw-1, n=null, b=null, iNT=null, dECIMAL=null, dOUBLE=null, sS=null, nS=null, bS=null, iNTSET=null, dECIMALSET=null, dOUBLESET=null, m=null, l=null, nULL=null, bOOL=null)}, workloadProfileName=null), deleteRequest=null), WriteRequest(putRequest=PutRequest(item={pk=AttributeValue(s=bw-2, n=null, b=null, iNT=null, dECIMAL=null, dOUBLE=null, sS=null, nS=null, bS=null, iNTSET=null, dECIMALSET=null, dOUBLESET=null, m=null, l=null, nULL=null, bOOL=null)}, workloadProfileName=null), deleteRequest=null), WriteRequest(putRequest=PutRequest(item={pk=AttributeValue(s=bw-3, n=null, b=null, iNT=null, dECIMAL=null, dOUBLE=null, sS=null, nS=null, bS=null, iNTSET=null, dECIMALSET=null, dOUBLESET=null, m=null, l=null, nULL=null, bOOL=null)}, workloadProfileName=null), deleteRequest=null), WriteRequest(putRequest=PutRequest(item={pk=AttributeValue(s=bw-4, n=null, b=null, iNT=null, dECIMAL=null, dOUBLE=null, sS=null, nS=null, bS=null, iNTSET=null, dECIMALSET=null, dOUBLESET=null, m=null, l=null, nULL=null, bOOL=null)}, workloadProfileName=null), deleteRequest=null), WriteRequest(putRequest=PutRequest(item={pk=AttributeValue(s=bw-5, n=null, b=null, iNT=null, dECIMAL=null, dOUBLE=null, sS=null, nS=null, bS=null, iNTSET=null, dECIMALSET=null, dOUBLESET=null, m=null, l=null, nULL=null, bOOL=null)}, workloadProfileName=null), deleteRequest=null), WriteRequest(putRequest=PutRequest(item={pk=AttributeValue(s=bw-6, n=null, b=null, iNT=null, dECIMAL=null, dOUBLE=null, sS=null, nS=null, bS=null, iNTSET=null, dECIMALSET=null, dOUBLESET=null, m=null, l=null, nULL=null, bOOL=null)}, workloadProfileName=null), deleteRequest=null), WriteRequest(putRequest=PutRequest(item={pk=AttributeValue(s=bw-7, n=null, b=null, iNT=null, dECIMAL=null, dOUBLE=null, sS=null, nS=null, bS=null, iNTSET=null, dECIMALSET=null, dOUBLESET=null, m=null, l=null, nULL=null, bOOL=null)}, workloadProfileName=null), deleteRequest=null), WriteRequest(putRequest=PutRequest(item={pk=AttributeValue(s=bw-8, n=null, b=null, iNT=null, dECIMAL=null, dOUBLE=null, sS=null, nS=null, bS=null, iNTSET=null, dECIMALSET=null, dOUBLESET=null, m=null, l=null, nULL=null, bOOL=null)}, workloadProfileName=null), deleteRequest=null), WriteRequest(putRequest=PutRequest(item={pk=AttributeValue(s=bw-9, n=null, b=null, iNT=null, dECIMAL=null, dOUBLE=null, sS=null, nS=null, bS=null, iNTSET=null, dECIMALSET=null, dOUBLESET=null, m=null, l=null, nULL=null, bOOL=null)}, workloadProfileName=null), deleteRequest=null), WriteRequest(putRequest=PutRequest(item={pk=AttributeValue(s=bw-10, n=null, b=null, iNT=null, dECIMAL=null, dOUBLE=null, sS=null, nS=null, bS=null, iNTSET=null, dECIMALSET=null, dOUBLESET=null, m=null, l=null, nULL=null, bOOL=null)}, workloadProfileName=null), deleteRequest=null), WriteRequest(putRequest=PutRequest(item={pk=AttributeValue(s=bw-11, n=null, b=null, iNT=null, dECIMAL=null, dOUBLE=null, sS=null, nS=null, bS=null, iNTSET=null, dECIMALSET=null, dOUBLESET=null, m=null, l=null, nULL=null, bOOL=null)}, workloadProfileName=null), deleteRequest=null), WriteRequest(putRequest=PutRequest(item={pk=AttributeValue(s=bw-12, n=null, b=null, iNT=null, dECIMAL=null, dOUBLE=null, sS=null, nS=null, bS=null, iNTSET=null, dECIMALSET=null, dOUBLESET=null, m=null, l=null, nULL=null, bOOL=null)}, workloadProfileName=null), deleteRequest=null), WriteRequest(putRequest=PutRequest(item={pk=AttributeValue(s=bw-13, n=null, b=null, iNT=null, dECIMAL=null, dOUBLE=null, sS=null, nS=null, bS=null, iNTSET=null, dECIMALSET=null, dOUBLESET=null, m=null, l=null, nULL=null, bOOL=null)}, workloadProfileName=null), deleteRequest=null), WriteRequest(putRequest=PutRequest(item={pk=AttributeValue(s=bw-14, n=null, b=null, iNT=null, dECIMAL=null, dOUBLE=null, sS=null, nS=null, bS=null, iNTSET=null, dECIMALSET=null, dOUBLESET=null, m=null, l=null, nULL=null, bOOL=null)}, workloadProfileName=null), deleteRequest=null), WriteRequest(putRequest=PutRequest(item={pk=AttributeValue(s=bw-15, n=null, b=null, iNT=null, dECIMAL=null, dOUBLE=null, sS=null, nS=null, bS=null, iNTSET=null, dECIMALSET=null, dOUBLESET=null, m=null, l=null, nULL=null, bOOL=null)}, workloadProfileName=null), deleteRequest=null), WriteRequest(putRequest=PutRequest(item={pk=AttributeValue(s=bw-16, n=null, b=null, iNT=null, dECIMAL=null, dOUBLE=null, sS=null, nS=null, bS=null, iNTSET=null, dECIMALSET=null, dOUBLESET=null, m=null, l=null, nULL=null, bOOL=null)}, workloadProfileName=null), deleteRequest=null), WriteRequest(putRequest=PutRequest(item={pk=AttributeValue(s=bw-17, n=null, b=null, iNT=null, dECIMAL=null, dOUBLE=null, sS=null, nS=null, bS=null, iNTSET=null, dECIMALSET=null, dOUBLESET=null, m=null, l=null, nULL=null, bOOL=null)}, workloadProfileName=null), deleteRequest=null), WriteRequest(putRequest=PutRequest(item={pk=AttributeValue(s=bw-18, n=null, b=null, iNT=null, dECIMAL=null, dOUBLE=null, sS=null, nS=null, bS=null, iNTSET=null, dECIMALSET=null, dOUBLESET=null, m=null, l=null, nULL=null, bOOL=null)}, workloadProfileName=null), deleteRequest=null), WriteRequest(putRequest=PutRequest(item={pk=AttributeValue(s=bw-19, n=null, b=null, iNT=null, dECIMAL=null, dOUBLE=null, sS=null, nS=null, bS=null, iNTSET=null, dECIMALSET=null, dOUBLESET=null, m=null, l=null, nULL=null, bOOL=null)}, workloadProfileName=null), deleteRequest=null), WriteRequest(putRequest=PutRequest(item={pk=AttributeValue(s=bw-20, n=null, b=null, iNT=null, dECIMAL=null, dOUBLE=null, sS=null, nS=null, bS=null, iNTSET=null, dECIMALSET=null, dOUBLESET=null, m=null, l=null, nULL=null, bOOL=null)}, workloadProfileName=null), deleteRequest=null), WriteRequest(putRequest=PutRequest(item={pk=AttributeValue(s=bw-21, n=null, b=null, iNT=null, dECIMAL=null, dOUBLE=null, sS=null, nS=null, bS=null, iNTSET=null, dECIMALSET=null, dOUBLESET=null, m=null, l=null, nULL=null, bOOL=null)}, workloadProfileName=null), deleteRequest=null), WriteRequest(putRequest=PutRequest(item={pk=AttributeValue(s=bw-22, n=null, b=null, iNT=null, dECIMAL=null, dOUBLE=null, sS=null, nS=null, bS=null, iNTSET=null, dECIMALSET=null, dOUBLESET=null, m=null, l=null, nULL=null, bOOL=null)}, workloadProfileName=null), deleteRequest=null), WriteRequest(putRequest=PutRequest(item={pk=AttributeValue(s=bw-23, n=null, b=null, iNT=null, dECIMAL=null, dOUBLE=null, sS=null, nS=null, bS=null, iNTSET=null, dECIMALSET=null, dOUBLESET=null, m=null, l=null, nULL=null, bOOL=null)}, workloadProfileName=null), deleteRequest=null), WriteRequest(putRequest=PutRequest(item={pk=AttributeValue(s=bw-24, n=null, b=null, iNT=null, dECIMAL=null, dOUBLE=null, sS=null, nS=null, bS=null, iNTSET=null, dECIMALSET=null, dOUBLESET=null, m=null, l=null, nULL=null, bOOL=null)}, workloadProfileName=null), deleteRequest=null), WriteRequest(putRequest=PutRequest(item={pk=AttributeValue(s=bw-25, n=null, b=null, iNT=null, dECIMAL=null, dOUBLE=null, sS=null, nS=null, bS=null, iNTSET=null, dECIMALSET=null, dOUBLESET=null, m=null, l=null, nULL=null, bOOL=null)}, workloadProfileName=null), deleteRequest=null)]}' at 'requestItems' failed to satisfy constraint: Map value must satisfy constraint: [Member must have length less than or equal to 25, Member must have length greater than or equal to 1]",
+          "n": 1,
+          "fields": [
+            "requestItems"
+          ]
+        },
+        {
+          "id": "c_ct_3keys",
+          "family": "echo-collection",
+          "note": "CreateTable 3 keySchema",
+          "threw": true,
+          "name": "ValidationException",
+          "message": "One or more parameter values were invalid: ReadCapacityUnits and WriteCapacityUnits must both be specified when BillingMode is PROVISIONED",
+          "n": null,
+          "fields": []
+        },
+        {
+          "id": "b_put_empty_ss",
+          "family": "bespoke",
+          "note": "empty string set",
+          "threw": true,
+          "name": "ValidationException",
+          "message": "One or more parameter values were invalid: An string set  may not be empty",
+          "n": null,
+          "fields": []
+        },
+        {
+          "id": "b_put_empty_ns",
+          "family": "bespoke",
+          "note": "empty number set",
+          "threw": true,
+          "name": "ValidationException",
+          "message": "One or more parameter values were invalid: An number set  may not be empty",
+          "n": null,
+          "fields": []
+        },
+        {
+          "id": "b_put_dup_ss",
+          "family": "bespoke",
+          "note": "duplicate SS",
+          "threw": true,
+          "name": "ValidationException",
+          "message": "One or more parameter values were invalid: Input collection [a, a] contains duplicates.",
+          "n": null,
+          "fields": []
+        },
+        {
+          "id": "b_put_mix_expr",
+          "family": "bespoke",
+          "note": "mixing expression and non-expression",
+          "threw": true,
+          "name": "ValidationException",
+          "message": "Can not use both expression and non-expression parameters in the same request: Non-expression parameters: {Expected} Expression parameters: {ConditionExpression}",
+          "n": null,
+          "fields": []
+        },
+        {
+          "id": "b_put_eav_no_expr",
+          "family": "bespoke",
+          "note": "EAV without expression",
+          "threw": true,
+          "name": "ValidationException",
+          "message": "ExpressionAttributeValues can only be specified when using expressions: ConditionExpression is null",
+          "n": null,
+          "fields": []
+        },
+        {
+          "id": "b_put_redundant_parens",
+          "family": "bespoke",
+          "note": "redundant parentheses",
+          "threw": true,
+          "name": "ValidationException",
+          "message": "Invalid ConditionExpression: The expression has redundant parentheses;",
+          "n": null,
+          "fields": []
+        },
+        {
+          "id": "b_put_contains_dup",
+          "family": "bespoke",
+          "note": "contains distinct operand",
+          "threw": true,
+          "name": "ValidationException",
+          "message": "Invalid ConditionExpression: The first operand must be distinct from the remaining operands for this operator or function; operator: contains, first operand: [data]",
+          "n": null,
+          "fields": []
+        },
+        {
+          "id": "u_upd_hashkey",
+          "family": "bespoke",
+          "note": "cannot update hash key",
+          "threw": true,
+          "name": "ValidationException",
+          "message": "One or more parameter values were invalid: Cannot update attribute pk. This attribute is part of the key",
+          "n": null,
+          "fields": []
+        },
+        {
+          "id": "u_upd_syntax",
+          "family": "bespoke",
+          "note": "invalid UpdateExpression syntax",
+          "threw": true,
+          "name": "ValidationException",
+          "message": "Invalid UpdateExpression: Syntax error; token: \"INVALID\", near: \"INVALID SYNTAX\"",
+          "n": null,
+          "fields": []
+        },
+        {
+          "id": "u_upd_unused_ean",
+          "family": "bespoke",
+          "note": "unused EAN",
+          "threw": true,
+          "name": "ValidationException",
+          "message": "Value provided in ExpressionAttributeNames unused in expressions: keys: {#unused}",
+          "n": null,
+          "fields": []
+        },
+        {
+          "id": "u_upd_unused_eav",
+          "family": "bespoke",
+          "note": "unused EAV",
+          "threw": true,
+          "name": "ValidationException",
+          "message": "Value provided in ExpressionAttributeValues unused in expressions: keys: {:unused}",
+          "n": null,
+          "fields": []
+        },
+        {
+          "id": "u_upd_missing_eav",
+          "family": "bespoke",
+          "note": "missing EAV ref",
+          "threw": true,
+          "name": "ValidationException",
+          "message": "Invalid UpdateExpression: An expression attribute value used in expression is not defined; attribute value: :v",
+          "n": null,
+          "fields": []
+        },
+        {
+          "id": "u_upd_mix",
+          "family": "bespoke",
+          "note": "mixing UpdateExpression + AttributeUpdates",
+          "threw": true,
+          "name": "ValidationException",
+          "message": "Can not use both expression and non-expression parameters in the same request: Non-expression parameters: {AttributeUpdates} Expression parameters: {UpdateExpression}",
+          "n": null,
+          "fields": []
+        },
+        {
+          "id": "u_upd_empty",
+          "family": "bespoke",
+          "note": "empty UpdateExpression",
+          "threw": true,
+          "name": "ValidationException",
+          "message": "Invalid UpdateExpression: The expression can not be empty;",
+          "n": null,
+          "fields": []
+        },
+        {
+          "id": "u_upd_rangekey",
+          "family": "bespoke",
+          "note": "cannot update range key",
+          "threw": true,
+          "name": "ValidationException",
+          "message": "One or more parameter values were invalid: Cannot update attribute sk. This attribute is part of the key",
+          "n": null,
+          "fields": []
+        },
+        {
+          "id": "o_put_empty_table_empty_item",
+          "family": "ordering",
+          "note": "PutItem TableName='' Item={}",
+          "threw": true,
+          "name": "ValidationException",
+          "message": "1 validation error detected: Value '' at 'tableName' failed to satisfy constraint: Member must have length greater than or equal to 1",
+          "n": 1,
+          "fields": [
+            "tableName"
+          ]
+        },
+        {
+          "id": "o_put_empty_table_bad_rv",
+          "family": "ordering",
+          "note": "PutItem TableName='' ReturnValues=INVALID Item={}",
+          "threw": true,
+          "name": "ValidationException",
+          "message": "2 validation errors detected: Value 'INVALID' at 'returnValues' failed to satisfy constraint: Member must satisfy enum value set: [ALL_NEW, UPDATED_OLD, ALL_OLD, NONE, UPDATED_NEW]; Value '' at 'tableName' failed to satisfy constraint: Member must have length greater than or equal to 1",
+          "n": 2,
+          "fields": [
+            "returnValues",
+            "tableName"
+          ]
+        },
+        {
+          "id": "o_put_three_bad_enums",
+          "family": "ordering",
+          "note": "PutItem 3 invalid enums on valid table name",
+          "threw": true,
+          "name": "ValidationException",
+          "message": "3 validation errors detected: Value 'INVALID' at 'returnValues' failed to satisfy constraint: Member must satisfy enum value set: [ALL_NEW, UPDATED_OLD, ALL_OLD, NONE, UPDATED_NEW]; Value 'INVALID' at 'returnConsumedCapacity' failed to satisfy constraint: Member must satisfy enum value set: [INDEXES, TOTAL, NONE]; Value 'INVALID' at 'returnItemCollectionMetrics' failed to satisfy constraint: Member must satisfy enum value set: [SIZE, NONE]",
+          "n": 3,
+          "fields": [
+            "returnValues",
+            "returnConsumedCapacity",
+            "returnItemCollectionMetrics"
+          ]
+        },
+        {
+          "id": "o_del_empty_table",
+          "family": "ordering",
+          "note": "DeleteItem TableName='' Key={}",
+          "threw": true,
+          "name": "ValidationException",
+          "message": "1 validation error detected: Value '' at 'tableName' failed to satisfy constraint: Member must have length greater than or equal to 1",
+          "n": 1,
+          "fields": [
+            "tableName"
+          ]
+        },
+        {
+          "id": "o_del_two_bad_enums",
+          "family": "ordering",
+          "note": "DeleteItem 2 invalid enums",
+          "threw": true,
+          "name": "ValidationException",
+          "message": "2 validation errors detected: Value 'INVALID' at 'returnValues' failed to satisfy constraint: Member must satisfy enum value set: [ALL_NEW, UPDATED_OLD, ALL_OLD, NONE, UPDATED_NEW]; Value 'INVALID' at 'returnConsumedCapacity' failed to satisfy constraint: Member must satisfy enum value set: [INDEXES, TOTAL, NONE]",
+          "n": 2,
+          "fields": [
+            "returnValues",
+            "returnConsumedCapacity"
+          ]
+        },
+        {
+          "id": "o_upd_empty_table",
+          "family": "ordering",
+          "note": "UpdateItem TableName='' Key={}",
+          "threw": true,
+          "name": "ValidationException",
+          "message": "1 validation error detected: Value '' at 'tableName' failed to satisfy constraint: Member must have length greater than or equal to 1",
+          "n": 1,
+          "fields": [
+            "tableName"
+          ]
+        },
+        {
+          "id": "o_upd_two_bad_enums",
+          "family": "ordering",
+          "note": "UpdateItem 2 invalid enums",
+          "threw": true,
+          "name": "ValidationException",
+          "message": "2 validation errors detected: Value 'INVALID' at 'returnConsumedCapacity' failed to satisfy constraint: Member must satisfy enum value set: [INDEXES, TOTAL, NONE]; Value 'INVALID' at 'returnValues' failed to satisfy constraint: Member must satisfy enum value set: [ALL_NEW, UPDATED_OLD, ALL_OLD, NONE, UPDATED_NEW]",
+          "n": 2,
+          "fields": [
+            "returnConsumedCapacity",
+            "returnValues"
+          ]
+        }
+      ],
+      "nullRoundTrip": {
+        "put": "rejected",
+        "name": "ValidationException",
+        "message": "One or more parameter values were invalid: Null attribute value types must have the value of true"
+      }
+    },
+    "ap-southeast-2": {
+      "probes": [
+        {
+          "id": "s_put_table_null",
+          "family": "echo-scalar",
+          "note": "PutItem TableName=undefined",
+          "threw": true,
+          "name": "ValidationException",
+          "message": "1 validation error detected: Value null at 'tableName' failed to satisfy constraint: Member must not be null",
+          "n": 1,
+          "fields": [
+            "tableName"
+          ]
+        },
+        {
+          "id": "s_put_table_empty",
+          "family": "echo-scalar",
+          "note": "PutItem TableName='' (empty echo)",
+          "threw": true,
+          "name": "ValidationException",
+          "message": "1 validation error detected: Value '' at 'tableName' failed to satisfy constraint: Member must have length greater than or equal to 1",
+          "n": 1,
+          "fields": [
+            "tableName"
+          ]
+        },
+        {
+          "id": "s_put_table_long",
+          "family": "echo-scalar",
+          "note": "PutItem TableName='a'*256",
+          "threw": true,
+          "name": "ValidationException",
+          "message": "1 validation error detected: Value 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa' at 'tableName' failed to satisfy constraint: Member must have length less than or equal to 255",
+          "n": 1,
+          "fields": [
+            "tableName"
+          ]
+        },
+        {
+          "id": "s_put_table_badchars",
+          "family": "echo-scalar",
+          "note": "PutItem TableName='bad table!@#'",
+          "threw": true,
+          "name": "ValidationException",
+          "message": "1 validation error detected: Value 'bad table!@#' at 'tableName' failed to satisfy constraint: Member must satisfy regular expression pattern: [a-zA-Z0-9_.-]+",
+          "n": 1,
+          "fields": [
+            "tableName"
+          ]
+        },
+        {
+          "id": "s_ct_table_short",
+          "family": "echo-scalar",
+          "note": "CreateTable TableName='ab'",
+          "threw": true,
+          "name": "ValidationException",
+          "message": "1 validation error detected: Value 'ab' at 'tableName' failed to satisfy constraint: Member must have length greater than or equal to 3",
+          "n": 1,
+          "fields": [
+            "tableName"
+          ]
+        },
+        {
+          "id": "c_bw_over25",
+          "family": "echo-collection",
+          "note": "BatchWrite 26 requests",
+          "threw": true,
+          "name": "ValidationException",
+          "message": "1 validation error detected: Value '{_conformance_capdrift_h_1780928157556847661=[WriteRequest(putRequest=PutRequest(item={pk=AttributeValue(s=bw-0, n=null, b=null, iNT=null, dECIMAL=null, dOUBLE=null, sS=null, nS=null, bS=null, iNTSET=null, dECIMALSET=null, dOUBLESET=null, m=null, l=null, nULL=null, bOOL=null)}, workloadProfileName=null), deleteRequest=null), WriteRequest(putRequest=PutRequest(item={pk=AttributeValue(s=bw-1, n=null, b=null, iNT=null, dECIMAL=null, dOUBLE=null, sS=null, nS=null, bS=null, iNTSET=null, dECIMALSET=null, dOUBLESET=null, m=null, l=null, nULL=null, bOOL=null)}, workloadProfileName=null), deleteRequest=null), WriteRequest(putRequest=PutRequest(item={pk=AttributeValue(s=bw-2, n=null, b=null, iNT=null, dECIMAL=null, dOUBLE=null, sS=null, nS=null, bS=null, iNTSET=null, dECIMALSET=null, dOUBLESET=null, m=null, l=null, nULL=null, bOOL=null)}, workloadProfileName=null), deleteRequest=null), WriteRequest(putRequest=PutRequest(item={pk=AttributeValue(s=bw-3, n=null, b=null, iNT=null, dECIMAL=null, dOUBLE=null, sS=null, nS=null, bS=null, iNTSET=null, dECIMALSET=null, dOUBLESET=null, m=null, l=null, nULL=null, bOOL=null)}, workloadProfileName=null), deleteRequest=null), WriteRequest(putRequest=PutRequest(item={pk=AttributeValue(s=bw-4, n=null, b=null, iNT=null, dECIMAL=null, dOUBLE=null, sS=null, nS=null, bS=null, iNTSET=null, dECIMALSET=null, dOUBLESET=null, m=null, l=null, nULL=null, bOOL=null)}, workloadProfileName=null), deleteRequest=null), WriteRequest(putRequest=PutRequest(item={pk=AttributeValue(s=bw-5, n=null, b=null, iNT=null, dECIMAL=null, dOUBLE=null, sS=null, nS=null, bS=null, iNTSET=null, dECIMALSET=null, dOUBLESET=null, m=null, l=null, nULL=null, bOOL=null)}, workloadProfileName=null), deleteRequest=null), WriteRequest(putRequest=PutRequest(item={pk=AttributeValue(s=bw-6, n=null, b=null, iNT=null, dECIMAL=null, dOUBLE=null, sS=null, nS=null, bS=null, iNTSET=null, dECIMALSET=null, dOUBLESET=null, m=null, l=null, nULL=null, bOOL=null)}, workloadProfileName=null), deleteRequest=null), WriteRequest(putRequest=PutRequest(item={pk=AttributeValue(s=bw-7, n=null, b=null, iNT=null, dECIMAL=null, dOUBLE=null, sS=null, nS=null, bS=null, iNTSET=null, dECIMALSET=null, dOUBLESET=null, m=null, l=null, nULL=null, bOOL=null)}, workloadProfileName=null), deleteRequest=null), WriteRequest(putRequest=PutRequest(item={pk=AttributeValue(s=bw-8, n=null, b=null, iNT=null, dECIMAL=null, dOUBLE=null, sS=null, nS=null, bS=null, iNTSET=null, dECIMALSET=null, dOUBLESET=null, m=null, l=null, nULL=null, bOOL=null)}, workloadProfileName=null), deleteRequest=null), WriteRequest(putRequest=PutRequest(item={pk=AttributeValue(s=bw-9, n=null, b=null, iNT=null, dECIMAL=null, dOUBLE=null, sS=null, nS=null, bS=null, iNTSET=null, dECIMALSET=null, dOUBLESET=null, m=null, l=null, nULL=null, bOOL=null)}, workloadProfileName=null), deleteRequest=null), WriteRequest(putRequest=PutRequest(item={pk=AttributeValue(s=bw-10, n=null, b=null, iNT=null, dECIMAL=null, dOUBLE=null, sS=null, nS=null, bS=null, iNTSET=null, dECIMALSET=null, dOUBLESET=null, m=null, l=null, nULL=null, bOOL=null)}, workloadProfileName=null), deleteRequest=null), WriteRequest(putRequest=PutRequest(item={pk=AttributeValue(s=bw-11, n=null, b=null, iNT=null, dECIMAL=null, dOUBLE=null, sS=null, nS=null, bS=null, iNTSET=null, dECIMALSET=null, dOUBLESET=null, m=null, l=null, nULL=null, bOOL=null)}, workloadProfileName=null), deleteRequest=null), WriteRequest(putRequest=PutRequest(item={pk=AttributeValue(s=bw-12, n=null, b=null, iNT=null, dECIMAL=null, dOUBLE=null, sS=null, nS=null, bS=null, iNTSET=null, dECIMALSET=null, dOUBLESET=null, m=null, l=null, nULL=null, bOOL=null)}, workloadProfileName=null), deleteRequest=null), WriteRequest(putRequest=PutRequest(item={pk=AttributeValue(s=bw-13, n=null, b=null, iNT=null, dECIMAL=null, dOUBLE=null, sS=null, nS=null, bS=null, iNTSET=null, dECIMALSET=null, dOUBLESET=null, m=null, l=null, nULL=null, bOOL=null)}, workloadProfileName=null), deleteRequest=null), WriteRequest(putRequest=PutRequest(item={pk=AttributeValue(s=bw-14, n=null, b=null, iNT=null, dECIMAL=null, dOUBLE=null, sS=null, nS=null, bS=null, iNTSET=null, dECIMALSET=null, dOUBLESET=null, m=null, l=null, nULL=null, bOOL=null)}, workloadProfileName=null), deleteRequest=null), WriteRequest(putRequest=PutRequest(item={pk=AttributeValue(s=bw-15, n=null, b=null, iNT=null, dECIMAL=null, dOUBLE=null, sS=null, nS=null, bS=null, iNTSET=null, dECIMALSET=null, dOUBLESET=null, m=null, l=null, nULL=null, bOOL=null)}, workloadProfileName=null), deleteRequest=null), WriteRequest(putRequest=PutRequest(item={pk=AttributeValue(s=bw-16, n=null, b=null, iNT=null, dECIMAL=null, dOUBLE=null, sS=null, nS=null, bS=null, iNTSET=null, dECIMALSET=null, dOUBLESET=null, m=null, l=null, nULL=null, bOOL=null)}, workloadProfileName=null), deleteRequest=null), WriteRequest(putRequest=PutRequest(item={pk=AttributeValue(s=bw-17, n=null, b=null, iNT=null, dECIMAL=null, dOUBLE=null, sS=null, nS=null, bS=null, iNTSET=null, dECIMALSET=null, dOUBLESET=null, m=null, l=null, nULL=null, bOOL=null)}, workloadProfileName=null), deleteRequest=null), WriteRequest(putRequest=PutRequest(item={pk=AttributeValue(s=bw-18, n=null, b=null, iNT=null, dECIMAL=null, dOUBLE=null, sS=null, nS=null, bS=null, iNTSET=null, dECIMALSET=null, dOUBLESET=null, m=null, l=null, nULL=null, bOOL=null)}, workloadProfileName=null), deleteRequest=null), WriteRequest(putRequest=PutRequest(item={pk=AttributeValue(s=bw-19, n=null, b=null, iNT=null, dECIMAL=null, dOUBLE=null, sS=null, nS=null, bS=null, iNTSET=null, dECIMALSET=null, dOUBLESET=null, m=null, l=null, nULL=null, bOOL=null)}, workloadProfileName=null), deleteRequest=null), WriteRequest(putRequest=PutRequest(item={pk=AttributeValue(s=bw-20, n=null, b=null, iNT=null, dECIMAL=null, dOUBLE=null, sS=null, nS=null, bS=null, iNTSET=null, dECIMALSET=null, dOUBLESET=null, m=null, l=null, nULL=null, bOOL=null)}, workloadProfileName=null), deleteRequest=null), WriteRequest(putRequest=PutRequest(item={pk=AttributeValue(s=bw-21, n=null, b=null, iNT=null, dECIMAL=null, dOUBLE=null, sS=null, nS=null, bS=null, iNTSET=null, dECIMALSET=null, dOUBLESET=null, m=null, l=null, nULL=null, bOOL=null)}, workloadProfileName=null), deleteRequest=null), WriteRequest(putRequest=PutRequest(item={pk=AttributeValue(s=bw-22, n=null, b=null, iNT=null, dECIMAL=null, dOUBLE=null, sS=null, nS=null, bS=null, iNTSET=null, dECIMALSET=null, dOUBLESET=null, m=null, l=null, nULL=null, bOOL=null)}, workloadProfileName=null), deleteRequest=null), WriteRequest(putRequest=PutRequest(item={pk=AttributeValue(s=bw-23, n=null, b=null, iNT=null, dECIMAL=null, dOUBLE=null, sS=null, nS=null, bS=null, iNTSET=null, dECIMALSET=null, dOUBLESET=null, m=null, l=null, nULL=null, bOOL=null)}, workloadProfileName=null), deleteRequest=null), WriteRequest(putRequest=PutRequest(item={pk=AttributeValue(s=bw-24, n=null, b=null, iNT=null, dECIMAL=null, dOUBLE=null, sS=null, nS=null, bS=null, iNTSET=null, dECIMALSET=null, dOUBLESET=null, m=null, l=null, nULL=null, bOOL=null)}, workloadProfileName=null), deleteRequest=null), WriteRequest(putRequest=PutRequest(item={pk=AttributeValue(s=bw-25, n=null, b=null, iNT=null, dECIMAL=null, dOUBLE=null, sS=null, nS=null, bS=null, iNTSET=null, dECIMALSET=null, dOUBLESET=null, m=null, l=null, nULL=null, bOOL=null)}, workloadProfileName=null), deleteRequest=null)]}' at 'requestItems' failed to satisfy constraint: Map value must satisfy constraint: [Member must have length less than or equal to 25, Member must have length greater than or equal to 1]",
+          "n": 1,
+          "fields": [
+            "requestItems"
+          ]
+        },
+        {
+          "id": "c_ct_3keys",
+          "family": "echo-collection",
+          "note": "CreateTable 3 keySchema",
+          "threw": true,
+          "name": "ValidationException",
+          "message": "One or more parameter values were invalid: ReadCapacityUnits and WriteCapacityUnits must both be specified when BillingMode is PROVISIONED",
+          "n": null,
+          "fields": []
+        },
+        {
+          "id": "b_put_empty_ss",
+          "family": "bespoke",
+          "note": "empty string set",
+          "threw": true,
+          "name": "ValidationException",
+          "message": "One or more parameter values were invalid: An string set  may not be empty",
+          "n": null,
+          "fields": []
+        },
+        {
+          "id": "b_put_empty_ns",
+          "family": "bespoke",
+          "note": "empty number set",
+          "threw": true,
+          "name": "ValidationException",
+          "message": "One or more parameter values were invalid: An number set  may not be empty",
+          "n": null,
+          "fields": []
+        },
+        {
+          "id": "b_put_dup_ss",
+          "family": "bespoke",
+          "note": "duplicate SS",
+          "threw": true,
+          "name": "ValidationException",
+          "message": "One or more parameter values were invalid: Input collection [a, a] contains duplicates.",
+          "n": null,
+          "fields": []
+        },
+        {
+          "id": "b_put_mix_expr",
+          "family": "bespoke",
+          "note": "mixing expression and non-expression",
+          "threw": true,
+          "name": "ValidationException",
+          "message": "Can not use both expression and non-expression parameters in the same request: Non-expression parameters: {Expected} Expression parameters: {ConditionExpression}",
+          "n": null,
+          "fields": []
+        },
+        {
+          "id": "b_put_eav_no_expr",
+          "family": "bespoke",
+          "note": "EAV without expression",
+          "threw": true,
+          "name": "ValidationException",
+          "message": "ExpressionAttributeValues can only be specified when using expressions: ConditionExpression is null",
+          "n": null,
+          "fields": []
+        },
+        {
+          "id": "b_put_redundant_parens",
+          "family": "bespoke",
+          "note": "redundant parentheses",
+          "threw": true,
+          "name": "ValidationException",
+          "message": "Invalid ConditionExpression: The expression has redundant parentheses;",
+          "n": null,
+          "fields": []
+        },
+        {
+          "id": "b_put_contains_dup",
+          "family": "bespoke",
+          "note": "contains distinct operand",
+          "threw": true,
+          "name": "ValidationException",
+          "message": "Invalid ConditionExpression: The first operand must be distinct from the remaining operands for this operator or function; operator: contains, first operand: [data]",
+          "n": null,
+          "fields": []
+        },
+        {
+          "id": "u_upd_hashkey",
+          "family": "bespoke",
+          "note": "cannot update hash key",
+          "threw": true,
+          "name": "ValidationException",
+          "message": "One or more parameter values were invalid: Cannot update attribute pk. This attribute is part of the key",
+          "n": null,
+          "fields": []
+        },
+        {
+          "id": "u_upd_syntax",
+          "family": "bespoke",
+          "note": "invalid UpdateExpression syntax",
+          "threw": true,
+          "name": "ValidationException",
+          "message": "Invalid UpdateExpression: Syntax error; token: \"INVALID\", near: \"INVALID SYNTAX\"",
+          "n": null,
+          "fields": []
+        },
+        {
+          "id": "u_upd_unused_ean",
+          "family": "bespoke",
+          "note": "unused EAN",
+          "threw": true,
+          "name": "ValidationException",
+          "message": "Value provided in ExpressionAttributeNames unused in expressions: keys: {#unused}",
+          "n": null,
+          "fields": []
+        },
+        {
+          "id": "u_upd_unused_eav",
+          "family": "bespoke",
+          "note": "unused EAV",
+          "threw": true,
+          "name": "ValidationException",
+          "message": "Value provided in ExpressionAttributeValues unused in expressions: keys: {:unused}",
+          "n": null,
+          "fields": []
+        },
+        {
+          "id": "u_upd_missing_eav",
+          "family": "bespoke",
+          "note": "missing EAV ref",
+          "threw": true,
+          "name": "ValidationException",
+          "message": "Invalid UpdateExpression: An expression attribute value used in expression is not defined; attribute value: :v",
+          "n": null,
+          "fields": []
+        },
+        {
+          "id": "u_upd_mix",
+          "family": "bespoke",
+          "note": "mixing UpdateExpression + AttributeUpdates",
+          "threw": true,
+          "name": "ValidationException",
+          "message": "Can not use both expression and non-expression parameters in the same request: Non-expression parameters: {AttributeUpdates} Expression parameters: {UpdateExpression}",
+          "n": null,
+          "fields": []
+        },
+        {
+          "id": "u_upd_empty",
+          "family": "bespoke",
+          "note": "empty UpdateExpression",
+          "threw": true,
+          "name": "ValidationException",
+          "message": "Invalid UpdateExpression: The expression can not be empty;",
+          "n": null,
+          "fields": []
+        },
+        {
+          "id": "u_upd_rangekey",
+          "family": "bespoke",
+          "note": "cannot update range key",
+          "threw": true,
+          "name": "ValidationException",
+          "message": "One or more parameter values were invalid: Cannot update attribute sk. This attribute is part of the key",
+          "n": null,
+          "fields": []
+        },
+        {
+          "id": "o_put_empty_table_empty_item",
+          "family": "ordering",
+          "note": "PutItem TableName='' Item={}",
+          "threw": true,
+          "name": "ValidationException",
+          "message": "1 validation error detected: Value '' at 'tableName' failed to satisfy constraint: Member must have length greater than or equal to 1",
+          "n": 1,
+          "fields": [
+            "tableName"
+          ]
+        },
+        {
+          "id": "o_put_empty_table_bad_rv",
+          "family": "ordering",
+          "note": "PutItem TableName='' ReturnValues=INVALID Item={}",
+          "threw": true,
+          "name": "ValidationException",
+          "message": "2 validation errors detected: Value 'INVALID' at 'returnValues' failed to satisfy constraint: Member must satisfy enum value set: [ALL_NEW, UPDATED_OLD, ALL_OLD, NONE, UPDATED_NEW]; Value '' at 'tableName' failed to satisfy constraint: Member must have length greater than or equal to 1",
+          "n": 2,
+          "fields": [
+            "returnValues",
+            "tableName"
+          ]
+        },
+        {
+          "id": "o_put_three_bad_enums",
+          "family": "ordering",
+          "note": "PutItem 3 invalid enums on valid table name",
+          "threw": true,
+          "name": "ValidationException",
+          "message": "3 validation errors detected: Value 'INVALID' at 'returnValues' failed to satisfy constraint: Member must satisfy enum value set: [ALL_NEW, UPDATED_OLD, ALL_OLD, NONE, UPDATED_NEW]; Value 'INVALID' at 'returnConsumedCapacity' failed to satisfy constraint: Member must satisfy enum value set: [INDEXES, TOTAL, NONE]; Value 'INVALID' at 'returnItemCollectionMetrics' failed to satisfy constraint: Member must satisfy enum value set: [SIZE, NONE]",
+          "n": 3,
+          "fields": [
+            "returnValues",
+            "returnConsumedCapacity",
+            "returnItemCollectionMetrics"
+          ]
+        },
+        {
+          "id": "o_del_empty_table",
+          "family": "ordering",
+          "note": "DeleteItem TableName='' Key={}",
+          "threw": true,
+          "name": "ValidationException",
+          "message": "1 validation error detected: Value '' at 'tableName' failed to satisfy constraint: Member must have length greater than or equal to 1",
+          "n": 1,
+          "fields": [
+            "tableName"
+          ]
+        },
+        {
+          "id": "o_del_two_bad_enums",
+          "family": "ordering",
+          "note": "DeleteItem 2 invalid enums",
+          "threw": true,
+          "name": "ValidationException",
+          "message": "2 validation errors detected: Value 'INVALID' at 'returnValues' failed to satisfy constraint: Member must satisfy enum value set: [ALL_NEW, UPDATED_OLD, ALL_OLD, NONE, UPDATED_NEW]; Value 'INVALID' at 'returnConsumedCapacity' failed to satisfy constraint: Member must satisfy enum value set: [INDEXES, TOTAL, NONE]",
+          "n": 2,
+          "fields": [
+            "returnValues",
+            "returnConsumedCapacity"
+          ]
+        },
+        {
+          "id": "o_upd_empty_table",
+          "family": "ordering",
+          "note": "UpdateItem TableName='' Key={}",
+          "threw": true,
+          "name": "ValidationException",
+          "message": "1 validation error detected: Value '' at 'tableName' failed to satisfy constraint: Member must have length greater than or equal to 1",
+          "n": 1,
+          "fields": [
+            "tableName"
+          ]
+        },
+        {
+          "id": "o_upd_two_bad_enums",
+          "family": "ordering",
+          "note": "UpdateItem 2 invalid enums",
+          "threw": true,
+          "name": "ValidationException",
+          "message": "2 validation errors detected: Value 'INVALID' at 'returnConsumedCapacity' failed to satisfy constraint: Member must satisfy enum value set: [INDEXES, TOTAL, NONE]; Value 'INVALID' at 'returnValues' failed to satisfy constraint: Member must satisfy enum value set: [ALL_NEW, UPDATED_OLD, ALL_OLD, NONE, UPDATED_NEW]",
+          "n": 2,
+          "fields": [
+            "returnConsumedCapacity",
+            "returnValues"
+          ]
+        }
+      ],
+      "nullRoundTrip": {
+        "put": "rejected",
+        "name": "ValidationException",
+        "message": "One or more parameter values were invalid: Null attribute value types must have the value of true"
+      }
+    }
+  }
+}

--- a/captures/README.md
+++ b/captures/README.md
@@ -1,0 +1,25 @@
+# Captures
+
+Dated, one-off records of what real DynamoDB actually returns, captured across
+regions. They exist for two reasons: provenance (a fixed record of what was seen
+on a date), and to draw the contract-versus-cosmetic line for Tier 3 assertions
+from what is invariant across regions rather than from a single region.
+
+Re-run with the capture script (needs real-AWS credentials with the
+`_conformance_` prefix permissions):
+
+```
+AWS_PROFILE=conformance-test node scripts/capture-validation-messages.mjs > captures/$(date +%F)-<topic>.json
+```
+
+It creates and deletes two temporary `_conformance_` tables per region.
+
+## 2026-06-09-validation-rewording.json
+
+Real DynamoDB reworded a chunk of its validation errors. Four regions captured:
+eu-west-2 and eu-central-1 returned the new wording (envelope prefix, dropped
+echoed value, PascalCase field on the empty-name case, `{ NULL: false }`
+accepted), us-east-1 and ap-southeast-2 still returned the old. The Tier 3
+error-message tests were re-pinned to assert the contract (type, field,
+constraint) that is invariant across all four, not the prose that varies. See
+`CHANGELOG.md` for 2026-06-09.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dynamodb-conformance",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "description": "Independent conformance test suite for DynamoDB-compatible endpoints",
   "type": "module",
   "scripts": {

--- a/scripts/capture-validation-messages.mjs
+++ b/scripts/capture-validation-messages.mjs
@@ -1,0 +1,148 @@
+// Multi-region capture of DynamoDB's negative-input behaviour.
+//
+// Fires the validation/error inputs the Tier 3 error-message and
+// validation-ordering tests care about against real AWS in one or more regions,
+// and records the raw err.name / err.message, the "N validation error detected"
+// count, the named field list, and the { NULL: false } round-trip. Output is a
+// combined JSON document on stdout, one block per region.
+//
+//   AWS_PROFILE=conformance-test node scripts/capture-validation-messages.mjs > capture.json
+//   AWS_PROFILE=conformance-test node scripts/capture-validation-messages.mjs eu-west-2 us-east-1 > capture.json
+//
+// Default regions are the four used for the June 2026 capture. The script
+// creates two temporary tables under the _conformance_ prefix per region and
+// deletes them by exact name afterwards.
+//
+// Why it exists: AWS varies validation wording by region and over time. When a
+// laggard region is due to flip, re-run this to see what actually changed, and
+// draw the contract/cosmetic line for Tier 3 assertions from what is invariant
+// across regions rather than from a single region. See docs in CONTRIBUTING
+// ("error-messages") and the committed June snapshot in captures/.
+
+import {
+  DynamoDBClient,
+  CreateTableCommand,
+  DeleteTableCommand,
+  DescribeTableCommand,
+  PutItemCommand,
+  GetItemCommand,
+  UpdateItemCommand,
+  DeleteItemCommand,
+  BatchWriteItemCommand,
+} from '@aws-sdk/client-dynamodb'
+
+const DEFAULT_REGIONS = ['eu-west-2', 'eu-central-1', 'us-east-1', 'ap-southeast-2']
+const regions = process.argv.slice(2).length ? process.argv.slice(2) : DEFAULT_REGIONS
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms))
+
+function parse(message) {
+  if (typeof message !== 'string') return { n: null, fields: [] }
+  const m = message.match(/^(\d+) validation error(?:s)? detected:/)
+  return { n: m ? Number(m[1]) : null, fields: [...message.matchAll(/at '([^']+)'/g)].map((x) => x[1]) }
+}
+
+async function waitActive(ddb, name) {
+  const start = Date.now()
+  for (;;) {
+    const res = await ddb.send(new DescribeTableCommand({ TableName: name }))
+    if (res.Table?.TableStatus === 'ACTIVE') return
+    if (Date.now() - start > 120_000) throw new Error(`timeout waiting ACTIVE: ${name}`)
+    await sleep(1000)
+  }
+}
+
+async function probe(id, family, note, fn) {
+  try {
+    await fn()
+    return { id, family, note, threw: false, name: null, message: null, n: null, fields: [] }
+  } catch (e) {
+    const message = e?.message ?? null
+    return { id, family, note, threw: true, name: e?.name ?? null, message, ...parse(message) }
+  }
+}
+
+async function captureRegion(region) {
+  const ddb = new DynamoDBClient({ region })
+  const suffix = `${Date.now()}${Math.floor(Math.random() * 1e6)}`
+  const H = `_conformance_capdrift_h_${suffix}`
+  const C = `_conformance_capdrift_c_${suffix}`
+  const CT3 = `_conformance_capdrift_ct3_${suffix}`
+  const pt = { ReadCapacityUnits: 5, WriteCapacityUnits: 5 }
+
+  await ddb.send(new CreateTableCommand({ TableName: H, BillingMode: 'PAY_PER_REQUEST', AttributeDefinitions: [{ AttributeName: 'pk', AttributeType: 'S' }], KeySchema: [{ AttributeName: 'pk', KeyType: 'HASH' }] }))
+  await ddb.send(new CreateTableCommand({ TableName: C, BillingMode: 'PAY_PER_REQUEST', AttributeDefinitions: [{ AttributeName: 'pk', AttributeType: 'S' }, { AttributeName: 'sk', AttributeType: 'S' }], KeySchema: [{ AttributeName: 'pk', KeyType: 'HASH' }, { AttributeName: 'sk', KeyType: 'RANGE' }] }))
+  await waitActive(ddb, H)
+  await waitActive(ddb, C)
+
+  const probes = []
+  const p = (id, family, note, fn) => probe(id, family, note, fn).then((r) => probes.push(r))
+  try {
+    // scalar echo (tableName)
+    await p('s_put_table_null', 'echo-scalar', 'PutItem TableName=undefined', () => ddb.send(new PutItemCommand({ TableName: undefined, Item: { pk: { S: 'test' } } })))
+    await p('s_put_table_empty', 'echo-scalar', "PutItem TableName=''", () => ddb.send(new PutItemCommand({ TableName: '', Item: { pk: { S: 'test' } } })))
+    await p('s_put_table_long', 'echo-scalar', "PutItem TableName='a'*256", () => ddb.send(new PutItemCommand({ TableName: 'a'.repeat(256), Item: { pk: { S: 'test' } } })))
+    await p('s_put_table_badchars', 'echo-scalar', "PutItem TableName='bad table!@#'", () => ddb.send(new PutItemCommand({ TableName: 'bad table!@#', Item: { pk: { S: 'test' } } })))
+    await p('s_ct_table_short', 'echo-scalar', "CreateTable TableName='ab'", () => ddb.send(new CreateTableCommand({ TableName: 'ab', AttributeDefinitions: [{ AttributeName: 'pk', AttributeType: 'S' }], KeySchema: [{ AttributeName: 'pk', KeyType: 'HASH' }], ProvisionedThroughput: pt })))
+    // collection echo
+    await p('c_bw_over25', 'echo-collection', 'BatchWrite 26 requests', () => ddb.send(new BatchWriteItemCommand({ RequestItems: { [H]: Array.from({ length: 26 }, (_, i) => ({ PutRequest: { Item: { pk: { S: `bw-${i}` } } } })) } })))
+    await p('c_ct_3keys', 'echo-collection', 'CreateTable 3 keySchema', () => ddb.send(new CreateTableCommand({ TableName: CT3, AttributeDefinitions: [{ AttributeName: 'pk', AttributeType: 'S' }, { AttributeName: 'sk', AttributeType: 'S' }, { AttributeName: 'extra', AttributeType: 'S' }], KeySchema: [{ AttributeName: 'pk', KeyType: 'HASH' }, { AttributeName: 'sk', KeyType: 'RANGE' }, { AttributeName: 'extra', KeyType: 'RANGE' }], ProvisionedThroughput: pt })))
+    // bespoke putItem
+    await p('b_put_empty_ss', 'bespoke', 'empty string set', () => ddb.send(new PutItemCommand({ TableName: H, Item: { pk: { S: 'test' }, bad: { SS: [] } } })))
+    await p('b_put_empty_ns', 'bespoke', 'empty number set', () => ddb.send(new PutItemCommand({ TableName: H, Item: { pk: { S: 'test' }, bad: { NS: [] } } })))
+    await p('b_put_dup_ss', 'bespoke', 'duplicate SS', () => ddb.send(new PutItemCommand({ TableName: H, Item: { pk: { S: 'test' }, bad: { SS: ['a', 'a'] } } })))
+    await p('b_put_mix_expr', 'bespoke', 'mixing expression and non-expression', () => ddb.send(new PutItemCommand({ TableName: H, Item: { pk: { S: 'test' } }, Expected: { pk: { Exists: false } }, ConditionExpression: 'attribute_not_exists(pk)' })))
+    await p('b_put_eav_no_expr', 'bespoke', 'EAV without expression', () => ddb.send(new PutItemCommand({ TableName: H, Item: { pk: { S: 'test' } }, ExpressionAttributeValues: { ':v': { S: 'unused' } } })))
+    await p('b_put_redundant_parens', 'bespoke', 'redundant parentheses', () => ddb.send(new PutItemCommand({ TableName: H, Item: { pk: { S: 'em-put-redundant' } }, ConditionExpression: '((attribute_not_exists(pk)))' })))
+    await p('b_put_contains_dup', 'bespoke', 'contains distinct operand', () => ddb.send(new PutItemCommand({ TableName: H, Item: { pk: { S: 'em-put-contains-dup' } }, ConditionExpression: 'contains(#a, #a)', ExpressionAttributeNames: { '#a': 'data' } })))
+    // bespoke updateItem
+    await p('u_upd_hashkey', 'bespoke', 'cannot update hash key', () => ddb.send(new UpdateItemCommand({ TableName: H, Key: { pk: { S: 'em-upd-key-mod' } }, UpdateExpression: 'SET pk = :v', ExpressionAttributeValues: { ':v': { S: 'new-val' } } })))
+    await p('u_upd_syntax', 'bespoke', 'invalid UpdateExpression syntax', () => ddb.send(new UpdateItemCommand({ TableName: H, Key: { pk: { S: 'em-upd-key-mod' } }, UpdateExpression: 'INVALID SYNTAX HERE', ExpressionAttributeValues: { ':v': { S: 'val' } } })))
+    await p('u_upd_unused_ean', 'bespoke', 'unused EAN', () => ddb.send(new UpdateItemCommand({ TableName: H, Key: { pk: { S: 'em-upd-key-mod' } }, UpdateExpression: 'SET attr1 = :v', ExpressionAttributeValues: { ':v': { S: 'val' } }, ExpressionAttributeNames: { '#unused': 'someattr' } })))
+    await p('u_upd_unused_eav', 'bespoke', 'unused EAV', () => ddb.send(new UpdateItemCommand({ TableName: H, Key: { pk: { S: 'em-upd-key-mod' } }, UpdateExpression: 'SET attr1 = :v', ExpressionAttributeValues: { ':v': { S: 'val' }, ':unused': { S: 'extra' } } })))
+    await p('u_upd_missing_eav', 'bespoke', 'missing EAV ref', () => ddb.send(new UpdateItemCommand({ TableName: H, Key: { pk: { S: 'em-upd-key-mod' } }, UpdateExpression: 'SET attr1 = :v' })))
+    await p('u_upd_mix', 'bespoke', 'mixing UpdateExpression + AttributeUpdates', () => ddb.send(new UpdateItemCommand({ TableName: H, Key: { pk: { S: 'em-upd-key-mod' } }, UpdateExpression: 'SET attr1 = :v', ExpressionAttributeValues: { ':v': { S: 'val' } }, AttributeUpdates: { attr1: { Value: { S: 'val' }, Action: 'PUT' } } })))
+    await p('u_upd_empty', 'bespoke', 'empty UpdateExpression', () => ddb.send(new UpdateItemCommand({ TableName: H, Key: { pk: { S: 'em-upd-key-mod' } }, UpdateExpression: '' })))
+    await p('u_upd_rangekey', 'bespoke', 'cannot update range key', () => ddb.send(new UpdateItemCommand({ TableName: C, Key: { pk: { S: 'em-upd-range-mod' }, sk: { S: 'sk1' } }, UpdateExpression: 'SET sk = :v', ExpressionAttributeValues: { ':v': { S: 'new-sk' } } })))
+    // validation-ordering / N count
+    await p('o_put_empty_table_empty_item', 'ordering', "PutItem TableName='' Item={}", () => ddb.send(new PutItemCommand({ TableName: '', Item: {} })))
+    await p('o_put_empty_table_bad_rv', 'ordering', "PutItem TableName='' ReturnValues=INVALID", () => ddb.send(new PutItemCommand({ TableName: '', ReturnValues: 'INVALID', Item: {} })))
+    await p('o_put_three_bad_enums', 'ordering', 'PutItem 3 invalid enums', () => ddb.send(new PutItemCommand({ TableName: '_conformance_valid_table_name', Item: { pk: { S: 'test' } }, ReturnConsumedCapacity: 'INVALID', ReturnItemCollectionMetrics: 'INVALID', ReturnValues: 'INVALID' })))
+    await p('o_del_empty_table', 'ordering', "DeleteItem TableName='' Key={}", () => ddb.send(new DeleteItemCommand({ TableName: '', Key: {} })))
+    await p('o_del_two_bad_enums', 'ordering', 'DeleteItem 2 invalid enums', () => ddb.send(new DeleteItemCommand({ TableName: '_conformance_valid_table_name', Key: { pk: { S: 'test' } }, ReturnValues: 'INVALID', ReturnConsumedCapacity: 'INVALID' })))
+    await p('o_upd_empty_table', 'ordering', "UpdateItem TableName='' Key={}", () => ddb.send(new UpdateItemCommand({ TableName: '', Key: {} })))
+    await p('o_upd_two_bad_enums', 'ordering', 'UpdateItem 2 invalid enums', () => ddb.send(new UpdateItemCommand({ TableName: '_conformance_valid_table_name', Key: { pk: { S: 'test' } }, ReturnValues: 'INVALID', ReturnConsumedCapacity: 'INVALID' })))
+
+    // { NULL: false } round-trip
+    let nullRoundTrip
+    try {
+      await ddb.send(new PutItemCommand({ TableName: H, Item: { pk: { S: 'em-put-null-false' }, attr1: { NULL: false } } }))
+      const got = await ddb.send(new GetItemCommand({ TableName: H, Key: { pk: { S: 'em-put-null-false' } }, ConsistentRead: true }))
+      nullRoundTrip = { put: 'accepted', returnedItem: got.Item ?? null }
+    } catch (e) {
+      nullRoundTrip = { put: 'rejected', name: e?.name ?? null, message: e?.message ?? null }
+    }
+    return { region, probes, nullRoundTrip }
+  } finally {
+    for (const name of [H, C, CT3]) {
+      try {
+        await ddb.send(new DeleteTableCommand({ TableName: name }))
+      } catch {
+        // best-effort; CT3 and any never-created table will ResourceNotFound
+      }
+    }
+  }
+}
+
+async function main() {
+  const out = { capturedAt: new Date().toISOString(), regions: {} }
+  for (const region of regions) {
+    process.stderr.write(`capturing ${region}...\n`)
+    out.regions[region] = await captureRegion(region)
+  }
+  process.stdout.write(JSON.stringify(out, null, 2) + '\n')
+}
+
+main().catch((e) => {
+  console.error('CAPTURE FAILED:', e?.name, e?.message)
+  process.exit(1)
+})

--- a/tests/tier3/error-messages/putItem.test.ts
+++ b/tests/tier3/error-messages/putItem.test.ts
@@ -48,8 +48,15 @@ describe('PutItem — exact error messages', () => {
     } catch (err) {
       expect(err).toBeInstanceOf(DynamoDBServiceException)
       expect((err as DynamoDBServiceException).name).toBe('ValidationException')
-      expect((err as DynamoDBServiceException).message).toBe(
-        "1 validation error detected: Value at 'TableName' failed to satisfy constraint: Member must have length greater than or equal to 1",
+      // Structural assertion: pin the contractual field and constraint, float
+      // the envelope prefix, echoed value and field casing that AWS varies by
+      // region (2026-06 four-region capture; same idea as createTable's
+      // backend-variant handling). See CONTRIBUTING, "error-messages".
+      expect((err as DynamoDBServiceException).message.toLowerCase()).toContain(
+        "tablename",
+      )
+      expect((err as DynamoDBServiceException).message).toContain(
+        'failed to satisfy constraint: Member must have length greater than or equal to 1',
       )
     }
   })
@@ -102,8 +109,8 @@ describe('PutItem — exact error messages', () => {
     } catch (err) {
       expect(err).toBeInstanceOf(DynamoDBServiceException)
       expect((err as DynamoDBServiceException).name).toBe('ValidationException')
-      expect((err as DynamoDBServiceException).message).toBe(
-        '1 validation error detected: One or more parameter values were invalid: An string set  may not be empty',
+      expect((err as DynamoDBServiceException).message).toContain(
+        'One or more parameter values were invalid: An string set  may not be empty',
       )
     }
   })
@@ -120,8 +127,8 @@ describe('PutItem — exact error messages', () => {
     } catch (err) {
       expect(err).toBeInstanceOf(DynamoDBServiceException)
       expect((err as DynamoDBServiceException).name).toBe('ValidationException')
-      expect((err as DynamoDBServiceException).message).toBe(
-        '1 validation error detected: One or more parameter values were invalid: An number set  may not be empty',
+      expect((err as DynamoDBServiceException).message).toContain(
+        'One or more parameter values were invalid: An number set  may not be empty',
       )
     }
   })
@@ -138,9 +145,12 @@ describe('PutItem — exact error messages', () => {
     } catch (err) {
       expect(err).toBeInstanceOf(DynamoDBServiceException)
       expect((err as DynamoDBServiceException).name).toBe('ValidationException')
-      expect((err as DynamoDBServiceException).message).toBe(
-        '1 validation error detected: One or more parameter values were invalid: Input collection ["a", "a"] contains duplicates.',
+      // Float the collection rendering (["a", "a"] in newer regions, [a, a] in
+      // older ones); pin the bespoke message either side of it.
+      expect((err as DynamoDBServiceException).message).toContain(
+        'One or more parameter values were invalid: Input collection',
       )
+      expect((err as DynamoDBServiceException).message).toContain('contains duplicates')
     }
   })
 
@@ -181,8 +191,8 @@ describe('PutItem — exact error messages', () => {
     } catch (err) {
       expect(err).toBeInstanceOf(DynamoDBServiceException)
       expect((err as DynamoDBServiceException).name).toBe('ValidationException')
-      expect((err as DynamoDBServiceException).message).toBe(
-        '1 validation error detected: Can not use both expression and non-expression parameters in the same request: Non-expression parameters: {Expected} Expression parameters: {ConditionExpression}',
+      expect((err as DynamoDBServiceException).message).toContain(
+        'Can not use both expression and non-expression parameters in the same request: Non-expression parameters: {Expected} Expression parameters: {ConditionExpression}',
       )
     }
   })
@@ -200,8 +210,8 @@ describe('PutItem — exact error messages', () => {
     } catch (err) {
       expect(err).toBeInstanceOf(DynamoDBServiceException)
       expect((err as DynamoDBServiceException).name).toBe('ValidationException')
-      expect((err as DynamoDBServiceException).message).toBe(
-        '1 validation error detected: ExpressionAttributeValues can only be specified when using expressions',
+      expect((err as DynamoDBServiceException).message).toContain(
+        'ExpressionAttributeValues can only be specified when using expressions',
       )
     }
   })
@@ -219,8 +229,8 @@ describe('PutItem — exact error messages', () => {
     } catch (err) {
       expect(err).toBeInstanceOf(DynamoDBServiceException)
       expect((err as DynamoDBServiceException).name).toBe('ValidationException')
-      expect((err as DynamoDBServiceException).message).toBe(
-        '1 validation error detected: Invalid ConditionExpression: The expression has redundant parentheses;',
+      expect((err as DynamoDBServiceException).message).toContain(
+        'Invalid ConditionExpression: The expression has redundant parentheses;',
       )
     }
   })
@@ -239,8 +249,8 @@ describe('PutItem — exact error messages', () => {
     } catch (err) {
       expect(err).toBeInstanceOf(DynamoDBServiceException)
       expect((err as DynamoDBServiceException).name).toBe('ValidationException')
-      expect((err as DynamoDBServiceException).message).toBe(
-        '1 validation error detected: Invalid ConditionExpression: The first operand must be distinct from the remaining operands for this operator or function; operator: contains, first operand: [data]',
+      expect((err as DynamoDBServiceException).message).toContain(
+        'Invalid ConditionExpression: The first operand must be distinct from the remaining operands for this operator or function; operator: contains, first operand: [data]',
       )
     }
   })

--- a/tests/tier3/error-messages/updateItem.test.ts
+++ b/tests/tier3/error-messages/updateItem.test.ts
@@ -58,8 +58,11 @@ describe('UpdateItem — exact error messages', () => {
     } catch (err) {
       expect(err).toBeInstanceOf(DynamoDBServiceException)
       expect((err as DynamoDBServiceException).name).toBe('ValidationException')
-      expect((err as DynamoDBServiceException).message).toBe(
-        '1 validation error detected: Invalid UpdateExpression: Syntax error; token: "INVALID", near: "INVALID SYNTAX"',
+      // Structural: pin the contractual constraint, float the "N validation
+      // error detected:" envelope AWS adds in some regions and not others
+      // (2026-06 four-region capture). See CONTRIBUTING, "error-messages".
+      expect((err as DynamoDBServiceException).message).toContain(
+        'Invalid UpdateExpression: Syntax error; token: "INVALID", near: "INVALID SYNTAX"',
       )
     }
   })
@@ -79,8 +82,8 @@ describe('UpdateItem — exact error messages', () => {
     } catch (err) {
       expect(err).toBeInstanceOf(DynamoDBServiceException)
       expect((err as DynamoDBServiceException).name).toBe('ValidationException')
-      expect((err as DynamoDBServiceException).message).toBe(
-        '1 validation error detected: Value provided in ExpressionAttributeNames unused in expressions: keys: {#unused}',
+      expect((err as DynamoDBServiceException).message).toContain(
+        'Value provided in ExpressionAttributeNames unused in expressions: keys: {#unused}',
       )
     }
   })
@@ -99,8 +102,8 @@ describe('UpdateItem — exact error messages', () => {
     } catch (err) {
       expect(err).toBeInstanceOf(DynamoDBServiceException)
       expect((err as DynamoDBServiceException).name).toBe('ValidationException')
-      expect((err as DynamoDBServiceException).message).toBe(
-        '1 validation error detected: Value provided in ExpressionAttributeValues unused in expressions: keys: {:unused}',
+      expect((err as DynamoDBServiceException).message).toContain(
+        'Value provided in ExpressionAttributeValues unused in expressions: keys: {:unused}',
       )
     }
   })
@@ -118,8 +121,8 @@ describe('UpdateItem — exact error messages', () => {
     } catch (err) {
       expect(err).toBeInstanceOf(DynamoDBServiceException)
       expect((err as DynamoDBServiceException).name).toBe('ValidationException')
-      expect((err as DynamoDBServiceException).message).toBe(
-        '1 validation error detected: Invalid UpdateExpression: An expression attribute value used in expression is not defined; attribute value: :v',
+      expect((err as DynamoDBServiceException).message).toContain(
+        'Invalid UpdateExpression: An expression attribute value used in expression is not defined; attribute value: :v',
       )
     }
   })
@@ -141,8 +144,8 @@ describe('UpdateItem — exact error messages', () => {
     } catch (err) {
       expect(err).toBeInstanceOf(DynamoDBServiceException)
       expect((err as DynamoDBServiceException).name).toBe('ValidationException')
-      expect((err as DynamoDBServiceException).message).toBe(
-        '1 validation error detected: Can not use both expression and non-expression parameters in the same request: Non-expression parameters: {AttributeUpdates} Expression parameters: {UpdateExpression}',
+      expect((err as DynamoDBServiceException).message).toContain(
+        'Can not use both expression and non-expression parameters in the same request: Non-expression parameters: {AttributeUpdates} Expression parameters: {UpdateExpression}',
       )
     }
   })
@@ -160,8 +163,8 @@ describe('UpdateItem — exact error messages', () => {
     } catch (err) {
       expect(err).toBeInstanceOf(DynamoDBServiceException)
       expect((err as DynamoDBServiceException).name).toBe('ValidationException')
-      expect((err as DynamoDBServiceException).message).toBe(
-        '1 validation error detected: Invalid UpdateExpression: The expression can not be empty;',
+      expect((err as DynamoDBServiceException).message).toContain(
+        'Invalid UpdateExpression: The expression can not be empty;',
       )
     }
   })


### PR DESCRIPTION
## What this changes

Follow-up to #24. That PR re-pinned the Tier 3 error-message tests to eu-west-2's new wording exactly; this one corrects the approach. The tests now assert the *contract* an error carries - its type, the field it objects to, and the constraint - rather than the exact prose, because AWS turns out to vary the prose by region, and the prose was never part of the contract the API model defines.

The line between exact and structural is drawn from a four-region capture, not from eu-west-2 alone: eu-west-2 and eu-central-1 returned the new wording, us-east-1 and ap-southeast-2 still returned the old, and every reworded assertion now pins only what is invariant across all four. The envelope, the echoed input value and the field casing are floated. Genuinely behavioural divergences stay pinned exactly - `{ NULL: false }` being accepted, and UpdateItem stopping at the first invalid enum.

This is a correction, not a loosening: it puts the bar where the model's contract actually is. `createTable.test.ts` already did exactly this for a backend-dependent wording variant; the change extends that pattern across the family.

Also in here:

- The throwaway capture harness is promoted to a committed, repeatable multi-region script (`scripts/capture-validation-messages.mjs`), with the dated June snapshot recorded in `captures/`.
- `CONTRIBUTING` documents the exact-where-stable / structural-where-non-deterministic rule.
- A `CHANGELOG` note, because this moves some public numbers (see Tier and scope).
- Version bump to 1.3.0.

## Checklist

- [x] New or modified tests run against real AWS DynamoDB and pass (107 Tier 3 error-message and validation-ordering tests against eu-west-2)
- [ ] New or modified tests run against at least one emulator target and behave as expected - not run live this pass; region-robustness was confirmed from the four-region capture (the old-format regions match the emulators' old wording), and the emulator jobs on this PR exercise it directly.
- [x] Linked issue or a short note explaining the motivation - follow-up to #24; the AWS rewording it recovered from turned out to be regional, so Tier 3 now asserts the region-invariant contract rather than one region's prose.

## Tier and scope

Touches Tier 3 assertion strictness, not the results pipeline or the scoring logic. Expect emulator Tier 3 numbers to **rise**: targets that were only ever marked down for wording DynamoDB renders inconsistently now pass those checks, because the suite has stopped counting a cosmetic difference as a behavioural one. Dynoxide returns to passing them; LocalStack and DynamoDB Local rise from roughly 69% on the wording-only failures. The `CHANGELOG` entry discloses this so it doesn't read as quiet goalpost-shifting.
