### PR TITLE
fix: restore single-fork execution under vitest 4 (migrate removed poolOptions)

### DIFF
--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -20,13 +20,17 @@ export default defineConfig({
     // singleFork worker against the shared tables, which is safe because each
     // test cleans up after itself; don't raise the bound blindly.
     retry: Number(process.env.CONFORMANCE_RETRY ?? 0),
-    // singleFork is a CORRECTNESS requirement, not just performance.
-    // Table definitions are resolved at module load time and shared by reference
-    // across test files. Parallel execution would cause table contention.
+    // CORRECTNESS requirement, not just performance. Table definitions are
+    // resolved at module load time and shared by reference across test files, so
+    // the suite must run as a single, non-isolated worker: parallel or
+    // module-isolated execution re-evaluates the table names per file and causes
+    // table contention and ResourceNotFoundException. vitest 4 removed
+    // `poolOptions` and replaced `forks.singleFork: true` with the top-level
+    // `maxWorkers: 1` + `isolate: false` below (see the v4 pool-rework migration);
+    // the old nested form was silently ignored, which reintroduced exactly that.
     pool: 'forks',
-    poolOptions: {
-      forks: { singleFork: true },
-    },
+    maxWorkers: 1,
+    isolate: false,
     setupFiles: ['./src/setup.ts'],
     // Canonical feature/capability tag vocabulary, declared in src/tags.ts.
     // strictTags stays on (the default), so applying a tag not declared here


### PR DESCRIPTION
## What this changes

vitest 4 removed `poolOptions`, so the suite's `poolOptions.forks.singleFork: true` has been **silently ignored** since the dev-deps bump to 4.1.x. Test files have run in parallel, module-isolated forks ever since - which both re-evaluates the shared-table names per file *and* provisions the tables concurrently. That surfaced as a `ResourceNotFoundException` cascade (plus some `ResourceInUseException`) that turned the `DynamoDB (ground truth)` job red.

This migrates the config to the v4 equivalent - `maxWorkers: 1` + `isolate: false` - restoring the single, non-isolated worker the shared-table design depends on (and silences the `poolOptions was removed` warning).

## Checklist

- [x] New or modified tests run against at least one emulator target and behave as expected - ran the previously-failing files against DynamoDB Local: **zero** `ResourceNotFoundException` / `ResourceInUseException`, and the only remaining failures are known DynamoDB Local conformance gaps (transaction WCU reporting, nested `ReturnValues`, error wording) that pass on real AWS.
- [x] Linked motivation: the ground-truth job has been red since the vitest 3→4 bump (run `27784561808`); this restores it.

Not applicable - this is a pool-config change, not a test-behaviour change:
- ~~New or modified tests run against real AWS DynamoDB and pass~~ - no AWS credentials locally; this PR's own `DynamoDB (ground truth)` job is the real-AWS validation.

## Tier and scope

Touches test execution only (the vitest pool config). No tier, scoring, or results-pipeline change.
