### PR TITLE
ci: make the weekly scheduled run trustworthy

### DIFF
--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -32,6 +32,7 @@ jobs:
     permissions:
       id-token: write
       contents: read
+      issues: write # file/update a scheduled-red issue on a deterministic failure
     environment: conformance-testing
 
     steps:
@@ -50,11 +51,14 @@ jobs:
           aws-region: eu-west-2
           role-duration-seconds: 7200
 
-      - name: Run conformance suite (excludes GSI lifecycle — see README)
+      - name: Run gating conformance suite (excludes GSI lifecycle and cloud-only ops — see README)
         env:
           CONFORMANCE_TARGET: dynamodb
           AWS_REGION: eu-west-2
-        run: npm run test:quick
+          # Absorb transient flakes on the one gating job. Real drift fails
+          # deterministically and survives the retry; a one-off throttle passes.
+          CONFORMANCE_RETRY: '1'
+        run: npm run test:gating
 
       - name: Sanitize account IDs
         if: always()
@@ -79,6 +83,101 @@ jobs:
         uses: actions/upload-artifact@v7
         with:
           name: results-dynamodb
+          path: results/
+
+      # A scheduled red survived the retry, so it is deterministic: either real
+      # AWS drift to re-characterise or a flake the retry missed. File or update a
+      # single deduped issue so it is actionable, not a silent X. A later
+      # cross-region drift signal will label the verdict at the body's triage slot.
+      - name: Report a deterministic failure as an issue
+        if: failure() && github.event_name == 'schedule'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          node scripts/report-failure.mjs results/dynamodb.json "$RUN_URL" > "$RUNNER_TEMP/issue-body.md"
+          gh label create scheduled-red --color B60205 \
+            --description "Scheduled conformance run went red" 2>/dev/null || true
+          existing=$(gh issue list --label scheduled-red --state open \
+            --json number --jq '.[0].number // empty')
+          if [ -n "$existing" ]; then
+            gh issue comment "$existing" --body-file "$RUNNER_TEMP/issue-body.md"
+          else
+            gh issue create --label scheduled-red \
+              --title "Scheduled conformance run went red ($(date -u +%Y-%m-%d))" \
+              --body-file "$RUNNER_TEMP/issue-body.md"
+          fi
+
+  test-dynamodb-cloud-only:
+    name: DynamoDB cloud-only (non-gating)
+    # The S3 export/import and Kinesis streaming-destination suites depend on slow
+    # async AWS control-plane operations and are skipped by every emulator (no
+    # emulator implements them), so they give zero comparative signal but carry
+    # real flake risk. They run here, off the gating path, so a slow import can
+    # never red the build. continue-on-error keeps the whole lane non-gating.
+    #
+    # The suite shares one AWS account and cleanup deletes every _conformance_
+    # table by prefix, so this lane must not run alongside the gating job or they
+    # delete each other's tables (this lane's import targets are exactly what the
+    # gating cleanup would nuke mid-import). `needs` orders it after the gating
+    # job *within a run* — explicit, not relying on same-run concurrency
+    # semantics — and `always()` keeps it running even when the gate goes red.
+    # The shared conformance-aws group below additionally serialises against
+    # *other* runs (an overlapping push or schedule), matching the gating job.
+    needs: test-dynamodb
+    if: always() && (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch')
+    continue-on-error: true
+    runs-on: ubuntu-latest
+    concurrency:
+      group: conformance-aws
+      cancel-in-progress: false
+    permissions:
+      id-token: write
+      contents: read
+    environment: conformance-testing
+
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 24
+          cache: npm
+
+      - run: npm ci
+
+      - name: Configure AWS credentials via OIDC
+        uses: aws-actions/configure-aws-credentials@v6
+        with:
+          role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
+          aws-region: eu-west-2
+          role-duration-seconds: 7200
+
+      - name: Run cloud-only conformance suite (S3 export/import, Kinesis)
+        continue-on-error: true
+        env:
+          CONFORMANCE_TARGET: dynamodb
+          AWS_REGION: eu-west-2
+        run: npm run test:cloud-only
+
+      - name: Sanitize account IDs
+        if: always()
+        run: node scripts/sanitize-arns.mjs
+
+      - name: Cleanup conformance tables
+        if: always()
+        timeout-minutes: 3
+        run: |
+          aws dynamodb list-tables --query "TableNames[?starts_with(@, '_conformance_')]" --output text | \
+          tr '\t' '\n' | \
+          xargs -P4 -I{} aws dynamodb delete-table --table-name {} 2>/dev/null || true
+
+      # Uploaded under a non `results-*` name so the Update Results Table overlay
+      # (which globs results-*) never folds this into the published comparison.
+      - name: Upload cloud-only results
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: cloud-only-results
           path: results/
 
   test-dynamodb-local:

--- a/README.md
+++ b/README.md
@@ -174,7 +174,7 @@ npm test
 
 The full suite includes 11 UpdateTable GSI lifecycle tests that add and remove Global Secondary Indexes from existing tables. On real DynamoDB, each GSI creation triggers a backfill that takes 5-15 minutes even on empty tables. These tests are important for conformance but they dominate runtime against real AWS.
 
-`test:quick` excludes the GSI lifecycle tests for faster iteration. CI uses `test:quick` for the real DynamoDB job to save billable AWS time. Emulator targets run the full `npm test` since GSI creation is instant locally. If you're modifying GSI-related code, run the full suite against real DynamoDB manually before merging.
+`test:quick` excludes the GSI lifecycle tests for faster local iteration. CI's gating real-DynamoDB job runs `test:gating`, which drops the GSI lifecycle tests *and* the cloud-only S3 and Kinesis suites (see "Cloud-only operations" below), so a slow async import can't redden the build. Those cloud-only suites still run against real AWS in a separate non-gating job via `npm run test:cloud-only`. Emulator targets run the full `npm test` since GSI creation is instant locally. If you're modifying GSI-related code, run the full suite against real DynamoDB manually before merging.
 
 ## Design principles
 
@@ -303,13 +303,23 @@ All test data must be synthetic. Don't use real names, emails, addresses, or any
 | TagResource | | add, list, remove, validation | |
 | DynamoDB Streams | | ListStreams, DescribeStream, GetRecords, view types | |
 
-### Not covered (cloud-only)
+### Cloud-only operations
+
+Some operations only exist on real AWS - no emulator implements them - so they
+can't sit in the comparison table, since every emulator would just skip them.
+Two are exercised against real DynamoDB anyway, in a separate non-gating CI job,
+because characterising AWS's own behaviour still has value:
+
+- Import/Export to S3
+- Kinesis Data Streams integration (streaming destinations)
+
+These run via `npm run test:cloud-only` and never gate the build - they lean on
+slow async control-plane calls that make poor gate material. The rest aren't
+covered at all:
 
 - Global Tables
 - Backups and Point-in-Time Recovery
 - DynamoDB Accelerator (DAX)
-- Kinesis Data Streams integration
-- Import/Export to S3
 - Table Class (Standard/Standard-IA)
 - Contributor Insights
 

--- a/package.json
+++ b/package.json
@@ -6,6 +6,8 @@
   "scripts": {
     "test": "vitest run",
     "test:quick": "vitest run --exclude 'tests/tier2/updateTable/gsi.test.ts'",
+    "test:gating": "vitest run --exclude 'tests/tier2/updateTable/gsi.test.ts' --exclude 'tests/tier2/export/exportImport.test.ts' --exclude 'tests/tier2/kinesis/streamingDestination.test.ts'",
+    "test:cloud-only": "vitest run tests/tier2/export/exportImport.test.ts tests/tier2/kinesis/streamingDestination.test.ts",
     "test:watch": "vitest",
     "test:tier1": "vitest run --include 'tests/tier1/**/*.test.ts'",
     "test:tier2": "vitest run --include 'tests/tier2/**/*.test.ts'",

--- a/scripts/report-failure.mjs
+++ b/scripts/report-failure.mjs
@@ -1,0 +1,88 @@
+#!/usr/bin/env node
+
+/**
+ * Format a GitHub issue body from a Vitest JSON report's failed assertions.
+ *
+ * Usage:
+ *   node scripts/report-failure.mjs results/dynamodb.json <run-url> > body.md
+ *
+ * The scheduled-run workflow calls this on a deterministic ground-truth failure
+ * (after retries) and threads the output onto a single deduped issue, so a red
+ * Monday is actionable rather than a silent X. The formatting lives in pure
+ * functions (collectFailures / buildIssueBody) so they can be unit-tested once a
+ * scripts/ tooling-test harness exists. A later cross-region drift signal will
+ * fill in the drift-versus-flake verdict at the triage slot.
+ */
+
+import { readFileSync } from 'node:fs'
+
+/** Pull failed assertions out of a Vitest JSON report. */
+export function collectFailures(report) {
+  const out = []
+  for (const tr of report?.testResults ?? []) {
+    for (const ar of tr?.assertionResults ?? []) {
+      if (ar?.status !== 'failed') continue
+      const name =
+        ar.fullName ||
+        [...(ar.ancestorTitles ?? []), ar.title].filter(Boolean).join(' > ')
+      const detail = (ar.failureMessages ?? [])[0]?.split('\n')[0]?.trim() ?? ''
+      out.push({ file: tr.name, name, detail })
+    }
+  }
+  return out
+}
+
+/** Build the Markdown issue body. `report` may be null when parsing failed. */
+export function buildIssueBody(report, runUrl) {
+  const lines = []
+  lines.push('The scheduled `Conformance Tests` ground-truth run went red after retries.')
+  lines.push('')
+  if (runUrl) lines.push(`Run: ${runUrl}`)
+  lines.push('')
+
+  if (!report) {
+    lines.push('The Vitest report could not be read or parsed, so the failure was')
+    lines.push('likely in setup/teardown or the runner itself. See the run log.')
+    return lines.join('\n')
+  }
+
+  const failures = collectFailures(report)
+  if (failures.length === 0) {
+    lines.push('No failed assertions are present in the report, so the failure was')
+    lines.push('likely in a `beforeAll`/`afterAll` hook or infrastructure rather than')
+    lines.push('a test body. See the run log.')
+  } else {
+    lines.push(`**${failures.length} failed test${failures.length === 1 ? '' : 's'}:**`)
+    lines.push('')
+    for (const f of failures) {
+      lines.push(`- \`${f.name}\``)
+      if (f.detail) lines.push(`  - ${f.detail}`)
+    }
+  }
+
+  lines.push('')
+  lines.push('<!-- triage-slot -->')
+  lines.push(
+    '_Triage: a deterministic red here is either real AWS drift (re-characterise ' +
+      'against current AWS) or a flake the retry did not catch. The drift metric ' +
+      'will label this automatically once it lands._',
+  )
+  return lines.join('\n')
+}
+
+function main() {
+  const [reportPath, runUrl = ''] = process.argv.slice(2)
+  if (!reportPath) {
+    console.error('usage: report-failure.mjs <vitest-json> <run-url>')
+    process.exit(1)
+  }
+  let report = null
+  try {
+    report = JSON.parse(readFileSync(reportPath, 'utf8'))
+  } catch {
+    // Leave report null; buildIssueBody emits the could-not-parse body.
+  }
+  process.stdout.write(buildIssueBody(report, runUrl) + '\n')
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) main()

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -9,6 +9,16 @@ export default defineConfig({
     globals: true,
     testTimeout: 30_000,
     hookTimeout: 180_000,
+    // Bounded retry, opt-in via CONFORMANCE_RETRY (set only on the real-AWS
+    // gating job). Off everywhere else: emulators are deterministic and instant,
+    // so retrying them would only mask real emulator bugs as flakes. Genuine AWS
+    // drift fails deterministically and survives the retry (stays red); a
+    // transient throttle or slow-settling read passes on the re-run. This covers
+    // test bodies only - vitest does not retry beforeAll, so shared-table
+    // provisioning flakes stay owned by hookTimeout, not this. Re-runs reuse the
+    // singleFork worker against the shared tables, which is safe because each
+    // test cleans up after itself; don't raise the bound blindly.
+    retry: Number(process.env.CONFORMANCE_RETRY ?? 0),
     // singleFork is a CORRECTNESS requirement, not just performance.
     // Table definitions are resolved at module load time and shared by reference
     // across test files. Parallel execution would cause table contention.


### PR DESCRIPTION
## What this changes

The weekly scheduled conformance run has gone red three Mondays running, each for a different reason - a provisioning timeout, the real-AWS validation-message drift (fixed in #25), and last Monday an S3 `ImportTable` that didn't finish inside its 270s poll. Only the `DynamoDB (ground truth)` job can fail the build, so one slow async call against real AWS reddens everything. And because `Update Results Table` only runs on a green scheduled run, that flake also quietly skipped the results-table refresh. Noise was suppressing signal.

This makes the gate trustworthy:

- **Cloud-only ops come off the gate.** The S3 export/import and Kinesis streaming-destination suites always skip on emulators (nothing else implements them), so they gave no comparative signal but carried real flake risk. They now run via `npm run test:cloud-only` in a separate non-gating job; the gate runs `npm run test:gating`, which drops them and the GSI lifecycle tests. The new lane runs after the gating job (`needs`) and shares the `conformance-aws` concurrency group, so the two AWS jobs can't race the by-prefix table cleanup. This also reconciles the README, which already listed Import/Export to S3 under "not covered".
- **A bounded, real-AWS-only retry.** Opt-in via `CONFORMANCE_RETRY`, set to 1 only on the gating job. Genuine drift fails deterministically and survives the retry (stays red); a one-off throttle or slow-settling read passes on the re-run. Off for emulators and local runs, where a retry would only mask real bugs.
- **A red that's actionable.** When a scheduled run goes red after the retry - so, deterministically - the workflow files or updates a single deduped `scheduled-red` issue listing the failed tests, instead of a silent X. There's a triage slot in the body for a later drift signal to fill in.

This is the first of two related changes; cross-region drift detection, which becomes the gate's drift-versus-flake triage, follows separately.

## Checklist

- ~~New or modified tests run against real AWS DynamoDB and pass~~ - no test files change; this is CI/runner config plus a reporting script. The gating behaviour validates on the first scheduled run (see below).
- ~~New or modified tests run against at least one emulator target and behave as expected~~ - same; emulator jobs are untouched, and the carved-out suites already skip on every emulator.
- ~~If AI tools drafted or materially shaped this change, disclosed in the description above~~
- [x] Linked issue or a short note explaining the motivation - three consecutive red scheduled runs (01, 08, 15 Jun); no tracking issue, since auto-filing one is part of this change.

## Tier and scope

No tier definitions or scoring change, and no score movement is expected: the cloud-only suites were already skips for every emulator, the ground-truth row is synthesised at 100%, and the cloud-only job's artefact uploads under a name the results-table overlay ignores. The README "Cloud-only operations" section is reworded to match.

## Testing

Everything checkable off-CI is green: `tsc` and `actionlint` clean; the gating/cloud-only file selection verified with `vitest list` (the gate excludes gsi/export/kinesis, cloud-only includes exactly the two); the retry config resolves (unset to 0, `1` to 1) and vitest loads it; and the failure-report script verified against a passing report, a synthetic failing one, and a missing file. The suite's gating behaviour itself only manifests against real AWS, so it validates on the first run.

## Post-Deploy Monitoring & Validation

- **Validate now:** run the workflow via `workflow_dispatch`. Confirm the gating job runs `test:gating` (no export/import/kinesis in its output), the cloud-only lane starts only after the gating job finishes, and a failure in the cloud-only lane leaves the run green.
- **Next Monday's scheduled run:** green if there's no real drift; the cloud-only lane runs separately; the results table refreshes on success.
- **Healthy signals:** gating job green, results-table commit lands, no `scheduled-red` issue.
- **Failure signals and triggers:** gating job still red on an import timeout means the carve-out didn't take (revert); a `ResourceNotFoundException` in a cleanup step means the two AWS jobs ran concurrently and raced (check the `needs` ordering). On a genuine drift, expect exactly one `scheduled-red` issue.
- **Window / owner:** Martin, through the first scheduled run after merge.
