### PR TITLE
ci: authenticate results-table and cross-region pushes as the results app

### DIFF
--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -224,10 +224,19 @@ jobs:
     environment: conformance-testing
 
     steps:
+      - name: Mint a token for the capture bot
+        id: app-token
+        uses: actions/create-github-app-token@v3
+        with:
+          app-id: ${{ vars.RESULTS_BOT_APP_ID }}
+          private-key: ${{ secrets.RESULTS_BOT_PRIVATE_KEY }}
+          permission-contents: write
+
       - uses: actions/checkout@v6
         with:
           ref: main
           fetch-depth: 0
+          token: ${{ steps.app-token.outputs.token }}
       - uses: actions/setup-node@v6
         with:
           node-version: 24

--- a/.github/workflows/results-table.yml
+++ b/.github/workflows/results-table.yml
@@ -34,10 +34,19 @@ jobs:
        github.event.workflow_run.head_branch == 'main')
 
     steps:
+      - name: Mint a token for the results bot
+        id: app-token
+        uses: actions/create-github-app-token@v3
+        with:
+          app-id: ${{ vars.RESULTS_BOT_APP_ID }}
+          private-key: ${{ secrets.RESULTS_BOT_PRIVATE_KEY }}
+          permission-contents: write
+
       - uses: actions/checkout@v6
         with:
           ref: main
           fetch-depth: 0
+          token: ${{ steps.app-token.outputs.token }}
 
       - uses: actions/setup-node@v6
         with:


### PR DESCRIPTION
Mint a per-run app token (contents:write only) and push generated data to main with it. `[skip ci]` still guards the bot's own push from self-triggering.