### PR TITLE
ci: use client-id for the results app token

### DIFF
--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -228,7 +228,7 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@v3
         with:
-          app-id: ${{ vars.RESULTS_BOT_APP_ID }}
+          client-id: ${{ vars.RESULTS_BOT_CLIENT_ID }}
           private-key: ${{ secrets.RESULTS_BOT_PRIVATE_KEY }}
           permission-contents: write
 

--- a/.github/workflows/results-table.yml
+++ b/.github/workflows/results-table.yml
@@ -38,7 +38,7 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@v3
         with:
-          app-id: ${{ vars.RESULTS_BOT_APP_ID }}
+          client-id: ${{ vars.RESULTS_BOT_CLIENT_ID }}
           private-key: ${{ secrets.RESULTS_BOT_PRIVATE_KEY }}
           permission-contents: write
 


### PR DESCRIPTION
Switch the app-token mint steps from the deprecated `app-id` input to `client-id` (vars.RESULTS_BOT_CLIENT_ID). No behaviour change.