### PR TITLE
fix: provision shared tables once per run, not once per file

### DIFF
--- a/src/global-teardown.ts
+++ b/src/global-teardown.ts
@@ -1,0 +1,9 @@
+import { cleanupAllTables } from './helpers.js'
+
+// Runs once after the whole run (vitest globalSetup teardown), removing the
+// shared tables that src/setup.ts now provisions once per run. cleanupAllTables
+// deletes by the `_conformance_` prefix, so it clears the shared tables (and any
+// ad-hoc tables a test left behind) regardless of which worker created them.
+export async function teardown(): Promise<void> {
+  await cleanupAllTables()
+}

--- a/src/setup.ts
+++ b/src/setup.ts
@@ -8,8 +8,18 @@ import {
   compositeBTableDef,
 } from './helpers.js'
 
-// Create shared tables once before all tests
+// Provision the shared tables once per run.
+//
+// vitest 4 runs setupFiles' beforeAll for every test file (vitest 3's singleFork
+// ran it once), so without this guard the suite deletes and recreates the five
+// shared tables ~once per file - ~100 times a run. That is slow, and on real AWS
+// the churn of just-created tables surfaces as InternalServerException on the
+// data operations that hit them. The single fork (maxWorkers: 1) means every
+// file shares one process, so a process.env flag set after the first successful
+// provision is seen by every later file. Final teardown runs once in
+// src/global-teardown.ts.
 beforeAll(async () => {
+  if (process.env.CONFORMANCE_PROVISIONED === '1') return
   await cleanupAllTables()
   await Promise.all([
     createTable(hashTableDef),
@@ -18,9 +28,6 @@ beforeAll(async () => {
     createTable(compositeNTableDef),
     createTable(compositeBTableDef),
   ])
+  // Set only after success, so a failed first attempt is retried by the next file.
+  process.env.CONFORMANCE_PROVISIONED = '1'
 }, 180_000)
-
-// Cleanup after all tests
-afterAll(async () => {
-  await cleanupAllTables()
-}, 60_000)

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -32,6 +32,9 @@ export default defineConfig({
     maxWorkers: 1,
     isolate: false,
     setupFiles: ['./src/setup.ts'],
+    // Removes the shared tables once after the whole run; src/setup.ts now
+    // provisions them once per run (guarded), not once per file.
+    globalSetup: ['./src/global-teardown.ts'],
     // Canonical feature/capability tag vocabulary, declared in src/tags.ts.
     // strictTags stays on (the default), so applying a tag not declared here
     // fails collection rather than silently mis-filtering. Tags are an axis


### PR DESCRIPTION
## What this changes

Follow-up to #41. That migration restored single-fork execution (the `ResourceNotFoundException` cascade is gone), but the ground-truth run still went red with `InternalServerError` and took ~54 min.

Root cause: vitest 4 runs `setupFiles`' `beforeAll` for **every test file** (vitest 3's `singleFork` ran it once - confirmed: 3 files → 3 firings). So "create the shared tables once" had silently become "delete-and-recreate the five shared tables ~once per file" - ~100× a run. On real AWS that churn is slow, and the rapid recreation of just-created tables draws `InternalServerError` on the data operations that hit them.

This guards provisioning so it runs **once per run** (the single fork shares one process), and moves the final teardown to a `globalSetup` that fires once.

## Checklist

- [x] New or modified tests run against at least one emulator target and behave as expected - against DynamoDB Local, setup now provisions **once** (was per-file), and the failing-test set is **identical** to the per-file-reset version (89 fail / 586 pass / 10 skip both ways, zero tests fail only under provision-once). The tests are key-isolated and clean up their own items, so there are **no cross-file collisions** from sharing the tables for the whole run.
- [x] Linked motivation: restores the ground-truth job after the vitest 3→4 bump churn (follows #41).

Not applicable - this is a setup/teardown change, not a test-behaviour change:
- ~~New or modified tests run against real AWS DynamoDB and pass~~ - no AWS credentials locally, and DynamoDB Local can't reproduce the AWS-side `InternalServerError`. This PR's own `DynamoDB (ground truth)` job is the real-AWS validation; eliminating the per-file churn is the direct fix for it.

## Tier and scope

Touches test execution only (shared-table provisioning lifecycle: `src/setup.ts`, new `src/global-teardown.ts`, `vitest.config.ts`). No tier, scoring, or results-pipeline change.
