### PR TITLE
feat: cross-region drift detection and scheduled-run triage

### DIFF
--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -260,11 +260,16 @@ jobs:
             echo "Cross-region capture unchanged."
           else
             git commit -m "chore: update cross-region capture [skip ci]"
+            pushed=0
             for i in 1 2 3; do
-              git pull --rebase && git push && break
+              if git pull --rebase && git push; then pushed=1; break; fi
               echo "push attempt $i failed; retrying"
               sleep 5
             done
+            if [ "$pushed" -ne 1 ]; then
+              echo "::warning title=Cross-region capture::push failed after 3 attempts; this week's capture was not persisted"
+              exit 1
+            fi
           fi
 
   test-dynamodb-local:

--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -51,7 +51,7 @@ jobs:
           aws-region: eu-west-2
           role-duration-seconds: 7200
 
-      - name: Run gating conformance suite (excludes GSI lifecycle and cloud-only ops — see README)
+      - name: Run gating conformance suite (excludes GSI lifecycle and integration suites — see README)
         env:
           CONFORMANCE_TARGET: dynamodb
           AWS_REGION: eu-west-2
@@ -136,22 +136,15 @@ jobs:
               --body-file "$RUNNER_TEMP/issue-body.md"
           fi
 
-  test-dynamodb-cloud-only:
-    name: DynamoDB cloud-only (non-gating)
-    # The S3 export/import and Kinesis streaming-destination suites depend on slow
-    # async AWS control-plane operations and are skipped by every emulator (no
-    # emulator implements them), so they give zero comparative signal but carry
-    # real flake risk. They run here, off the gating path, so a slow import can
-    # never red the build. continue-on-error keeps the whole lane non-gating.
-    #
-    # The suite shares one AWS account and cleanup deletes every _conformance_
-    # table by prefix, so this lane must not run alongside the gating job or they
-    # delete each other's tables (this lane's import targets are exactly what the
-    # gating cleanup would nuke mid-import). `needs` orders it after the gating
-    # job *within a run* — explicit, not relying on same-run concurrency
-    # semantics — and `always()` keeps it running even when the gate goes red.
-    # The shared conformance-aws group below additionally serialises against
-    # *other* runs (an overlapping push or schedule), matching the gating job.
+  test-dynamodb-integrations:
+    name: DynamoDB service integrations (non-gating)
+    # DynamoDB's integrations with other AWS services (S3 export/import, Kinesis
+    # streaming destinations). No emulator implements them, so they can't be
+    # compared, and they lean on slow async calls - so they run off the gating
+    # path and continue-on-error, where a slow import can't red the build.
+    # `needs` plus the shared conformance-aws group serialise this against the
+    # gating job so the two don't race the by-prefix table cleanup; `always()`
+    # keeps it running even when the gate is red.
     needs: test-dynamodb
     if: always() && (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch')
     continue-on-error: true
@@ -180,12 +173,12 @@ jobs:
           aws-region: eu-west-2
           role-duration-seconds: 7200
 
-      - name: Run cloud-only conformance suite (S3 export/import, Kinesis)
+      - name: Run service-integration suite (S3 export/import, Kinesis)
         continue-on-error: true
         env:
           CONFORMANCE_TARGET: dynamodb
           AWS_REGION: eu-west-2
-        run: npm run test:cloud-only
+        run: npm run test:integrations
 
       - name: Sanitize account IDs
         if: always()
@@ -201,11 +194,11 @@ jobs:
 
       # Uploaded under a non `results-*` name so the Update Results Table overlay
       # (which globs results-*) never folds this into the published comparison.
-      - name: Upload cloud-only results
+      - name: Upload integration results
         if: always()
         uses: actions/upload-artifact@v7
         with:
-          name: cloud-only-results
+          name: integration-results
           path: results/
 
   capture-cross-region:

--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -208,6 +208,65 @@ jobs:
           name: cloud-only-results
           path: results/
 
+  capture-cross-region:
+    name: Cross-region drift capture (non-gating)
+    # Capture real AWS's negative-input wording in the candidate regions each
+    # week and commit it, so the paritysuite drift lens has fresh, versioned data
+    # (the site builds from committed files, not CI artefacts). Non-gating: a
+    # capture hiccup never touches the build. Only candidate regions are
+    # captured, never eu-west-2: the IAM role forces a _conformance_ table prefix
+    # that the gating job's cleanup deletes, so an eu-west-2 capture here would
+    # race that cleanup. The lens diffs these against the committed eu-west-2
+    # baseline; the scheduled-run drift verdict flags when the baseline itself
+    # needs refreshing.
+    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+    continue-on-error: true
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: write
+    environment: conformance-testing
+
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: main
+          fetch-depth: 0
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 24
+          cache: npm
+
+      - run: npm ci
+
+      - name: Configure AWS credentials via OIDC
+        uses: aws-actions/configure-aws-credentials@v6
+        with:
+          role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
+          aws-region: eu-west-2
+          role-duration-seconds: 7200
+
+      - name: Capture candidate regions
+        run: |
+          node scripts/capture-validation-messages.mjs us-east-1 ap-southeast-2 eu-central-1 \
+            > captures/cross-region-latest.json
+
+      - name: Commit the capture
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add captures/cross-region-latest.json
+          if git diff --staged --quiet; then
+            echo "Cross-region capture unchanged."
+          else
+            git commit -m "chore: update cross-region capture [skip ci]"
+            for i in 1 2 3; do
+              git pull --rebase && git push && break
+              echo "push attempt $i failed; retrying"
+              sleep 5
+            done
+          fi
+
   test-dynamodb-local:
     name: DynamoDB Local
     continue-on-error: true

--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -86,24 +86,52 @@ jobs:
           path: results/
 
       # A scheduled red survived the retry, so it is deterministic: either real
-      # AWS drift to re-characterise or a flake the retry missed. File or update a
-      # single deduped issue so it is actionable, not a silent X. A later
-      # cross-region drift signal will label the verdict at the body's triage slot.
+      # AWS drift or a flake the retry missed. Re-capture eu-west-2's raw wording
+      # and diff it against the committed baseline so the failure can be labelled
+      # drift-versus-flake. continue-on-error: a capture hiccup must not block the
+      # issue - the reporter falls back to a generic triage note without a verdict.
+      - name: Compute the drift verdict
+        if: failure() && github.event_name == 'schedule'
+        continue-on-error: true
+        env:
+          AWS_REGION: eu-west-2
+        run: |
+          node scripts/capture-validation-messages.mjs eu-west-2 > "$RUNNER_TEMP/euw2.json"
+          node scripts/drift-diff.mjs "$RUNNER_TEMP/euw2.json" \
+            --baseline captures/2026-06-09-validation-rewording.json \
+            --region eu-west-2 --out "$RUNNER_TEMP/drift.json"
+
+      # File or update a single deduped issue so a red Monday is actionable, not a
+      # silent X. The drift verdict (if computed above) labels it aws-drift-confirmed
+      # or likely-flake and fills the body's triage slot.
       - name: Report a deterministic failure as an issue
         if: failure() && github.event_name == 'schedule'
         env:
           GH_TOKEN: ${{ github.token }}
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         run: |
-          node scripts/report-failure.mjs results/dynamodb.json "$RUN_URL" > "$RUNNER_TEMP/issue-body.md"
-          gh label create scheduled-red --color B60205 \
-            --description "Scheduled conformance run went red" 2>/dev/null || true
+          drift_args=()
+          if [ -f "$RUNNER_TEMP/drift.json" ]; then
+            drift_args=(--drift "$RUNNER_TEMP/drift.json" --verdict-out "$RUNNER_TEMP/verdict.txt")
+          fi
+          node scripts/report-failure.mjs results/dynamodb.json "$RUN_URL" "${drift_args[@]}" > "$RUNNER_TEMP/issue-body.md"
+
+          gh label create scheduled-red       --color B60205 --description "Scheduled conformance run went red" 2>/dev/null || true
+          gh label create aws-drift-confirmed  --color 5319E7 --description "Scheduled red is confirmed AWS wording drift" 2>/dev/null || true
+          gh label create likely-flake         --color FBCA04 --description "Scheduled red shows no wording drift; likely transient" 2>/dev/null || true
+
+          labels="scheduled-red"
+          if [ -f "$RUNNER_TEMP/verdict.txt" ]; then
+            labels="$labels,$(cat "$RUNNER_TEMP/verdict.txt")"
+          fi
+
           existing=$(gh issue list --label scheduled-red --state open \
             --json number --jq '.[0].number // empty')
           if [ -n "$existing" ]; then
+            gh issue edit "$existing" --add-label "$labels" >/dev/null
             gh issue comment "$existing" --body-file "$RUNNER_TEMP/issue-body.md"
           else
-            gh issue create --label scheduled-red \
+            gh issue create --label "$labels" \
               --title "Scheduled conformance run went red ($(date -u +%Y-%m-%d))" \
               --body-file "$RUNNER_TEMP/issue-body.md"
           fi

--- a/README.md
+++ b/README.md
@@ -174,7 +174,7 @@ npm test
 
 The full suite includes 11 UpdateTable GSI lifecycle tests that add and remove Global Secondary Indexes from existing tables. On real DynamoDB, each GSI creation triggers a backfill that takes 5-15 minutes even on empty tables. These tests are important for conformance but they dominate runtime against real AWS.
 
-`test:quick` excludes the GSI lifecycle tests for faster local iteration. CI's gating real-DynamoDB job runs `test:gating`, which drops the GSI lifecycle tests *and* the cloud-only S3 and Kinesis suites (see "Cloud-only operations" below), so a slow async import can't redden the build. Those cloud-only suites still run against real AWS in a separate non-gating job via `npm run test:cloud-only`. Emulator targets run the full `npm test` since GSI creation is instant locally. If you're modifying GSI-related code, run the full suite against real DynamoDB manually before merging.
+`test:quick` excludes the GSI lifecycle tests for faster local iteration. CI's gating real-DynamoDB job runs `test:gating`, which drops the GSI lifecycle tests *and* the S3 and Kinesis integration suites (see "Operations no emulator implements" below), so a slow async import can't redden the build. Those integration suites still run against real AWS in a separate non-gating job via `npm run test:integrations`. Emulator targets run the full `npm test` since GSI creation is instant locally. If you're modifying GSI-related code, run the full suite against real DynamoDB manually before merging.
 
 ## Design principles
 
@@ -303,18 +303,18 @@ All test data must be synthetic. Don't use real names, emails, addresses, or any
 | TagResource | | add, list, remove, validation | |
 | DynamoDB Streams | | ListStreams, DescribeStream, GetRecords, view types | |
 
-### Cloud-only operations
+### Operations no emulator implements
 
-Some operations only exist on real AWS - no emulator implements them - so they
-can't sit in the comparison table, since every emulator would just skip them.
-Two are exercised against real DynamoDB anyway, in a separate non-gating CI job,
-because characterising AWS's own behaviour still has value:
+Some operations only exist on real AWS, so they can't sit in the comparison
+table - every emulator just skips them. Two are integrations with other AWS
+services, exercised against real DynamoDB anyway (in a separate non-gating CI
+job) because characterising AWS's own behaviour still has value:
 
 - Import/Export to S3
 - Kinesis Data Streams integration (streaming destinations)
 
-These run via `npm run test:cloud-only` and never gate the build - they lean on
-slow async control-plane calls that make poor gate material. The rest aren't
+These run via `npm run test:integrations` and never gate the build - they lean
+on slow async control-plane calls that make poor gate material. The rest aren't
 covered at all:
 
 - Global Tables

--- a/captures/README.md
+++ b/captures/README.md
@@ -14,6 +14,19 @@ AWS_PROFILE=conformance-test node scripts/capture-validation-messages.mjs > capt
 
 It creates and deletes two temporary `_conformance_` tables per region.
 
+## cross-region-latest.json
+
+The latest capture of the candidate regions (`us-east-1`, `ap-southeast-2`,
+`eu-central-1`), refreshed weekly by the `capture-cross-region` job in
+`.github/workflows/conformance.yml` and committed back with `[skip ci]`. It
+feeds the paritysuite.org regional-drift lens, which diffs each region's raw
+wording against the committed eu-west-2 baseline. eu-west-2 itself is not in
+here - the IAM role forces a `_conformance_` table prefix that the gating job's
+cleanup deletes, so capturing eu-west-2 in that job would race the cleanup; the
+baseline lives in the dated snapshot below instead, and the scheduled-run drift
+verdict flags when it needs refreshing. Currently seeded from the 2026-06-09
+capture until the first scheduled run overwrites it.
+
 ## 2026-06-09-validation-rewording.json
 
 Real DynamoDB reworded a chunk of its validation errors. Four regions captured:

--- a/captures/cross-region-latest.json
+++ b/captures/cross-region-latest.json
@@ -1,0 +1,995 @@
+{
+  "capturedAt": "2026-06-09",
+  "note": "Seeded from the 2026-06-09 four-region capture; the capture-cross-region CI job overwrites this weekly with a fresh capture of the candidate regions.",
+  "regions": {
+    "us-east-1": {
+      "probes": [
+        {
+          "id": "s_put_table_null",
+          "family": "echo-scalar",
+          "note": "PutItem TableName=undefined",
+          "threw": true,
+          "name": "ValidationException",
+          "message": "1 validation error detected: Value null at 'tableName' failed to satisfy constraint: Member must not be null",
+          "n": 1,
+          "fields": [
+            "tableName"
+          ]
+        },
+        {
+          "id": "s_put_table_empty",
+          "family": "echo-scalar",
+          "note": "PutItem TableName='' (empty echo)",
+          "threw": true,
+          "name": "ValidationException",
+          "message": "1 validation error detected: Value '' at 'tableName' failed to satisfy constraint: Member must have length greater than or equal to 1",
+          "n": 1,
+          "fields": [
+            "tableName"
+          ]
+        },
+        {
+          "id": "s_put_table_long",
+          "family": "echo-scalar",
+          "note": "PutItem TableName='a'*256",
+          "threw": true,
+          "name": "ValidationException",
+          "message": "1 validation error detected: Value 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa' at 'tableName' failed to satisfy constraint: Member must have length less than or equal to 255",
+          "n": 1,
+          "fields": [
+            "tableName"
+          ]
+        },
+        {
+          "id": "s_put_table_badchars",
+          "family": "echo-scalar",
+          "note": "PutItem TableName='bad table!@#'",
+          "threw": true,
+          "name": "ValidationException",
+          "message": "1 validation error detected: Value 'bad table!@#' at 'tableName' failed to satisfy constraint: Member must satisfy regular expression pattern: [a-zA-Z0-9_.-]+",
+          "n": 1,
+          "fields": [
+            "tableName"
+          ]
+        },
+        {
+          "id": "s_ct_table_short",
+          "family": "echo-scalar",
+          "note": "CreateTable TableName='ab'",
+          "threw": true,
+          "name": "ValidationException",
+          "message": "1 validation error detected: Value 'ab' at 'tableName' failed to satisfy constraint: Member must have length greater than or equal to 3",
+          "n": 1,
+          "fields": [
+            "tableName"
+          ]
+        },
+        {
+          "id": "c_bw_over25",
+          "family": "echo-collection",
+          "note": "BatchWrite 26 requests",
+          "threw": true,
+          "name": "ValidationException",
+          "message": "1 validation error detected: Value '{_conformance_capdrift_h_1780928121410175759=[WriteRequest(putRequest=PutRequest(item={pk=AttributeValue(s=bw-0, n=null, b=null, iNT=null, dECIMAL=null, dOUBLE=null, sS=null, nS=null, bS=null, iNTSET=null, dECIMALSET=null, dOUBLESET=null, m=null, l=null, nULL=null, bOOL=null)}, workloadProfileName=null), deleteRequest=null), WriteRequest(putRequest=PutRequest(item={pk=AttributeValue(s=bw-1, n=null, b=null, iNT=null, dECIMAL=null, dOUBLE=null, sS=null, nS=null, bS=null, iNTSET=null, dECIMALSET=null, dOUBLESET=null, m=null, l=null, nULL=null, bOOL=null)}, workloadProfileName=null), deleteRequest=null), WriteRequest(putRequest=PutRequest(item={pk=AttributeValue(s=bw-2, n=null, b=null, iNT=null, dECIMAL=null, dOUBLE=null, sS=null, nS=null, bS=null, iNTSET=null, dECIMALSET=null, dOUBLESET=null, m=null, l=null, nULL=null, bOOL=null)}, workloadProfileName=null), deleteRequest=null), WriteRequest(putRequest=PutRequest(item={pk=AttributeValue(s=bw-3, n=null, b=null, iNT=null, dECIMAL=null, dOUBLE=null, sS=null, nS=null, bS=null, iNTSET=null, dECIMALSET=null, dOUBLESET=null, m=null, l=null, nULL=null, bOOL=null)}, workloadProfileName=null), deleteRequest=null), WriteRequest(putRequest=PutRequest(item={pk=AttributeValue(s=bw-4, n=null, b=null, iNT=null, dECIMAL=null, dOUBLE=null, sS=null, nS=null, bS=null, iNTSET=null, dECIMALSET=null, dOUBLESET=null, m=null, l=null, nULL=null, bOOL=null)}, workloadProfileName=null), deleteRequest=null), WriteRequest(putRequest=PutRequest(item={pk=AttributeValue(s=bw-5, n=null, b=null, iNT=null, dECIMAL=null, dOUBLE=null, sS=null, nS=null, bS=null, iNTSET=null, dECIMALSET=null, dOUBLESET=null, m=null, l=null, nULL=null, bOOL=null)}, workloadProfileName=null), deleteRequest=null), WriteRequest(putRequest=PutRequest(item={pk=AttributeValue(s=bw-6, n=null, b=null, iNT=null, dECIMAL=null, dOUBLE=null, sS=null, nS=null, bS=null, iNTSET=null, dECIMALSET=null, dOUBLESET=null, m=null, l=null, nULL=null, bOOL=null)}, workloadProfileName=null), deleteRequest=null), WriteRequest(putRequest=PutRequest(item={pk=AttributeValue(s=bw-7, n=null, b=null, iNT=null, dECIMAL=null, dOUBLE=null, sS=null, nS=null, bS=null, iNTSET=null, dECIMALSET=null, dOUBLESET=null, m=null, l=null, nULL=null, bOOL=null)}, workloadProfileName=null), deleteRequest=null), WriteRequest(putRequest=PutRequest(item={pk=AttributeValue(s=bw-8, n=null, b=null, iNT=null, dECIMAL=null, dOUBLE=null, sS=null, nS=null, bS=null, iNTSET=null, dECIMALSET=null, dOUBLESET=null, m=null, l=null, nULL=null, bOOL=null)}, workloadProfileName=null), deleteRequest=null), WriteRequest(putRequest=PutRequest(item={pk=AttributeValue(s=bw-9, n=null, b=null, iNT=null, dECIMAL=null, dOUBLE=null, sS=null, nS=null, bS=null, iNTSET=null, dECIMALSET=null, dOUBLESET=null, m=null, l=null, nULL=null, bOOL=null)}, workloadProfileName=null), deleteRequest=null), WriteRequest(putRequest=PutRequest(item={pk=AttributeValue(s=bw-10, n=null, b=null, iNT=null, dECIMAL=null, dOUBLE=null, sS=null, nS=null, bS=null, iNTSET=null, dECIMALSET=null, dOUBLESET=null, m=null, l=null, nULL=null, bOOL=null)}, workloadProfileName=null), deleteRequest=null), WriteRequest(putRequest=PutRequest(item={pk=AttributeValue(s=bw-11, n=null, b=null, iNT=null, dECIMAL=null, dOUBLE=null, sS=null, nS=null, bS=null, iNTSET=null, dECIMALSET=null, dOUBLESET=null, m=null, l=null, nULL=null, bOOL=null)}, workloadProfileName=null), deleteRequest=null), WriteRequest(putRequest=PutRequest(item={pk=AttributeValue(s=bw-12, n=null, b=null, iNT=null, dECIMAL=null, dOUBLE=null, sS=null, nS=null, bS=null, iNTSET=null, dECIMALSET=null, dOUBLESET=null, m=null, l=null, nULL=null, bOOL=null)}, workloadProfileName=null), deleteRequest=null), WriteRequest(putRequest=PutRequest(item={pk=AttributeValue(s=bw-13, n=null, b=null, iNT=null, dECIMAL=null, dOUBLE=null, sS=null, nS=null, bS=null, iNTSET=null, dECIMALSET=null, dOUBLESET=null, m=null, l=null, nULL=null, bOOL=null)}, workloadProfileName=null), deleteRequest=null), WriteRequest(putRequest=PutRequest(item={pk=AttributeValue(s=bw-14, n=null, b=null, iNT=null, dECIMAL=null, dOUBLE=null, sS=null, nS=null, bS=null, iNTSET=null, dECIMALSET=null, dOUBLESET=null, m=null, l=null, nULL=null, bOOL=null)}, workloadProfileName=null), deleteRequest=null), WriteRequest(putRequest=PutRequest(item={pk=AttributeValue(s=bw-15, n=null, b=null, iNT=null, dECIMAL=null, dOUBLE=null, sS=null, nS=null, bS=null, iNTSET=null, dECIMALSET=null, dOUBLESET=null, m=null, l=null, nULL=null, bOOL=null)}, workloadProfileName=null), deleteRequest=null), WriteRequest(putRequest=PutRequest(item={pk=AttributeValue(s=bw-16, n=null, b=null, iNT=null, dECIMAL=null, dOUBLE=null, sS=null, nS=null, bS=null, iNTSET=null, dECIMALSET=null, dOUBLESET=null, m=null, l=null, nULL=null, bOOL=null)}, workloadProfileName=null), deleteRequest=null), WriteRequest(putRequest=PutRequest(item={pk=AttributeValue(s=bw-17, n=null, b=null, iNT=null, dECIMAL=null, dOUBLE=null, sS=null, nS=null, bS=null, iNTSET=null, dECIMALSET=null, dOUBLESET=null, m=null, l=null, nULL=null, bOOL=null)}, workloadProfileName=null), deleteRequest=null), WriteRequest(putRequest=PutRequest(item={pk=AttributeValue(s=bw-18, n=null, b=null, iNT=null, dECIMAL=null, dOUBLE=null, sS=null, nS=null, bS=null, iNTSET=null, dECIMALSET=null, dOUBLESET=null, m=null, l=null, nULL=null, bOOL=null)}, workloadProfileName=null), deleteRequest=null), WriteRequest(putRequest=PutRequest(item={pk=AttributeValue(s=bw-19, n=null, b=null, iNT=null, dECIMAL=null, dOUBLE=null, sS=null, nS=null, bS=null, iNTSET=null, dECIMALSET=null, dOUBLESET=null, m=null, l=null, nULL=null, bOOL=null)}, workloadProfileName=null), deleteRequest=null), WriteRequest(putRequest=PutRequest(item={pk=AttributeValue(s=bw-20, n=null, b=null, iNT=null, dECIMAL=null, dOUBLE=null, sS=null, nS=null, bS=null, iNTSET=null, dECIMALSET=null, dOUBLESET=null, m=null, l=null, nULL=null, bOOL=null)}, workloadProfileName=null), deleteRequest=null), WriteRequest(putRequest=PutRequest(item={pk=AttributeValue(s=bw-21, n=null, b=null, iNT=null, dECIMAL=null, dOUBLE=null, sS=null, nS=null, bS=null, iNTSET=null, dECIMALSET=null, dOUBLESET=null, m=null, l=null, nULL=null, bOOL=null)}, workloadProfileName=null), deleteRequest=null), WriteRequest(putRequest=PutRequest(item={pk=AttributeValue(s=bw-22, n=null, b=null, iNT=null, dECIMAL=null, dOUBLE=null, sS=null, nS=null, bS=null, iNTSET=null, dECIMALSET=null, dOUBLESET=null, m=null, l=null, nULL=null, bOOL=null)}, workloadProfileName=null), deleteRequest=null), WriteRequest(putRequest=PutRequest(item={pk=AttributeValue(s=bw-23, n=null, b=null, iNT=null, dECIMAL=null, dOUBLE=null, sS=null, nS=null, bS=null, iNTSET=null, dECIMALSET=null, dOUBLESET=null, m=null, l=null, nULL=null, bOOL=null)}, workloadProfileName=null), deleteRequest=null), WriteRequest(putRequest=PutRequest(item={pk=AttributeValue(s=bw-24, n=null, b=null, iNT=null, dECIMAL=null, dOUBLE=null, sS=null, nS=null, bS=null, iNTSET=null, dECIMALSET=null, dOUBLESET=null, m=null, l=null, nULL=null, bOOL=null)}, workloadProfileName=null), deleteRequest=null), WriteRequest(putRequest=PutRequest(item={pk=AttributeValue(s=bw-25, n=null, b=null, iNT=null, dECIMAL=null, dOUBLE=null, sS=null, nS=null, bS=null, iNTSET=null, dECIMALSET=null, dOUBLESET=null, m=null, l=null, nULL=null, bOOL=null)}, workloadProfileName=null), deleteRequest=null)]}' at 'requestItems' failed to satisfy constraint: Map value must satisfy constraint: [Member must have length less than or equal to 25, Member must have length greater than or equal to 1]",
+          "n": 1,
+          "fields": [
+            "requestItems"
+          ]
+        },
+        {
+          "id": "c_ct_3keys",
+          "family": "echo-collection",
+          "note": "CreateTable 3 keySchema",
+          "threw": true,
+          "name": "ValidationException",
+          "message": "One or more parameter values were invalid: ReadCapacityUnits and WriteCapacityUnits must both be specified when BillingMode is PROVISIONED",
+          "n": null,
+          "fields": []
+        },
+        {
+          "id": "b_put_empty_ss",
+          "family": "bespoke",
+          "note": "empty string set",
+          "threw": true,
+          "name": "ValidationException",
+          "message": "One or more parameter values were invalid: An string set  may not be empty",
+          "n": null,
+          "fields": []
+        },
+        {
+          "id": "b_put_empty_ns",
+          "family": "bespoke",
+          "note": "empty number set",
+          "threw": true,
+          "name": "ValidationException",
+          "message": "One or more parameter values were invalid: An number set  may not be empty",
+          "n": null,
+          "fields": []
+        },
+        {
+          "id": "b_put_dup_ss",
+          "family": "bespoke",
+          "note": "duplicate SS",
+          "threw": true,
+          "name": "ValidationException",
+          "message": "One or more parameter values were invalid: Input collection [a, a] contains duplicates.",
+          "n": null,
+          "fields": []
+        },
+        {
+          "id": "b_put_mix_expr",
+          "family": "bespoke",
+          "note": "mixing expression and non-expression",
+          "threw": true,
+          "name": "ValidationException",
+          "message": "Can not use both expression and non-expression parameters in the same request: Non-expression parameters: {Expected} Expression parameters: {ConditionExpression}",
+          "n": null,
+          "fields": []
+        },
+        {
+          "id": "b_put_eav_no_expr",
+          "family": "bespoke",
+          "note": "EAV without expression",
+          "threw": true,
+          "name": "ValidationException",
+          "message": "ExpressionAttributeValues can only be specified when using expressions: ConditionExpression is null",
+          "n": null,
+          "fields": []
+        },
+        {
+          "id": "b_put_redundant_parens",
+          "family": "bespoke",
+          "note": "redundant parentheses",
+          "threw": true,
+          "name": "ValidationException",
+          "message": "Invalid ConditionExpression: The expression has redundant parentheses;",
+          "n": null,
+          "fields": []
+        },
+        {
+          "id": "b_put_contains_dup",
+          "family": "bespoke",
+          "note": "contains distinct operand",
+          "threw": true,
+          "name": "ValidationException",
+          "message": "Invalid ConditionExpression: The first operand must be distinct from the remaining operands for this operator or function; operator: contains, first operand: [data]",
+          "n": null,
+          "fields": []
+        },
+        {
+          "id": "u_upd_hashkey",
+          "family": "bespoke",
+          "note": "cannot update hash key",
+          "threw": true,
+          "name": "ValidationException",
+          "message": "One or more parameter values were invalid: Cannot update attribute pk. This attribute is part of the key",
+          "n": null,
+          "fields": []
+        },
+        {
+          "id": "u_upd_syntax",
+          "family": "bespoke",
+          "note": "invalid UpdateExpression syntax",
+          "threw": true,
+          "name": "ValidationException",
+          "message": "Invalid UpdateExpression: Syntax error; token: \"INVALID\", near: \"INVALID SYNTAX\"",
+          "n": null,
+          "fields": []
+        },
+        {
+          "id": "u_upd_unused_ean",
+          "family": "bespoke",
+          "note": "unused EAN",
+          "threw": true,
+          "name": "ValidationException",
+          "message": "Value provided in ExpressionAttributeNames unused in expressions: keys: {#unused}",
+          "n": null,
+          "fields": []
+        },
+        {
+          "id": "u_upd_unused_eav",
+          "family": "bespoke",
+          "note": "unused EAV",
+          "threw": true,
+          "name": "ValidationException",
+          "message": "Value provided in ExpressionAttributeValues unused in expressions: keys: {:unused}",
+          "n": null,
+          "fields": []
+        },
+        {
+          "id": "u_upd_missing_eav",
+          "family": "bespoke",
+          "note": "missing EAV ref",
+          "threw": true,
+          "name": "ValidationException",
+          "message": "Invalid UpdateExpression: An expression attribute value used in expression is not defined; attribute value: :v",
+          "n": null,
+          "fields": []
+        },
+        {
+          "id": "u_upd_mix",
+          "family": "bespoke",
+          "note": "mixing UpdateExpression + AttributeUpdates",
+          "threw": true,
+          "name": "ValidationException",
+          "message": "Can not use both expression and non-expression parameters in the same request: Non-expression parameters: {AttributeUpdates} Expression parameters: {UpdateExpression}",
+          "n": null,
+          "fields": []
+        },
+        {
+          "id": "u_upd_empty",
+          "family": "bespoke",
+          "note": "empty UpdateExpression",
+          "threw": true,
+          "name": "ValidationException",
+          "message": "Invalid UpdateExpression: The expression can not be empty;",
+          "n": null,
+          "fields": []
+        },
+        {
+          "id": "u_upd_rangekey",
+          "family": "bespoke",
+          "note": "cannot update range key",
+          "threw": true,
+          "name": "ValidationException",
+          "message": "One or more parameter values were invalid: Cannot update attribute sk. This attribute is part of the key",
+          "n": null,
+          "fields": []
+        },
+        {
+          "id": "o_put_empty_table_empty_item",
+          "family": "ordering",
+          "note": "PutItem TableName='' Item={}",
+          "threw": true,
+          "name": "ValidationException",
+          "message": "1 validation error detected: Value '' at 'tableName' failed to satisfy constraint: Member must have length greater than or equal to 1",
+          "n": 1,
+          "fields": [
+            "tableName"
+          ]
+        },
+        {
+          "id": "o_put_empty_table_bad_rv",
+          "family": "ordering",
+          "note": "PutItem TableName='' ReturnValues=INVALID Item={}",
+          "threw": true,
+          "name": "ValidationException",
+          "message": "2 validation errors detected: Value 'INVALID' at 'returnValues' failed to satisfy constraint: Member must satisfy enum value set: [ALL_NEW, UPDATED_OLD, ALL_OLD, NONE, UPDATED_NEW]; Value '' at 'tableName' failed to satisfy constraint: Member must have length greater than or equal to 1",
+          "n": 2,
+          "fields": [
+            "returnValues",
+            "tableName"
+          ]
+        },
+        {
+          "id": "o_put_three_bad_enums",
+          "family": "ordering",
+          "note": "PutItem 3 invalid enums on valid table name",
+          "threw": true,
+          "name": "ValidationException",
+          "message": "3 validation errors detected: Value 'INVALID' at 'returnValues' failed to satisfy constraint: Member must satisfy enum value set: [ALL_NEW, UPDATED_OLD, ALL_OLD, NONE, UPDATED_NEW]; Value 'INVALID' at 'returnConsumedCapacity' failed to satisfy constraint: Member must satisfy enum value set: [INDEXES, TOTAL, NONE]; Value 'INVALID' at 'returnItemCollectionMetrics' failed to satisfy constraint: Member must satisfy enum value set: [SIZE, NONE]",
+          "n": 3,
+          "fields": [
+            "returnValues",
+            "returnConsumedCapacity",
+            "returnItemCollectionMetrics"
+          ]
+        },
+        {
+          "id": "o_del_empty_table",
+          "family": "ordering",
+          "note": "DeleteItem TableName='' Key={}",
+          "threw": true,
+          "name": "ValidationException",
+          "message": "1 validation error detected: Value '' at 'tableName' failed to satisfy constraint: Member must have length greater than or equal to 1",
+          "n": 1,
+          "fields": [
+            "tableName"
+          ]
+        },
+        {
+          "id": "o_del_two_bad_enums",
+          "family": "ordering",
+          "note": "DeleteItem 2 invalid enums",
+          "threw": true,
+          "name": "ValidationException",
+          "message": "2 validation errors detected: Value 'INVALID' at 'returnValues' failed to satisfy constraint: Member must satisfy enum value set: [ALL_NEW, UPDATED_OLD, ALL_OLD, NONE, UPDATED_NEW]; Value 'INVALID' at 'returnConsumedCapacity' failed to satisfy constraint: Member must satisfy enum value set: [INDEXES, TOTAL, NONE]",
+          "n": 2,
+          "fields": [
+            "returnValues",
+            "returnConsumedCapacity"
+          ]
+        },
+        {
+          "id": "o_upd_empty_table",
+          "family": "ordering",
+          "note": "UpdateItem TableName='' Key={}",
+          "threw": true,
+          "name": "ValidationException",
+          "message": "1 validation error detected: Value '' at 'tableName' failed to satisfy constraint: Member must have length greater than or equal to 1",
+          "n": 1,
+          "fields": [
+            "tableName"
+          ]
+        },
+        {
+          "id": "o_upd_two_bad_enums",
+          "family": "ordering",
+          "note": "UpdateItem 2 invalid enums",
+          "threw": true,
+          "name": "ValidationException",
+          "message": "2 validation errors detected: Value 'INVALID' at 'returnConsumedCapacity' failed to satisfy constraint: Member must satisfy enum value set: [INDEXES, TOTAL, NONE]; Value 'INVALID' at 'returnValues' failed to satisfy constraint: Member must satisfy enum value set: [ALL_NEW, UPDATED_OLD, ALL_OLD, NONE, UPDATED_NEW]",
+          "n": 2,
+          "fields": [
+            "returnConsumedCapacity",
+            "returnValues"
+          ]
+        }
+      ],
+      "nullRoundTrip": {
+        "put": "rejected",
+        "name": "ValidationException",
+        "message": "One or more parameter values were invalid: Null attribute value types must have the value of true"
+      }
+    },
+    "ap-southeast-2": {
+      "probes": [
+        {
+          "id": "s_put_table_null",
+          "family": "echo-scalar",
+          "note": "PutItem TableName=undefined",
+          "threw": true,
+          "name": "ValidationException",
+          "message": "1 validation error detected: Value null at 'tableName' failed to satisfy constraint: Member must not be null",
+          "n": 1,
+          "fields": [
+            "tableName"
+          ]
+        },
+        {
+          "id": "s_put_table_empty",
+          "family": "echo-scalar",
+          "note": "PutItem TableName='' (empty echo)",
+          "threw": true,
+          "name": "ValidationException",
+          "message": "1 validation error detected: Value '' at 'tableName' failed to satisfy constraint: Member must have length greater than or equal to 1",
+          "n": 1,
+          "fields": [
+            "tableName"
+          ]
+        },
+        {
+          "id": "s_put_table_long",
+          "family": "echo-scalar",
+          "note": "PutItem TableName='a'*256",
+          "threw": true,
+          "name": "ValidationException",
+          "message": "1 validation error detected: Value 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa' at 'tableName' failed to satisfy constraint: Member must have length less than or equal to 255",
+          "n": 1,
+          "fields": [
+            "tableName"
+          ]
+        },
+        {
+          "id": "s_put_table_badchars",
+          "family": "echo-scalar",
+          "note": "PutItem TableName='bad table!@#'",
+          "threw": true,
+          "name": "ValidationException",
+          "message": "1 validation error detected: Value 'bad table!@#' at 'tableName' failed to satisfy constraint: Member must satisfy regular expression pattern: [a-zA-Z0-9_.-]+",
+          "n": 1,
+          "fields": [
+            "tableName"
+          ]
+        },
+        {
+          "id": "s_ct_table_short",
+          "family": "echo-scalar",
+          "note": "CreateTable TableName='ab'",
+          "threw": true,
+          "name": "ValidationException",
+          "message": "1 validation error detected: Value 'ab' at 'tableName' failed to satisfy constraint: Member must have length greater than or equal to 3",
+          "n": 1,
+          "fields": [
+            "tableName"
+          ]
+        },
+        {
+          "id": "c_bw_over25",
+          "family": "echo-collection",
+          "note": "BatchWrite 26 requests",
+          "threw": true,
+          "name": "ValidationException",
+          "message": "1 validation error detected: Value '{_conformance_capdrift_h_1780928157556847661=[WriteRequest(putRequest=PutRequest(item={pk=AttributeValue(s=bw-0, n=null, b=null, iNT=null, dECIMAL=null, dOUBLE=null, sS=null, nS=null, bS=null, iNTSET=null, dECIMALSET=null, dOUBLESET=null, m=null, l=null, nULL=null, bOOL=null)}, workloadProfileName=null), deleteRequest=null), WriteRequest(putRequest=PutRequest(item={pk=AttributeValue(s=bw-1, n=null, b=null, iNT=null, dECIMAL=null, dOUBLE=null, sS=null, nS=null, bS=null, iNTSET=null, dECIMALSET=null, dOUBLESET=null, m=null, l=null, nULL=null, bOOL=null)}, workloadProfileName=null), deleteRequest=null), WriteRequest(putRequest=PutRequest(item={pk=AttributeValue(s=bw-2, n=null, b=null, iNT=null, dECIMAL=null, dOUBLE=null, sS=null, nS=null, bS=null, iNTSET=null, dECIMALSET=null, dOUBLESET=null, m=null, l=null, nULL=null, bOOL=null)}, workloadProfileName=null), deleteRequest=null), WriteRequest(putRequest=PutRequest(item={pk=AttributeValue(s=bw-3, n=null, b=null, iNT=null, dECIMAL=null, dOUBLE=null, sS=null, nS=null, bS=null, iNTSET=null, dECIMALSET=null, dOUBLESET=null, m=null, l=null, nULL=null, bOOL=null)}, workloadProfileName=null), deleteRequest=null), WriteRequest(putRequest=PutRequest(item={pk=AttributeValue(s=bw-4, n=null, b=null, iNT=null, dECIMAL=null, dOUBLE=null, sS=null, nS=null, bS=null, iNTSET=null, dECIMALSET=null, dOUBLESET=null, m=null, l=null, nULL=null, bOOL=null)}, workloadProfileName=null), deleteRequest=null), WriteRequest(putRequest=PutRequest(item={pk=AttributeValue(s=bw-5, n=null, b=null, iNT=null, dECIMAL=null, dOUBLE=null, sS=null, nS=null, bS=null, iNTSET=null, dECIMALSET=null, dOUBLESET=null, m=null, l=null, nULL=null, bOOL=null)}, workloadProfileName=null), deleteRequest=null), WriteRequest(putRequest=PutRequest(item={pk=AttributeValue(s=bw-6, n=null, b=null, iNT=null, dECIMAL=null, dOUBLE=null, sS=null, nS=null, bS=null, iNTSET=null, dECIMALSET=null, dOUBLESET=null, m=null, l=null, nULL=null, bOOL=null)}, workloadProfileName=null), deleteRequest=null), WriteRequest(putRequest=PutRequest(item={pk=AttributeValue(s=bw-7, n=null, b=null, iNT=null, dECIMAL=null, dOUBLE=null, sS=null, nS=null, bS=null, iNTSET=null, dECIMALSET=null, dOUBLESET=null, m=null, l=null, nULL=null, bOOL=null)}, workloadProfileName=null), deleteRequest=null), WriteRequest(putRequest=PutRequest(item={pk=AttributeValue(s=bw-8, n=null, b=null, iNT=null, dECIMAL=null, dOUBLE=null, sS=null, nS=null, bS=null, iNTSET=null, dECIMALSET=null, dOUBLESET=null, m=null, l=null, nULL=null, bOOL=null)}, workloadProfileName=null), deleteRequest=null), WriteRequest(putRequest=PutRequest(item={pk=AttributeValue(s=bw-9, n=null, b=null, iNT=null, dECIMAL=null, dOUBLE=null, sS=null, nS=null, bS=null, iNTSET=null, dECIMALSET=null, dOUBLESET=null, m=null, l=null, nULL=null, bOOL=null)}, workloadProfileName=null), deleteRequest=null), WriteRequest(putRequest=PutRequest(item={pk=AttributeValue(s=bw-10, n=null, b=null, iNT=null, dECIMAL=null, dOUBLE=null, sS=null, nS=null, bS=null, iNTSET=null, dECIMALSET=null, dOUBLESET=null, m=null, l=null, nULL=null, bOOL=null)}, workloadProfileName=null), deleteRequest=null), WriteRequest(putRequest=PutRequest(item={pk=AttributeValue(s=bw-11, n=null, b=null, iNT=null, dECIMAL=null, dOUBLE=null, sS=null, nS=null, bS=null, iNTSET=null, dECIMALSET=null, dOUBLESET=null, m=null, l=null, nULL=null, bOOL=null)}, workloadProfileName=null), deleteRequest=null), WriteRequest(putRequest=PutRequest(item={pk=AttributeValue(s=bw-12, n=null, b=null, iNT=null, dECIMAL=null, dOUBLE=null, sS=null, nS=null, bS=null, iNTSET=null, dECIMALSET=null, dOUBLESET=null, m=null, l=null, nULL=null, bOOL=null)}, workloadProfileName=null), deleteRequest=null), WriteRequest(putRequest=PutRequest(item={pk=AttributeValue(s=bw-13, n=null, b=null, iNT=null, dECIMAL=null, dOUBLE=null, sS=null, nS=null, bS=null, iNTSET=null, dECIMALSET=null, dOUBLESET=null, m=null, l=null, nULL=null, bOOL=null)}, workloadProfileName=null), deleteRequest=null), WriteRequest(putRequest=PutRequest(item={pk=AttributeValue(s=bw-14, n=null, b=null, iNT=null, dECIMAL=null, dOUBLE=null, sS=null, nS=null, bS=null, iNTSET=null, dECIMALSET=null, dOUBLESET=null, m=null, l=null, nULL=null, bOOL=null)}, workloadProfileName=null), deleteRequest=null), WriteRequest(putRequest=PutRequest(item={pk=AttributeValue(s=bw-15, n=null, b=null, iNT=null, dECIMAL=null, dOUBLE=null, sS=null, nS=null, bS=null, iNTSET=null, dECIMALSET=null, dOUBLESET=null, m=null, l=null, nULL=null, bOOL=null)}, workloadProfileName=null), deleteRequest=null), WriteRequest(putRequest=PutRequest(item={pk=AttributeValue(s=bw-16, n=null, b=null, iNT=null, dECIMAL=null, dOUBLE=null, sS=null, nS=null, bS=null, iNTSET=null, dECIMALSET=null, dOUBLESET=null, m=null, l=null, nULL=null, bOOL=null)}, workloadProfileName=null), deleteRequest=null), WriteRequest(putRequest=PutRequest(item={pk=AttributeValue(s=bw-17, n=null, b=null, iNT=null, dECIMAL=null, dOUBLE=null, sS=null, nS=null, bS=null, iNTSET=null, dECIMALSET=null, dOUBLESET=null, m=null, l=null, nULL=null, bOOL=null)}, workloadProfileName=null), deleteRequest=null), WriteRequest(putRequest=PutRequest(item={pk=AttributeValue(s=bw-18, n=null, b=null, iNT=null, dECIMAL=null, dOUBLE=null, sS=null, nS=null, bS=null, iNTSET=null, dECIMALSET=null, dOUBLESET=null, m=null, l=null, nULL=null, bOOL=null)}, workloadProfileName=null), deleteRequest=null), WriteRequest(putRequest=PutRequest(item={pk=AttributeValue(s=bw-19, n=null, b=null, iNT=null, dECIMAL=null, dOUBLE=null, sS=null, nS=null, bS=null, iNTSET=null, dECIMALSET=null, dOUBLESET=null, m=null, l=null, nULL=null, bOOL=null)}, workloadProfileName=null), deleteRequest=null), WriteRequest(putRequest=PutRequest(item={pk=AttributeValue(s=bw-20, n=null, b=null, iNT=null, dECIMAL=null, dOUBLE=null, sS=null, nS=null, bS=null, iNTSET=null, dECIMALSET=null, dOUBLESET=null, m=null, l=null, nULL=null, bOOL=null)}, workloadProfileName=null), deleteRequest=null), WriteRequest(putRequest=PutRequest(item={pk=AttributeValue(s=bw-21, n=null, b=null, iNT=null, dECIMAL=null, dOUBLE=null, sS=null, nS=null, bS=null, iNTSET=null, dECIMALSET=null, dOUBLESET=null, m=null, l=null, nULL=null, bOOL=null)}, workloadProfileName=null), deleteRequest=null), WriteRequest(putRequest=PutRequest(item={pk=AttributeValue(s=bw-22, n=null, b=null, iNT=null, dECIMAL=null, dOUBLE=null, sS=null, nS=null, bS=null, iNTSET=null, dECIMALSET=null, dOUBLESET=null, m=null, l=null, nULL=null, bOOL=null)}, workloadProfileName=null), deleteRequest=null), WriteRequest(putRequest=PutRequest(item={pk=AttributeValue(s=bw-23, n=null, b=null, iNT=null, dECIMAL=null, dOUBLE=null, sS=null, nS=null, bS=null, iNTSET=null, dECIMALSET=null, dOUBLESET=null, m=null, l=null, nULL=null, bOOL=null)}, workloadProfileName=null), deleteRequest=null), WriteRequest(putRequest=PutRequest(item={pk=AttributeValue(s=bw-24, n=null, b=null, iNT=null, dECIMAL=null, dOUBLE=null, sS=null, nS=null, bS=null, iNTSET=null, dECIMALSET=null, dOUBLESET=null, m=null, l=null, nULL=null, bOOL=null)}, workloadProfileName=null), deleteRequest=null), WriteRequest(putRequest=PutRequest(item={pk=AttributeValue(s=bw-25, n=null, b=null, iNT=null, dECIMAL=null, dOUBLE=null, sS=null, nS=null, bS=null, iNTSET=null, dECIMALSET=null, dOUBLESET=null, m=null, l=null, nULL=null, bOOL=null)}, workloadProfileName=null), deleteRequest=null)]}' at 'requestItems' failed to satisfy constraint: Map value must satisfy constraint: [Member must have length less than or equal to 25, Member must have length greater than or equal to 1]",
+          "n": 1,
+          "fields": [
+            "requestItems"
+          ]
+        },
+        {
+          "id": "c_ct_3keys",
+          "family": "echo-collection",
+          "note": "CreateTable 3 keySchema",
+          "threw": true,
+          "name": "ValidationException",
+          "message": "One or more parameter values were invalid: ReadCapacityUnits and WriteCapacityUnits must both be specified when BillingMode is PROVISIONED",
+          "n": null,
+          "fields": []
+        },
+        {
+          "id": "b_put_empty_ss",
+          "family": "bespoke",
+          "note": "empty string set",
+          "threw": true,
+          "name": "ValidationException",
+          "message": "One or more parameter values were invalid: An string set  may not be empty",
+          "n": null,
+          "fields": []
+        },
+        {
+          "id": "b_put_empty_ns",
+          "family": "bespoke",
+          "note": "empty number set",
+          "threw": true,
+          "name": "ValidationException",
+          "message": "One or more parameter values were invalid: An number set  may not be empty",
+          "n": null,
+          "fields": []
+        },
+        {
+          "id": "b_put_dup_ss",
+          "family": "bespoke",
+          "note": "duplicate SS",
+          "threw": true,
+          "name": "ValidationException",
+          "message": "One or more parameter values were invalid: Input collection [a, a] contains duplicates.",
+          "n": null,
+          "fields": []
+        },
+        {
+          "id": "b_put_mix_expr",
+          "family": "bespoke",
+          "note": "mixing expression and non-expression",
+          "threw": true,
+          "name": "ValidationException",
+          "message": "Can not use both expression and non-expression parameters in the same request: Non-expression parameters: {Expected} Expression parameters: {ConditionExpression}",
+          "n": null,
+          "fields": []
+        },
+        {
+          "id": "b_put_eav_no_expr",
+          "family": "bespoke",
+          "note": "EAV without expression",
+          "threw": true,
+          "name": "ValidationException",
+          "message": "ExpressionAttributeValues can only be specified when using expressions: ConditionExpression is null",
+          "n": null,
+          "fields": []
+        },
+        {
+          "id": "b_put_redundant_parens",
+          "family": "bespoke",
+          "note": "redundant parentheses",
+          "threw": true,
+          "name": "ValidationException",
+          "message": "Invalid ConditionExpression: The expression has redundant parentheses;",
+          "n": null,
+          "fields": []
+        },
+        {
+          "id": "b_put_contains_dup",
+          "family": "bespoke",
+          "note": "contains distinct operand",
+          "threw": true,
+          "name": "ValidationException",
+          "message": "Invalid ConditionExpression: The first operand must be distinct from the remaining operands for this operator or function; operator: contains, first operand: [data]",
+          "n": null,
+          "fields": []
+        },
+        {
+          "id": "u_upd_hashkey",
+          "family": "bespoke",
+          "note": "cannot update hash key",
+          "threw": true,
+          "name": "ValidationException",
+          "message": "One or more parameter values were invalid: Cannot update attribute pk. This attribute is part of the key",
+          "n": null,
+          "fields": []
+        },
+        {
+          "id": "u_upd_syntax",
+          "family": "bespoke",
+          "note": "invalid UpdateExpression syntax",
+          "threw": true,
+          "name": "ValidationException",
+          "message": "Invalid UpdateExpression: Syntax error; token: \"INVALID\", near: \"INVALID SYNTAX\"",
+          "n": null,
+          "fields": []
+        },
+        {
+          "id": "u_upd_unused_ean",
+          "family": "bespoke",
+          "note": "unused EAN",
+          "threw": true,
+          "name": "ValidationException",
+          "message": "Value provided in ExpressionAttributeNames unused in expressions: keys: {#unused}",
+          "n": null,
+          "fields": []
+        },
+        {
+          "id": "u_upd_unused_eav",
+          "family": "bespoke",
+          "note": "unused EAV",
+          "threw": true,
+          "name": "ValidationException",
+          "message": "Value provided in ExpressionAttributeValues unused in expressions: keys: {:unused}",
+          "n": null,
+          "fields": []
+        },
+        {
+          "id": "u_upd_missing_eav",
+          "family": "bespoke",
+          "note": "missing EAV ref",
+          "threw": true,
+          "name": "ValidationException",
+          "message": "Invalid UpdateExpression: An expression attribute value used in expression is not defined; attribute value: :v",
+          "n": null,
+          "fields": []
+        },
+        {
+          "id": "u_upd_mix",
+          "family": "bespoke",
+          "note": "mixing UpdateExpression + AttributeUpdates",
+          "threw": true,
+          "name": "ValidationException",
+          "message": "Can not use both expression and non-expression parameters in the same request: Non-expression parameters: {AttributeUpdates} Expression parameters: {UpdateExpression}",
+          "n": null,
+          "fields": []
+        },
+        {
+          "id": "u_upd_empty",
+          "family": "bespoke",
+          "note": "empty UpdateExpression",
+          "threw": true,
+          "name": "ValidationException",
+          "message": "Invalid UpdateExpression: The expression can not be empty;",
+          "n": null,
+          "fields": []
+        },
+        {
+          "id": "u_upd_rangekey",
+          "family": "bespoke",
+          "note": "cannot update range key",
+          "threw": true,
+          "name": "ValidationException",
+          "message": "One or more parameter values were invalid: Cannot update attribute sk. This attribute is part of the key",
+          "n": null,
+          "fields": []
+        },
+        {
+          "id": "o_put_empty_table_empty_item",
+          "family": "ordering",
+          "note": "PutItem TableName='' Item={}",
+          "threw": true,
+          "name": "ValidationException",
+          "message": "1 validation error detected: Value '' at 'tableName' failed to satisfy constraint: Member must have length greater than or equal to 1",
+          "n": 1,
+          "fields": [
+            "tableName"
+          ]
+        },
+        {
+          "id": "o_put_empty_table_bad_rv",
+          "family": "ordering",
+          "note": "PutItem TableName='' ReturnValues=INVALID Item={}",
+          "threw": true,
+          "name": "ValidationException",
+          "message": "2 validation errors detected: Value 'INVALID' at 'returnValues' failed to satisfy constraint: Member must satisfy enum value set: [ALL_NEW, UPDATED_OLD, ALL_OLD, NONE, UPDATED_NEW]; Value '' at 'tableName' failed to satisfy constraint: Member must have length greater than or equal to 1",
+          "n": 2,
+          "fields": [
+            "returnValues",
+            "tableName"
+          ]
+        },
+        {
+          "id": "o_put_three_bad_enums",
+          "family": "ordering",
+          "note": "PutItem 3 invalid enums on valid table name",
+          "threw": true,
+          "name": "ValidationException",
+          "message": "3 validation errors detected: Value 'INVALID' at 'returnValues' failed to satisfy constraint: Member must satisfy enum value set: [ALL_NEW, UPDATED_OLD, ALL_OLD, NONE, UPDATED_NEW]; Value 'INVALID' at 'returnConsumedCapacity' failed to satisfy constraint: Member must satisfy enum value set: [INDEXES, TOTAL, NONE]; Value 'INVALID' at 'returnItemCollectionMetrics' failed to satisfy constraint: Member must satisfy enum value set: [SIZE, NONE]",
+          "n": 3,
+          "fields": [
+            "returnValues",
+            "returnConsumedCapacity",
+            "returnItemCollectionMetrics"
+          ]
+        },
+        {
+          "id": "o_del_empty_table",
+          "family": "ordering",
+          "note": "DeleteItem TableName='' Key={}",
+          "threw": true,
+          "name": "ValidationException",
+          "message": "1 validation error detected: Value '' at 'tableName' failed to satisfy constraint: Member must have length greater than or equal to 1",
+          "n": 1,
+          "fields": [
+            "tableName"
+          ]
+        },
+        {
+          "id": "o_del_two_bad_enums",
+          "family": "ordering",
+          "note": "DeleteItem 2 invalid enums",
+          "threw": true,
+          "name": "ValidationException",
+          "message": "2 validation errors detected: Value 'INVALID' at 'returnValues' failed to satisfy constraint: Member must satisfy enum value set: [ALL_NEW, UPDATED_OLD, ALL_OLD, NONE, UPDATED_NEW]; Value 'INVALID' at 'returnConsumedCapacity' failed to satisfy constraint: Member must satisfy enum value set: [INDEXES, TOTAL, NONE]",
+          "n": 2,
+          "fields": [
+            "returnValues",
+            "returnConsumedCapacity"
+          ]
+        },
+        {
+          "id": "o_upd_empty_table",
+          "family": "ordering",
+          "note": "UpdateItem TableName='' Key={}",
+          "threw": true,
+          "name": "ValidationException",
+          "message": "1 validation error detected: Value '' at 'tableName' failed to satisfy constraint: Member must have length greater than or equal to 1",
+          "n": 1,
+          "fields": [
+            "tableName"
+          ]
+        },
+        {
+          "id": "o_upd_two_bad_enums",
+          "family": "ordering",
+          "note": "UpdateItem 2 invalid enums",
+          "threw": true,
+          "name": "ValidationException",
+          "message": "2 validation errors detected: Value 'INVALID' at 'returnConsumedCapacity' failed to satisfy constraint: Member must satisfy enum value set: [INDEXES, TOTAL, NONE]; Value 'INVALID' at 'returnValues' failed to satisfy constraint: Member must satisfy enum value set: [ALL_NEW, UPDATED_OLD, ALL_OLD, NONE, UPDATED_NEW]",
+          "n": 2,
+          "fields": [
+            "returnConsumedCapacity",
+            "returnValues"
+          ]
+        }
+      ],
+      "nullRoundTrip": {
+        "put": "rejected",
+        "name": "ValidationException",
+        "message": "One or more parameter values were invalid: Null attribute value types must have the value of true"
+      }
+    },
+    "eu-central-1": {
+      "probes": [
+        {
+          "id": "s_put_table_null",
+          "family": "echo-scalar",
+          "note": "PutItem TableName=undefined",
+          "threw": true,
+          "name": "ValidationException",
+          "message": "1 validation error detected: Value null at 'tableName' failed to satisfy constraint: Member must not be null",
+          "n": 1,
+          "fields": [
+            "tableName"
+          ]
+        },
+        {
+          "id": "s_put_table_empty",
+          "family": "echo-scalar",
+          "note": "PutItem TableName='' (empty echo)",
+          "threw": true,
+          "name": "ValidationException",
+          "message": "1 validation error detected: Value at 'TableName' failed to satisfy constraint: Member must have length greater than or equal to 1",
+          "n": 1,
+          "fields": [
+            "TableName"
+          ]
+        },
+        {
+          "id": "s_put_table_long",
+          "family": "echo-scalar",
+          "note": "PutItem TableName='a'*256",
+          "threw": true,
+          "name": "ValidationException",
+          "message": "1 validation error detected: Value 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa' at 'tableName' failed to satisfy constraint: Member must have length less than or equal to 255",
+          "n": 1,
+          "fields": [
+            "tableName"
+          ]
+        },
+        {
+          "id": "s_put_table_badchars",
+          "family": "echo-scalar",
+          "note": "PutItem TableName='bad table!@#'",
+          "threw": true,
+          "name": "ValidationException",
+          "message": "1 validation error detected: Value 'bad table!@#' at 'tableName' failed to satisfy constraint: Member must satisfy regular expression pattern: [a-zA-Z0-9_.-]+",
+          "n": 1,
+          "fields": [
+            "tableName"
+          ]
+        },
+        {
+          "id": "s_ct_table_short",
+          "family": "echo-scalar",
+          "note": "CreateTable TableName='ab'",
+          "threw": true,
+          "name": "ValidationException",
+          "message": "1 validation error detected: Value 'ab' at 'tableName' failed to satisfy constraint: Member must have length greater than or equal to 3",
+          "n": 1,
+          "fields": [
+            "tableName"
+          ]
+        },
+        {
+          "id": "c_bw_over25",
+          "family": "echo-collection",
+          "note": "BatchWrite 26 requests",
+          "threw": true,
+          "name": "ValidationException",
+          "message": "1 validation error detected: Value '{_conformance_capdrift_h_178092814461159127=[WriteRequest(putRequest=PutRequest(item={pk=AttributeValue(s=bw-0, n=null, b=null, iNT=null, dECIMAL=null, dOUBLE=null, sS=null, nS=null, bS=null, iNTSET=null, dECIMALSET=null, dOUBLESET=null, m=null, l=null, nULL=null, bOOL=null)}, workloadProfileName=null), deleteRequest=null), WriteRequest(putRequest=PutRequest(item={pk=AttributeValue(s=bw-1, n=null, b=null, iNT=null, dECIMAL=null, dOUBLE=null, sS=null, nS=null, bS=null, iNTSET=null, dECIMALSET=null, dOUBLESET=null, m=null, l=null, nULL=null, bOOL=null)}, workloadProfileName=null), deleteRequest=null), WriteRequest(putRequest=PutRequest(item={pk=AttributeValue(s=bw-2, n=null, b=null, iNT=null, dECIMAL=null, dOUBLE=null, sS=null, nS=null, bS=null, iNTSET=null, dECIMALSET=null, dOUBLESET=null, m=null, l=null, nULL=null, bOOL=null)}, workloadProfileName=null), deleteRequest=null), WriteRequest(putRequest=PutRequest(item={pk=AttributeValue(s=bw-3, n=null, b=null, iNT=null, dECIMAL=null, dOUBLE=null, sS=null, nS=null, bS=null, iNTSET=null, dECIMALSET=null, dOUBLESET=null, m=null, l=null, nULL=null, bOOL=null)}, workloadProfileName=null), deleteRequest=null), WriteRequest(putRequest=PutRequest(item={pk=AttributeValue(s=bw-4, n=null, b=null, iNT=null, dECIMAL=null, dOUBLE=null, sS=null, nS=null, bS=null, iNTSET=null, dECIMALSET=null, dOUBLESET=null, m=null, l=null, nULL=null, bOOL=null)}, workloadProfileName=null), deleteRequest=null), WriteRequest(putRequest=PutRequest(item={pk=AttributeValue(s=bw-5, n=null, b=null, iNT=null, dECIMAL=null, dOUBLE=null, sS=null, nS=null, bS=null, iNTSET=null, dECIMALSET=null, dOUBLESET=null, m=null, l=null, nULL=null, bOOL=null)}, workloadProfileName=null), deleteRequest=null), WriteRequest(putRequest=PutRequest(item={pk=AttributeValue(s=bw-6, n=null, b=null, iNT=null, dECIMAL=null, dOUBLE=null, sS=null, nS=null, bS=null, iNTSET=null, dECIMALSET=null, dOUBLESET=null, m=null, l=null, nULL=null, bOOL=null)}, workloadProfileName=null), deleteRequest=null), WriteRequest(putRequest=PutRequest(item={pk=AttributeValue(s=bw-7, n=null, b=null, iNT=null, dECIMAL=null, dOUBLE=null, sS=null, nS=null, bS=null, iNTSET=null, dECIMALSET=null, dOUBLESET=null, m=null, l=null, nULL=null, bOOL=null)}, workloadProfileName=null), deleteRequest=null), WriteRequest(putRequest=PutRequest(item={pk=AttributeValue(s=bw-8, n=null, b=null, iNT=null, dECIMAL=null, dOUBLE=null, sS=null, nS=null, bS=null, iNTSET=null, dECIMALSET=null, dOUBLESET=null, m=null, l=null, nULL=null, bOOL=null)}, workloadProfileName=null), deleteRequest=null), WriteRequest(putRequest=PutRequest(item={pk=AttributeValue(s=bw-9, n=null, b=null, iNT=null, dECIMAL=null, dOUBLE=null, sS=null, nS=null, bS=null, iNTSET=null, dECIMALSET=null, dOUBLESET=null, m=null, l=null, nULL=null, bOOL=null)}, workloadProfileName=null), deleteRequest=null), WriteRequest(putRequest=PutRequest(item={pk=AttributeValue(s=bw-10, n=null, b=null, iNT=null, dECIMAL=null, dOUBLE=null, sS=null, nS=null, bS=null, iNTSET=null, dECIMALSET=null, dOUBLESET=null, m=null, l=null, nULL=null, bOOL=null)}, workloadProfileName=null), deleteRequest=null), WriteRequest(putRequest=PutRequest(item={pk=AttributeValue(s=bw-11, n=null, b=null, iNT=null, dECIMAL=null, dOUBLE=null, sS=null, nS=null, bS=null, iNTSET=null, dECIMALSET=null, dOUBLESET=null, m=null, l=null, nULL=null, bOOL=null)}, workloadProfileName=null), deleteRequest=null), WriteRequest(putRequest=PutRequest(item={pk=AttributeValue(s=bw-12, n=null, b=null, iNT=null, dECIMAL=null, dOUBLE=null, sS=null, nS=null, bS=null, iNTSET=null, dECIMALSET=null, dOUBLESET=null, m=null, l=null, nULL=null, bOOL=null)}, workloadProfileName=null), deleteRequest=null), WriteRequest(putRequest=PutRequest(item={pk=AttributeValue(s=bw-13, n=null, b=null, iNT=null, dECIMAL=null, dOUBLE=null, sS=null, nS=null, bS=null, iNTSET=null, dECIMALSET=null, dOUBLESET=null, m=null, l=null, nULL=null, bOOL=null)}, workloadProfileName=null), deleteRequest=null), WriteRequest(putRequest=PutRequest(item={pk=AttributeValue(s=bw-14, n=null, b=null, iNT=null, dECIMAL=null, dOUBLE=null, sS=null, nS=null, bS=null, iNTSET=null, dECIMALSET=null, dOUBLESET=null, m=null, l=null, nULL=null, bOOL=null)}, workloadProfileName=null), deleteRequest=null), WriteRequest(putRequest=PutRequest(item={pk=AttributeValue(s=bw-15, n=null, b=null, iNT=null, dECIMAL=null, dOUBLE=null, sS=null, nS=null, bS=null, iNTSET=null, dECIMALSET=null, dOUBLESET=null, m=null, l=null, nULL=null, bOOL=null)}, workloadProfileName=null), deleteRequest=null), WriteRequest(putRequest=PutRequest(item={pk=AttributeValue(s=bw-16, n=null, b=null, iNT=null, dECIMAL=null, dOUBLE=null, sS=null, nS=null, bS=null, iNTSET=null, dECIMALSET=null, dOUBLESET=null, m=null, l=null, nULL=null, bOOL=null)}, workloadProfileName=null), deleteRequest=null), WriteRequest(putRequest=PutRequest(item={pk=AttributeValue(s=bw-17, n=null, b=null, iNT=null, dECIMAL=null, dOUBLE=null, sS=null, nS=null, bS=null, iNTSET=null, dECIMALSET=null, dOUBLESET=null, m=null, l=null, nULL=null, bOOL=null)}, workloadProfileName=null), deleteRequest=null), WriteRequest(putRequest=PutRequest(item={pk=AttributeValue(s=bw-18, n=null, b=null, iNT=null, dECIMAL=null, dOUBLE=null, sS=null, nS=null, bS=null, iNTSET=null, dECIMALSET=null, dOUBLESET=null, m=null, l=null, nULL=null, bOOL=null)}, workloadProfileName=null), deleteRequest=null), WriteRequest(putRequest=PutRequest(item={pk=AttributeValue(s=bw-19, n=null, b=null, iNT=null, dECIMAL=null, dOUBLE=null, sS=null, nS=null, bS=null, iNTSET=null, dECIMALSET=null, dOUBLESET=null, m=null, l=null, nULL=null, bOOL=null)}, workloadProfileName=null), deleteRequest=null), WriteRequest(putRequest=PutRequest(item={pk=AttributeValue(s=bw-20, n=null, b=null, iNT=null, dECIMAL=null, dOUBLE=null, sS=null, nS=null, bS=null, iNTSET=null, dECIMALSET=null, dOUBLESET=null, m=null, l=null, nULL=null, bOOL=null)}, workloadProfileName=null), deleteRequest=null), WriteRequest(putRequest=PutRequest(item={pk=AttributeValue(s=bw-21, n=null, b=null, iNT=null, dECIMAL=null, dOUBLE=null, sS=null, nS=null, bS=null, iNTSET=null, dECIMALSET=null, dOUBLESET=null, m=null, l=null, nULL=null, bOOL=null)}, workloadProfileName=null), deleteRequest=null), WriteRequest(putRequest=PutRequest(item={pk=AttributeValue(s=bw-22, n=null, b=null, iNT=null, dECIMAL=null, dOUBLE=null, sS=null, nS=null, bS=null, iNTSET=null, dECIMALSET=null, dOUBLESET=null, m=null, l=null, nULL=null, bOOL=null)}, workloadProfileName=null), deleteRequest=null), WriteRequest(putRequest=PutRequest(item={pk=AttributeValue(s=bw-23, n=null, b=null, iNT=null, dECIMAL=null, dOUBLE=null, sS=null, nS=null, bS=null, iNTSET=null, dECIMALSET=null, dOUBLESET=null, m=null, l=null, nULL=null, bOOL=null)}, workloadProfileName=null), deleteRequest=null), WriteRequest(putRequest=PutRequest(item={pk=AttributeValue(s=bw-24, n=null, b=null, iNT=null, dECIMAL=null, dOUBLE=null, sS=null, nS=null, bS=null, iNTSET=null, dECIMALSET=null, dOUBLESET=null, m=null, l=null, nULL=null, bOOL=null)}, workloadProfileName=null), deleteRequest=null), WriteRequest(putRequest=PutRequest(item={pk=AttributeValue(s=bw-25, n=null, b=null, iNT=null, dECIMAL=null, dOUBLE=null, sS=null, nS=null, bS=null, iNTSET=null, dECIMALSET=null, dOUBLESET=null, m=null, l=null, nULL=null, bOOL=null)}, workloadProfileName=null), deleteRequest=null)]}' at 'requestItems' failed to satisfy constraint: Map value must satisfy constraint: [Member must have length less than or equal to 25, Member must have length greater than or equal to 1]",
+          "n": 1,
+          "fields": [
+            "requestItems"
+          ]
+        },
+        {
+          "id": "c_ct_3keys",
+          "family": "echo-collection",
+          "note": "CreateTable 3 keySchema",
+          "threw": true,
+          "name": "ValidationException",
+          "message": "One or more parameter values were invalid: ReadCapacityUnits and WriteCapacityUnits must both be specified when BillingMode is PROVISIONED",
+          "n": null,
+          "fields": []
+        },
+        {
+          "id": "b_put_empty_ss",
+          "family": "bespoke",
+          "note": "empty string set",
+          "threw": true,
+          "name": "ValidationException",
+          "message": "1 validation error detected: One or more parameter values were invalid: An string set  may not be empty",
+          "n": 1,
+          "fields": []
+        },
+        {
+          "id": "b_put_empty_ns",
+          "family": "bespoke",
+          "note": "empty number set",
+          "threw": true,
+          "name": "ValidationException",
+          "message": "1 validation error detected: One or more parameter values were invalid: An number set  may not be empty",
+          "n": 1,
+          "fields": []
+        },
+        {
+          "id": "b_put_dup_ss",
+          "family": "bespoke",
+          "note": "duplicate SS",
+          "threw": true,
+          "name": "ValidationException",
+          "message": "1 validation error detected: One or more parameter values were invalid: Input collection [\"a\", \"a\"] contains duplicates.",
+          "n": 1,
+          "fields": []
+        },
+        {
+          "id": "b_put_mix_expr",
+          "family": "bespoke",
+          "note": "mixing expression and non-expression",
+          "threw": true,
+          "name": "ValidationException",
+          "message": "1 validation error detected: Can not use both expression and non-expression parameters in the same request: Non-expression parameters: {Expected} Expression parameters: {ConditionExpression}",
+          "n": 1,
+          "fields": []
+        },
+        {
+          "id": "b_put_eav_no_expr",
+          "family": "bespoke",
+          "note": "EAV without expression",
+          "threw": true,
+          "name": "ValidationException",
+          "message": "1 validation error detected: ExpressionAttributeValues can only be specified when using expressions",
+          "n": 1,
+          "fields": []
+        },
+        {
+          "id": "b_put_redundant_parens",
+          "family": "bespoke",
+          "note": "redundant parentheses",
+          "threw": true,
+          "name": "ValidationException",
+          "message": "1 validation error detected: Invalid ConditionExpression: The expression has redundant parentheses;",
+          "n": 1,
+          "fields": []
+        },
+        {
+          "id": "b_put_contains_dup",
+          "family": "bespoke",
+          "note": "contains distinct operand",
+          "threw": true,
+          "name": "ValidationException",
+          "message": "1 validation error detected: Invalid ConditionExpression: The first operand must be distinct from the remaining operands for this operator or function; operator: contains, first operand: [data]",
+          "n": 1,
+          "fields": []
+        },
+        {
+          "id": "u_upd_hashkey",
+          "family": "bespoke",
+          "note": "cannot update hash key",
+          "threw": true,
+          "name": "ValidationException",
+          "message": "One or more parameter values were invalid: Cannot update attribute pk. This attribute is part of the key",
+          "n": null,
+          "fields": []
+        },
+        {
+          "id": "u_upd_syntax",
+          "family": "bespoke",
+          "note": "invalid UpdateExpression syntax",
+          "threw": true,
+          "name": "ValidationException",
+          "message": "1 validation error detected: Invalid UpdateExpression: Syntax error; token: \"INVALID\", near: \"INVALID SYNTAX\"",
+          "n": 1,
+          "fields": []
+        },
+        {
+          "id": "u_upd_unused_ean",
+          "family": "bespoke",
+          "note": "unused EAN",
+          "threw": true,
+          "name": "ValidationException",
+          "message": "1 validation error detected: Value provided in ExpressionAttributeNames unused in expressions: keys: {#unused}",
+          "n": 1,
+          "fields": []
+        },
+        {
+          "id": "u_upd_unused_eav",
+          "family": "bespoke",
+          "note": "unused EAV",
+          "threw": true,
+          "name": "ValidationException",
+          "message": "1 validation error detected: Value provided in ExpressionAttributeValues unused in expressions: keys: {:unused}",
+          "n": 1,
+          "fields": []
+        },
+        {
+          "id": "u_upd_missing_eav",
+          "family": "bespoke",
+          "note": "missing EAV ref",
+          "threw": true,
+          "name": "ValidationException",
+          "message": "1 validation error detected: Invalid UpdateExpression: An expression attribute value used in expression is not defined; attribute value: :v",
+          "n": 1,
+          "fields": []
+        },
+        {
+          "id": "u_upd_mix",
+          "family": "bespoke",
+          "note": "mixing UpdateExpression + AttributeUpdates",
+          "threw": true,
+          "name": "ValidationException",
+          "message": "1 validation error detected: Can not use both expression and non-expression parameters in the same request: Non-expression parameters: {AttributeUpdates} Expression parameters: {UpdateExpression}",
+          "n": 1,
+          "fields": []
+        },
+        {
+          "id": "u_upd_empty",
+          "family": "bespoke",
+          "note": "empty UpdateExpression",
+          "threw": true,
+          "name": "ValidationException",
+          "message": "1 validation error detected: Invalid UpdateExpression: The expression can not be empty;",
+          "n": 1,
+          "fields": []
+        },
+        {
+          "id": "u_upd_rangekey",
+          "family": "bespoke",
+          "note": "cannot update range key",
+          "threw": true,
+          "name": "ValidationException",
+          "message": "One or more parameter values were invalid: Cannot update attribute sk. This attribute is part of the key",
+          "n": null,
+          "fields": []
+        },
+        {
+          "id": "o_put_empty_table_empty_item",
+          "family": "ordering",
+          "note": "PutItem TableName='' Item={}",
+          "threw": true,
+          "name": "ValidationException",
+          "message": "1 validation error detected: Value at 'TableName' failed to satisfy constraint: Member must have length greater than or equal to 1",
+          "n": 1,
+          "fields": [
+            "TableName"
+          ]
+        },
+        {
+          "id": "o_put_empty_table_bad_rv",
+          "family": "ordering",
+          "note": "PutItem TableName='' ReturnValues=INVALID Item={}",
+          "threw": true,
+          "name": "ValidationException",
+          "message": "1 validation error detected: Value at 'TableName' failed to satisfy constraint: Member must have length greater than or equal to 1",
+          "n": 1,
+          "fields": [
+            "TableName"
+          ]
+        },
+        {
+          "id": "o_put_three_bad_enums",
+          "family": "ordering",
+          "note": "PutItem 3 invalid enums on valid table name",
+          "threw": true,
+          "name": "ValidationException",
+          "message": "3 validation errors detected: Value 'INVALID' at 'returnConsumedCapacity' failed to satisfy constraint: Member must satisfy enum value set: [INDEXES, TOTAL, NONE]; Failed to satisfy constraint: Member must satisfy enum value set: [ALL_OLD, UPDATED_OLD, ALL_NEW, UPDATE_NEW, NONE]; ReturnItemCollectionMetrics can only be SIZE or NONE",
+          "n": 3,
+          "fields": [
+            "returnConsumedCapacity"
+          ]
+        },
+        {
+          "id": "o_del_empty_table",
+          "family": "ordering",
+          "note": "DeleteItem TableName='' Key={}",
+          "threw": true,
+          "name": "ValidationException",
+          "message": "1 validation error detected: Value at 'TableName' failed to satisfy constraint: Member must have length greater than or equal to 1",
+          "n": 1,
+          "fields": [
+            "TableName"
+          ]
+        },
+        {
+          "id": "o_del_two_bad_enums",
+          "family": "ordering",
+          "note": "DeleteItem 2 invalid enums",
+          "threw": true,
+          "name": "ValidationException",
+          "message": "2 validation errors detected: Value 'INVALID' at 'returnConsumedCapacity' failed to satisfy constraint: Member must satisfy enum value set: [INDEXES, TOTAL, NONE]; Failed to satisfy constraint: Member must satisfy enum value set: [ALL_OLD, UPDATED_OLD, ALL_NEW, UPDATE_NEW, NONE]",
+          "n": 2,
+          "fields": [
+            "returnConsumedCapacity"
+          ]
+        },
+        {
+          "id": "o_upd_empty_table",
+          "family": "ordering",
+          "note": "UpdateItem TableName='' Key={}",
+          "threw": true,
+          "name": "ValidationException",
+          "message": "1 validation error detected: Value at 'TableName' failed to satisfy constraint: Member must have length greater than or equal to 1",
+          "n": 1,
+          "fields": [
+            "TableName"
+          ]
+        },
+        {
+          "id": "o_upd_two_bad_enums",
+          "family": "ordering",
+          "note": "UpdateItem 2 invalid enums",
+          "threw": true,
+          "name": "ValidationException",
+          "message": "1 validation error detected: Failed to satisfy constraint: Member must satisfy enum value set: [ALL_OLD, UPDATED_OLD, ALL_NEW, UPDATE_NEW, NONE]",
+          "n": 1,
+          "fields": []
+        }
+      ],
+      "nullRoundTrip": {
+        "put": "accepted",
+        "returnedItem": {
+          "pk": {
+            "S": "em-put-null-false"
+          },
+          "attr1": {
+            "NULL": true
+          }
+        }
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "test:tier1": "vitest run --include 'tests/tier1/**/*.test.ts'",
     "test:tier2": "vitest run --include 'tests/tier2/**/*.test.ts'",
     "test:tier3": "vitest run --include 'tests/tier3/**/*.test.ts'",
+    "test:tooling": "vitest run --config vitest.tooling.config.ts",
     "test:capture-ground-truth": "DYNAMODB_ENDPOINT= vitest run --reporter=json --outputFile=ground-truth/latest.json",
     "test:capture-ddb-local": "DYNAMODB_ENDPOINT=http://localhost:8000 vitest run --reporter=json --outputFile=results/dynamodb-local.json",
     "results:table": "node scripts/summarise.mjs",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "test": "vitest run",
     "test:quick": "vitest run --exclude 'tests/tier2/updateTable/gsi.test.ts'",
     "test:gating": "vitest run --exclude 'tests/tier2/updateTable/gsi.test.ts' --exclude 'tests/tier2/export/exportImport.test.ts' --exclude 'tests/tier2/kinesis/streamingDestination.test.ts'",
-    "test:cloud-only": "vitest run tests/tier2/export/exportImport.test.ts tests/tier2/kinesis/streamingDestination.test.ts",
+    "test:integrations": "vitest run tests/tier2/export/exportImport.test.ts tests/tier2/kinesis/streamingDestination.test.ts",
     "test:watch": "vitest",
     "test:tier1": "vitest run --include 'tests/tier1/**/*.test.ts'",
     "test:tier2": "vitest run --include 'tests/tier2/**/*.test.ts'",

--- a/scripts/drift-diff.mjs
+++ b/scripts/drift-diff.mjs
@@ -45,9 +45,24 @@ function main() {
   let result
   if (args.baseline) {
     const baseline = JSON.parse(readFileSync(args.baseline, 'utf8'))
-    const drift = diffCaptures(baseline.regions?.[args.region], current.regions?.[args.region])
-    result = { mode: 'across-time', region: args.region, baseline: args.baseline, clean: isClean(drift), drift }
+    const baselineBlock = baseline.regions?.[args.region]
+    const currentBlock = current.regions?.[args.region]
+    // If either side lacks the region, the diff compared nothing - report it as
+    // not comparable rather than clean, so a missing block can't be read as "no
+    // drift" (which would mislabel a real failure as a flake).
+    const comparable = Boolean(baselineBlock && currentBlock)
+    const drift = diffCaptures(baselineBlock, currentBlock)
+    if (!comparable) {
+      console.error(`warning: region '${args.region}' missing from ${baselineBlock ? 'the capture' : 'the baseline'}; no verdict possible`)
+    }
+    result = { mode: 'across-time', region: args.region, baseline: args.baseline, comparable, clean: comparable && isClean(drift), drift }
   } else {
+    // Cross-region needs the baseline region present in the document, or every
+    // probe of every other region reads as "added" - fabricated total drift.
+    if (!current.regions?.[args.region]) {
+      console.error(`error: baseline region '${args.region}' is not in ${currentPath}; pass --region <r> or --baseline <file>`)
+      process.exit(2)
+    }
     const cross = diffRegions(current, args.region)
     result = { mode: 'cross-region', ...cross, clean: Object.values(cross.regions).every(isClean) }
   }

--- a/scripts/drift-diff.mjs
+++ b/scripts/drift-diff.mjs
@@ -1,0 +1,64 @@
+#!/usr/bin/env node
+
+/**
+ * CLI over scripts/lib/drift.mjs - report raw-message drift between captures.
+ *
+ *   # cross-region: every region vs the document's own baseline region
+ *   node scripts/drift-diff.mjs capture.json
+ *
+ *   # across-time: a fresh capture's region vs a committed baseline's region
+ *   node scripts/drift-diff.mjs fresh.json --baseline captures/2026-06-09-validation-rewording.json
+ *
+ * Flags: --region <r> (baseline region, default eu-west-2); --out <file>
+ * (default stdout). The result carries a top-level `clean` boolean so a caller
+ * can branch on drift without parsing the probe list. Reads captures, never
+ * results/*.json, and writes its own artefact, so summarise.mjs and the website
+ * scorer stay byte-stable.
+ */
+
+import { readFileSync, writeFileSync } from 'node:fs'
+import { diffCaptures, diffRegions, isClean } from './lib/drift.mjs'
+
+export function parseArgs(argv) {
+  const args = { region: 'eu-west-2', baseline: null, out: null, _: [] }
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i]
+    if (a === '--region') args.region = argv[++i]
+    else if (a === '--baseline') args.baseline = argv[++i]
+    else if (a === '--out') args.out = argv[++i]
+    else args._.push(a)
+  }
+  return args
+}
+
+function main() {
+  const args = parseArgs(process.argv.slice(2))
+  const [currentPath] = args._
+  if (!currentPath) {
+    console.error(
+      'usage: drift-diff.mjs <capture.json> [--baseline <file>] [--region <r>] [--out <file>]',
+    )
+    process.exit(2)
+  }
+  const current = JSON.parse(readFileSync(currentPath, 'utf8'))
+
+  let result
+  if (args.baseline) {
+    const baseline = JSON.parse(readFileSync(args.baseline, 'utf8'))
+    const drift = diffCaptures(baseline.regions?.[args.region], current.regions?.[args.region])
+    result = { mode: 'across-time', region: args.region, baseline: args.baseline, clean: isClean(drift), drift }
+  } else {
+    const cross = diffRegions(current, args.region)
+    result = { mode: 'cross-region', ...cross, clean: Object.values(cross.regions).every(isClean) }
+  }
+
+  const json = JSON.stringify(result, null, 2)
+  if (args.out) {
+    writeFileSync(args.out, json + '\n')
+    console.error(`drift written to ${args.out} (clean=${result.clean})`)
+  } else {
+    process.stdout.write(json + '\n')
+  }
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) main()

--- a/scripts/lib/drift.mjs
+++ b/scripts/lib/drift.mjs
@@ -52,10 +52,17 @@ export function diffProbe(baseline, observed) {
   }
 }
 
+// Key-order-insensitive serialisation: DynamoDB does not guarantee the order of
+// attributes in a returned item map, so a reordered-but-identical round-trip
+// must not read as drift.
+function stableKey(v) {
+  if (v === null || typeof v !== 'object') return JSON.stringify(v)
+  if (Array.isArray(v)) return '[' + v.map(stableKey).join(',') + ']'
+  return '{' + Object.keys(v).sort().map((k) => JSON.stringify(k) + ':' + stableKey(v[k])).join(',') + '}'
+}
+
 function diffNullRoundTrip(baseline, observed) {
-  const b = JSON.stringify(baseline ?? null)
-  const o = JSON.stringify(observed ?? null)
-  if (b === o) return null
+  if (stableKey(baseline ?? null) === stableKey(observed ?? null)) return null
   return { changed: ['nullRoundTrip'], baseline: baseline ?? null, observed: observed ?? null }
 }
 

--- a/scripts/lib/drift.mjs
+++ b/scripts/lib/drift.mjs
@@ -1,0 +1,116 @@
+// Raw-message drift between two capture blocks.
+//
+// A "block" is one region's slice of a capture document, the shape that
+// scripts/capture-validation-messages.mjs emits per region:
+//
+//   { probes: [{ id, name, message, n, fields, ... }], nullRoundTrip: {...} }
+//
+// Drift is a difference in the *raw* values a probe returned - the error type
+// (`name`), the full `message`, the `N validation error detected` count, or the
+// named `fields` list. This is deliberately independent of whether the Tier 3
+// suite would pass or fail: a probe whose error type and field are unchanged but
+// whose prose was reworded still *passes* the tolerant (type + field +
+// constraint) assertions, yet its raw message drifted. That passing-but-different
+// case is exactly what a pass/fail signal is blind to and why drift is measured
+// by diffing captured messages, never by re-running the suite.
+//
+// Pure and dependency-free so it can be unit-tested directly (no AWS, no
+// network) and mirrored in the website's lens derivation.
+
+/** The raw fields that count as drift when they move. */
+function pick(probe) {
+  return {
+    name: probe?.name ?? null,
+    message: probe?.message ?? null,
+    n: probe?.n ?? null,
+    fields: probe?.fields ?? [],
+  }
+}
+
+function sameFields(a = [], b = []) {
+  if (a.length !== b.length) return false
+  return a.every((v, i) => v === b[i])
+}
+
+/** Diff one probe against its baseline. Returns null when nothing moved. */
+export function diffProbe(baseline, observed) {
+  const changed = []
+  if (baseline.name !== observed.name) changed.push('name')
+  if (baseline.message !== observed.message) changed.push('message')
+  if (baseline.n !== observed.n) changed.push('n')
+  if (!sameFields(baseline.fields, observed.fields)) changed.push('fields')
+  if (changed.length === 0) return null
+  // Only the prose moved - type, field and count are intact - so a tolerant
+  // assertion still passes while the raw wording drifted.
+  const passingButDifferent = changed.length === 1 && changed[0] === 'message'
+  return {
+    id: baseline.id ?? observed.id,
+    changed,
+    passingButDifferent,
+    baseline: pick(baseline),
+    observed: pick(observed),
+  }
+}
+
+function diffNullRoundTrip(baseline, observed) {
+  const b = JSON.stringify(baseline ?? null)
+  const o = JSON.stringify(observed ?? null)
+  if (b === o) return null
+  return { changed: ['nullRoundTrip'], baseline: baseline ?? null, observed: observed ?? null }
+}
+
+function indexById(probes = []) {
+  const map = new Map()
+  for (const p of probes) if (p && p.id != null) map.set(p.id, p)
+  return map
+}
+
+/**
+ * Diff an observed block against a baseline block. Returns the probe-level
+ * divergences (probes present in only one side are reported as added/removed)
+ * and any nullRoundTrip divergence. An empty `probes` array and a null
+ * `nullRoundTrip` means the two blocks match.
+ */
+export function diffCaptures(baseline, observed) {
+  const base = indexById(baseline?.probes)
+  const obs = indexById(observed?.probes)
+  const ids = [...new Set([...base.keys(), ...obs.keys()])]
+  const probes = []
+  for (const id of ids) {
+    const b = base.get(id)
+    const o = obs.get(id)
+    if (!b) {
+      probes.push({ id, changed: ['added'], passingButDifferent: false, observed: pick(o) })
+      continue
+    }
+    if (!o) {
+      probes.push({ id, changed: ['removed'], passingButDifferent: false, baseline: pick(b) })
+      continue
+    }
+    const d = diffProbe(b, o)
+    if (d) probes.push(d)
+  }
+  return { probes, nullRoundTrip: diffNullRoundTrip(baseline?.nullRoundTrip, observed?.nullRoundTrip) }
+}
+
+/** True when a diff result carries no divergence at all. */
+export function isClean(diff) {
+  return (diff?.probes?.length ?? 0) === 0 && !diff?.nullRoundTrip
+}
+
+/**
+ * Compare every non-baseline region in a capture document against the
+ * baseline region within the same document. Used for the cross-region lens:
+ * "which regions differ from eu-west-2 right now". Returns
+ * { baselineRegion, regions: { <region>: <diffCaptures result> } }.
+ */
+export function diffRegions(captureDoc, baselineRegion = 'eu-west-2') {
+  const regions = captureDoc?.regions ?? {}
+  const base = regions[baselineRegion]
+  const out = {}
+  for (const [region, block] of Object.entries(regions)) {
+    if (region === baselineRegion) continue
+    out[region] = diffCaptures(base, block)
+  }
+  return { baselineRegion, regions: out }
+}

--- a/scripts/lib/drift.test.mjs
+++ b/scripts/lib/drift.test.mjs
@@ -1,0 +1,110 @@
+import { describe, it, expect } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+import { dirname, join } from 'node:path'
+import { diffCaptures, diffProbe, diffRegions, isClean } from './drift.mjs'
+
+const here = dirname(fileURLToPath(import.meta.url))
+const snapshot = JSON.parse(
+  readFileSync(join(here, '../../captures/2026-06-09-validation-rewording.json'), 'utf8'),
+)
+
+const probe = (over) => ({
+  id: 'p1',
+  name: 'ValidationException',
+  message: 'a message',
+  n: 1,
+  fields: ['tableName'],
+  ...over,
+})
+
+const block = (...probes) => ({ probes, nullRoundTrip: { put: 'accepted' } })
+
+describe('diffProbe', () => {
+  it('returns null when nothing moved', () => {
+    expect(diffProbe(probe(), probe())).toBeNull()
+  })
+
+  it('flags a changed message with both texts', () => {
+    const d = diffProbe(probe({ message: 'old' }), probe({ message: 'new' }))
+    expect(d.changed).toEqual(['message'])
+    expect(d.baseline.message).toBe('old')
+    expect(d.observed.message).toBe('new')
+  })
+
+  it('marks a prose-only change as passing-but-different', () => {
+    // same type, count and field; only the wording moved
+    const d = diffProbe(probe({ message: 'old prose' }), probe({ message: 'new prose' }))
+    expect(d.passingButDifferent).toBe(true)
+  })
+
+  it('does NOT mark a field or type change as passing-but-different', () => {
+    const d = diffProbe(probe({ fields: ['tableName'] }), probe({ message: 'new', fields: ['TableName'] }))
+    expect(d.changed).toContain('fields')
+    expect(d.passingButDifferent).toBe(false)
+  })
+
+  it('flags a changed N count', () => {
+    expect(diffProbe(probe({ n: 1 }), probe({ n: 2 })).changed).toContain('n')
+  })
+
+  it('flags a changed field list (order-sensitive)', () => {
+    const d = diffProbe(probe({ fields: ['a', 'b'] }), probe({ fields: ['b', 'a'] }))
+    expect(d.changed).toContain('fields')
+  })
+})
+
+describe('diffCaptures', () => {
+  it('is clean when blocks are identical', () => {
+    const b = block(probe())
+    expect(isClean(diffCaptures(b, b))).toBe(true)
+  })
+
+  it('reports an added and a removed probe', () => {
+    const base = block(probe({ id: 'only-base' }))
+    const obs = block(probe({ id: 'only-obs' }))
+    const ids = diffCaptures(base, obs).probes
+    expect(ids.find((p) => p.id === 'only-base').changed).toEqual(['removed'])
+    expect(ids.find((p) => p.id === 'only-obs').changed).toEqual(['added'])
+  })
+
+  it('flags a nullRoundTrip divergence', () => {
+    const base = { probes: [], nullRoundTrip: { put: 'accepted', returnedItem: { x: { NULL: true } } } }
+    const obs = { probes: [], nullRoundTrip: { put: 'rejected', name: 'ValidationException' } }
+    const d = diffCaptures(base, obs)
+    expect(d.nullRoundTrip).not.toBeNull()
+    expect(d.nullRoundTrip.observed.put).toBe('rejected')
+  })
+})
+
+describe('fixture regression: the June 2026 four-region snapshot', () => {
+  const euw2 = snapshot.regions['eu-west-2']
+
+  it('finds no drift comparing eu-west-2 to itself', () => {
+    expect(isClean(diffCaptures(euw2, euw2))).toBe(true)
+  })
+
+  it('reproduces the 22 eu-west-2-vs-us-east-1 divergences (old vs new wording)', () => {
+    const d = diffCaptures(euw2, snapshot.regions['us-east-1'])
+    expect(d.probes).toHaveLength(22)
+    // the empty-TableName case moved both prose and the field token (camelCase -> PascalCase)
+    const empty = d.probes.find((p) => p.id === 's_put_table_empty')
+    expect(empty.changed).toEqual(expect.arrayContaining(['message', 'fields']))
+    expect(empty.baseline.message).toContain("at 'TableName'")
+    expect(empty.observed.message).toContain("at 'tableName'")
+    // { NULL: false } acceptance differs between the lead and laggard regions
+    expect(d.nullRoundTrip).not.toBeNull()
+    // at least one probe drifted in prose only (the case a tolerant assertion misses)
+    expect(d.probes.some((p) => p.passingButDifferent)).toBe(true)
+  })
+
+  it('shows eu-central-1 tracking eu-west-2 far more closely than the laggards', () => {
+    const cr = diffRegions(snapshot, 'eu-west-2')
+    expect(cr.baselineRegion).toBe('eu-west-2')
+    expect(cr.regions['eu-central-1'].probes.length).toBeLessThan(
+      cr.regions['us-east-1'].probes.length,
+    )
+    expect(cr.regions['us-east-1'].probes).toHaveLength(22)
+    expect(cr.regions['ap-southeast-2'].probes).toHaveLength(22)
+  })
+})

--- a/scripts/lib/drift.test.mjs
+++ b/scripts/lib/drift.test.mjs
@@ -75,6 +75,12 @@ describe('diffCaptures', () => {
     expect(d.nullRoundTrip).not.toBeNull()
     expect(d.nullRoundTrip.observed.put).toBe('rejected')
   })
+
+  it('does not flag a nullRoundTrip whose returned item only reordered its keys', () => {
+    const base = { probes: [], nullRoundTrip: { put: 'accepted', returnedItem: { pk: { S: 'a' }, attr1: { NULL: true } } } }
+    const obs = { probes: [], nullRoundTrip: { put: 'accepted', returnedItem: { attr1: { NULL: true }, pk: { S: 'a' } } } }
+    expect(isClean(diffCaptures(base, obs))).toBe(true)
+  })
 })
 
 describe('fixture regression: the June 2026 four-region snapshot', () => {

--- a/scripts/report-failure.mjs
+++ b/scripts/report-failure.mjs
@@ -1,20 +1,24 @@
 #!/usr/bin/env node
 
 /**
- * Format a GitHub issue body from a Vitest JSON report's failed assertions.
+ * Format a GitHub issue body from a Vitest JSON report's failed assertions, and
+ * - when a drift diff is supplied - label the failure as confirmed AWS drift or
+ * a likely flake.
  *
  * Usage:
- *   node scripts/report-failure.mjs results/dynamodb.json <run-url> > body.md
+ *   node scripts/report-failure.mjs <vitest-json> <run-url> \
+ *     [--drift <drift.json>] [--verdict-out <file>]
  *
  * The scheduled-run workflow calls this on a deterministic ground-truth failure
  * (after retries) and threads the output onto a single deduped issue, so a red
- * Monday is actionable rather than a silent X. The formatting lives in pure
- * functions (collectFailures / buildIssueBody) so they can be unit-tested once a
- * scripts/ tooling-test harness exists. A later cross-region drift signal will
- * fill in the drift-versus-flake verdict at the triage slot.
+ * Monday is actionable rather than a silent X. With --drift (the output of
+ * drift-diff.mjs comparing a fresh eu-west-2 capture against the committed
+ * baseline) it fills the triage slot with a verdict and writes the recommended
+ * issue label to --verdict-out. The pure functions are unit-tested via
+ * test:tooling.
  */
 
-import { readFileSync } from 'node:fs'
+import { readFileSync, writeFileSync } from 'node:fs'
 
 /** Pull failed assertions out of a Vitest JSON report. */
 export function collectFailures(report) {
@@ -32,8 +36,34 @@ export function collectFailures(report) {
   return out
 }
 
+/**
+ * Turn a drift-diff result (drift-diff.mjs across-time output) into a verdict.
+ * Returns null when no usable drift data is available, so the body falls back to
+ * the generic triage note.
+ */
+export function verdictFromDrift(driftResult) {
+  if (!driftResult || typeof driftResult.clean !== 'boolean') return null
+  if (driftResult.clean) {
+    return {
+      label: 'likely-flake',
+      summary:
+        "eu-west-2's wording matches the committed baseline, so this is most likely a " +
+        'transient flake the retry happened not to catch. Investigate timing rather than ' +
+        're-characterising.',
+      probes: [],
+    }
+  }
+  return {
+    label: 'aws-drift-confirmed',
+    summary:
+      "eu-west-2's wording has moved from the committed baseline, so this is real AWS drift. " +
+      'Re-characterise the affected assertions against current AWS per the suite doctrine.',
+    probes: (driftResult.drift?.probes ?? []).map((p) => p.id),
+  }
+}
+
 /** Build the Markdown issue body. `report` may be null when parsing failed. */
-export function buildIssueBody(report, runUrl) {
+export function buildIssueBody(report, runUrl, verdict = null) {
   const lines = []
   lines.push('The scheduled `Conformance Tests` ground-truth run went red after retries.')
   lines.push('')
@@ -43,46 +73,71 @@ export function buildIssueBody(report, runUrl) {
   if (!report) {
     lines.push('The Vitest report could not be read or parsed, so the failure was')
     lines.push('likely in setup/teardown or the runner itself. See the run log.')
-    return lines.join('\n')
-  }
-
-  const failures = collectFailures(report)
-  if (failures.length === 0) {
-    lines.push('No failed assertions are present in the report, so the failure was')
-    lines.push('likely in a `beforeAll`/`afterAll` hook or infrastructure rather than')
-    lines.push('a test body. See the run log.')
   } else {
-    lines.push(`**${failures.length} failed test${failures.length === 1 ? '' : 's'}:**`)
-    lines.push('')
-    for (const f of failures) {
-      lines.push(`- \`${f.name}\``)
-      if (f.detail) lines.push(`  - ${f.detail}`)
+    const failures = collectFailures(report)
+    if (failures.length === 0) {
+      lines.push('No failed assertions are present in the report, so the failure was')
+      lines.push('likely in a `beforeAll`/`afterAll` hook or infrastructure rather than')
+      lines.push('a test body. See the run log.')
+    } else {
+      lines.push(`**${failures.length} failed test${failures.length === 1 ? '' : 's'}:**`)
+      lines.push('')
+      for (const f of failures) {
+        lines.push(`- \`${f.name}\``)
+        if (f.detail) lines.push(`  - ${f.detail}`)
+      }
     }
   }
 
   lines.push('')
   lines.push('<!-- triage-slot -->')
-  lines.push(
-    '_Triage: a deterministic red here is either real AWS drift (re-characterise ' +
-      'against current AWS) or a flake the retry did not catch. The drift metric ' +
-      'will label this automatically once it lands._',
-  )
+  if (verdict) {
+    const tag = verdict.label === 'aws-drift-confirmed' ? 'AWS drift confirmed' : 'Likely a flake'
+    lines.push(`**Verdict: ${tag}.** ${verdict.summary}`)
+    if (verdict.probes.length) {
+      lines.push('')
+      lines.push('Drifted probes: ' + verdict.probes.map((id) => `\`${id}\``).join(', '))
+    }
+  } else {
+    lines.push(
+      '_Triage: a deterministic red here is either real AWS drift (re-characterise ' +
+        'against current AWS) or a flake the retry did not catch. No drift verdict was ' +
+        'available for this run._',
+    )
+  }
   return lines.join('\n')
 }
 
+function parseArgs(argv) {
+  const args = { drift: null, verdictOut: null, _: [] }
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i]
+    if (a === '--drift') args.drift = argv[++i]
+    else if (a === '--verdict-out') args.verdictOut = argv[++i]
+    else args._.push(a)
+  }
+  return args
+}
+
+function readJson(path) {
+  try {
+    return JSON.parse(readFileSync(path, 'utf8'))
+  } catch {
+    return null
+  }
+}
+
 function main() {
-  const [reportPath, runUrl = ''] = process.argv.slice(2)
+  const args = parseArgs(process.argv.slice(2))
+  const [reportPath, runUrl = ''] = args._
   if (!reportPath) {
-    console.error('usage: report-failure.mjs <vitest-json> <run-url>')
+    console.error('usage: report-failure.mjs <vitest-json> <run-url> [--drift <file>] [--verdict-out <file>]')
     process.exit(1)
   }
-  let report = null
-  try {
-    report = JSON.parse(readFileSync(reportPath, 'utf8'))
-  } catch {
-    // Leave report null; buildIssueBody emits the could-not-parse body.
-  }
-  process.stdout.write(buildIssueBody(report, runUrl) + '\n')
+  const report = readJson(reportPath)
+  const verdict = args.drift ? verdictFromDrift(readJson(args.drift)) : null
+  process.stdout.write(buildIssueBody(report, runUrl, verdict) + '\n')
+  if (args.verdictOut && verdict) writeFileSync(args.verdictOut, verdict.label + '\n')
 }
 
 if (import.meta.url === `file://${process.argv[1]}`) main()

--- a/scripts/report-failure.mjs
+++ b/scripts/report-failure.mjs
@@ -43,6 +43,9 @@ export function collectFailures(report) {
  */
 export function verdictFromDrift(driftResult) {
   if (!driftResult || typeof driftResult.clean !== 'boolean') return null
+  // A diff that compared nothing (a missing region block) yields no verdict -
+  // fall back to the generic triage note rather than guessing flake or drift.
+  if (driftResult.comparable === false) return null
   if (driftResult.clean) {
     return {
       label: 'likely-flake',
@@ -53,12 +56,16 @@ export function verdictFromDrift(driftResult) {
       probes: [],
     }
   }
+  const probes = (driftResult.drift?.probes ?? []).map((p) => p.id)
+  // A round-trip-only change carries no probe id, so name it explicitly or the
+  // issue would claim drift with nothing to act on.
+  if (driftResult.drift?.nullRoundTrip) probes.push('{ NULL: false } round-trip')
   return {
     label: 'aws-drift-confirmed',
     summary:
       "eu-west-2's wording has moved from the committed baseline, so this is real AWS drift. " +
       'Re-characterise the affected assertions against current AWS per the suite doctrine.',
-    probes: (driftResult.drift?.probes ?? []).map((p) => p.id),
+    probes,
   }
 }
 

--- a/scripts/report-failure.test.mjs
+++ b/scripts/report-failure.test.mjs
@@ -1,0 +1,74 @@
+import { describe, it, expect } from 'vitest'
+import { collectFailures, verdictFromDrift, buildIssueBody } from './report-failure.mjs'
+
+const report = (assertions) => ({
+  testResults: [{ name: 'tests/tier3/error-messages/putItem.test.ts', assertionResults: assertions }],
+})
+
+describe('collectFailures', () => {
+  it('keeps only failed assertions, with the first failure line', () => {
+    const r = report([
+      { status: 'passed', fullName: 'a > ok' },
+      { status: 'failed', fullName: 'a > broke', failureMessages: ['Error: nope\n  at x'] },
+    ])
+    const fails = collectFailures(r)
+    expect(fails).toHaveLength(1)
+    expect(fails[0].name).toBe('a > broke')
+    expect(fails[0].detail).toBe('Error: nope')
+  })
+
+  it('falls back to ancestorTitles + title when fullName is absent', () => {
+    const r = report([{ status: 'failed', ancestorTitles: ['Suite', 'Case'], title: 'does X' }])
+    expect(collectFailures(r)[0].name).toBe('Suite > Case > does X')
+  })
+})
+
+describe('verdictFromDrift', () => {
+  it('returns null when there is no usable drift data', () => {
+    expect(verdictFromDrift(null)).toBeNull()
+    expect(verdictFromDrift({})).toBeNull()
+  })
+
+  it('labels a clean diff as a likely flake', () => {
+    const v = verdictFromDrift({ clean: true, drift: { probes: [] } })
+    expect(v.label).toBe('likely-flake')
+    expect(v.probes).toEqual([])
+  })
+
+  it('labels a dirty diff as confirmed drift and lists the probe ids', () => {
+    const v = verdictFromDrift({ clean: false, drift: { probes: [{ id: 's_put_table_empty' }, { id: 'b_put_dup_ss' }] } })
+    expect(v.label).toBe('aws-drift-confirmed')
+    expect(v.probes).toEqual(['s_put_table_empty', 'b_put_dup_ss'])
+  })
+})
+
+describe('buildIssueBody', () => {
+  it('reports a could-not-parse body when the report is null', () => {
+    expect(buildIssueBody(null, 'https://run')).toContain('could not be read or parsed')
+  })
+
+  it('lists failed tests and links the run', () => {
+    const body = buildIssueBody(report([{ status: 'failed', fullName: 'a > broke' }]), 'https://run/1')
+    expect(body).toContain('1 failed test')
+    expect(body).toContain('a > broke')
+    expect(body).toContain('https://run/1')
+  })
+
+  it('fills the triage slot with a confirmed-drift verdict and probes', () => {
+    const verdict = verdictFromDrift({ clean: false, drift: { probes: [{ id: 's_put_table_empty' }] } })
+    const body = buildIssueBody(report([{ status: 'failed', fullName: 'x' }]), '', verdict)
+    expect(body).toContain('Verdict: AWS drift confirmed')
+    expect(body).toContain('`s_put_table_empty`')
+  })
+
+  it('fills the triage slot with a flake verdict when the diff is clean', () => {
+    const verdict = verdictFromDrift({ clean: true, drift: { probes: [] } })
+    const body = buildIssueBody(report([{ status: 'failed', fullName: 'x' }]), '', verdict)
+    expect(body).toContain('Verdict: Likely a flake')
+  })
+
+  it('falls back to the generic triage note without a verdict', () => {
+    const body = buildIssueBody(report([{ status: 'failed', fullName: 'x' }]), '')
+    expect(body).toContain('No drift verdict was')
+  })
+})

--- a/scripts/report-failure.test.mjs
+++ b/scripts/report-failure.test.mjs
@@ -40,6 +40,16 @@ describe('verdictFromDrift', () => {
     expect(v.label).toBe('aws-drift-confirmed')
     expect(v.probes).toEqual(['s_put_table_empty', 'b_put_dup_ss'])
   })
+
+  it('gives no verdict when the diff was not comparable (missing region block)', () => {
+    expect(verdictFromDrift({ comparable: false, clean: false, drift: { probes: [] } })).toBeNull()
+  })
+
+  it('names a round-trip-only drift so the issue is not left with an empty probe list', () => {
+    const v = verdictFromDrift({ clean: false, drift: { probes: [], nullRoundTrip: { changed: ['nullRoundTrip'] } } })
+    expect(v.label).toBe('aws-drift-confirmed')
+    expect(v.probes).toEqual(['{ NULL: false } round-trip'])
+  })
 })
 
 describe('buildIssueBody', () => {

--- a/vitest.tooling.config.ts
+++ b/vitest.tooling.config.ts
@@ -1,0 +1,12 @@
+import { defineConfig } from 'vitest/config'
+
+// Tooling tests (scripts/**/*.test.mjs) are pure-logic unit tests for the helper
+// scripts. They must not load the conformance setup - src/setup.ts provisions
+// real AWS tables in a global beforeAll - nor the tests/ suite, so they run
+// under their own config: no setupFiles, a scripts-only include, and no target.
+export default defineConfig({
+  test: {
+    globals: true,
+    include: ['scripts/**/*.test.mjs'],
+  },
+})


### PR DESCRIPTION
## What this changes

The weekly scheduled run keeps the suite honest against real AWS, but a red run only ever said "something failed" - it couldn't tell a genuine AWS wording change from a transient flake, and a flake even blocked the results-table refresh. This adds the missing signal.

- **A drift metric.** `scripts/lib/drift.mjs` diffs captured validation messages by probe (error type, full message, error count, fields) and flags prose-only changes that the tolerant Tier 3 assertions still pass. `drift-diff.mjs` reports it cross-region or across-time, under a separate `test:tooling` config that never loads the AWS suite.
- **A weekly cross-region capture.** A non-gating job captures real AWS's negative-input wording in us-east-1, ap-southeast-2 and eu-central-1 and commits `captures/cross-region-latest.json`, so paritysuite.org can show where regions diverge from the eu-west-2 baseline.
- **Drift-vs-flake triage.** When a scheduled run goes red after the retry, it re-captures eu-west-2, diffs against the committed baseline, and labels the auto-filed issue `aws-drift-confirmed` (with the drifted checks) or `likely-flake`.
- **A clearer name.** The former "cloud-only" lane is renamed to "service integrations": the ground-truth job already runs on AWS, so what sets those two tests apart is that they exercise DynamoDB's integrations with S3 and Kinesis.

## Checklist

- ~~New or modified tests run against real AWS DynamoDB and pass~~ - no conformance tests change; the new tests are pure tooling units under `test:tooling`. The capture job and triage are CI behaviour, validated on the first scheduled run (see below).
- ~~New or modified tests run against at least one emulator target and behave as expected~~ - same; emulator jobs are untouched.
- ~~If AI tools drafted or materially shaped this change, disclosed in the description above~~
- [x] Linked issue or a short note explaining the motivation - the scheduled run had gone red on consecutive Mondays for different reasons, with no way to tell drift from flake.

## Tier and scope

No tier or scoring change, and no score movement: the drift metric reads captures, writes its own artefact, and never feeds `summarise.mjs`; the capture file lives in `captures/` (not `results/`) and commits under `[skip ci]`. The integrations lane keeps running, non-gating, under its new name.

## Testing

`tsc` and `actionlint` clean; 25 tooling tests cover the diff, the verdict, and the missing-block and round-trip edge cases; the triage was exercised end to end for both labels; the lens rendering was verified against the committed capture. The gating behaviour itself only manifests against real AWS, so it validates on the first run.

## Post-Deploy Monitoring & Validation

- **Validate now:** `workflow_dispatch` the run. Confirm the capture job commits `captures/cross-region-latest.json`, the service-integrations lane runs after the gate (non-gating), and the published scores are unchanged.
- **Next scheduled run:** green if there is no real drift; the capture refreshes; on a genuine red, expect one labelled `scheduled-red` issue carrying a drift-or-flake verdict.
- **Healthy signals:** gate green, results-table commit lands, capture file refreshed.
- **Failure signals:** a red gate with no verdict (the capture step failed - check the run warning); `ResourceNotFoundException` in a cleanup step (a serialisation slip).
- **Window / owner:** Martin, through the first scheduled run after merge.
