### PR TITLE
fix: make the shared hash table on-demand so large writes don't throttle

### DIFF
--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -375,6 +375,11 @@ function sleep(ms: number): Promise<void> {
 export const hashTableDef: TestTableDef = {
   name: uniqueTableName('hash'),
   hashKey: { name: 'pk', type: 'S' },
+  // On-demand, like hashNTableDef. The shared tables now live for the whole run
+  // (provisioned once), so a provisioned 5-WCU table runs out of burst capacity
+  // for the near-400KB writes in tests/tier3/limits/itemSize.test.ts and throttles.
+  // Nothing asserts this table is provisioned; createTable/config covers that mode.
+  billingMode: 'PAY_PER_REQUEST',
 }
 
 export const hashNTableDef: TestTableDef = {


### PR DESCRIPTION
## What this changes

Follow-up to #42. After provisioning the shared tables once per run, the ground-truth job went from 13 failing files to just one: `tests/tier3/limits/itemSize.test.ts` ("large binary attribute approaching limit succeeds") throttling with `ProvisionedThroughputExceededException`, reproducibly.

Cause: `hashTableDef` had no `billingMode`, so it was created **PROVISIONED at 5 WCU**. A ~400KB write needs ~400 WCU - fine on a fresh per-file table (full burst), but the tables now live for the whole run, so by the time the large write runs the burst is spent and it throttles.

Fix: give `hashTableDef` `billingMode: 'PAY_PER_REQUEST'` (matching `hashNTableDef`). On-demand has no provisioned ceiling, so the write succeeds. `ConsumedCapacity` is reported identically on-demand vs provisioned, so the consumed-capacity tests are unaffected, and nothing asserts this table is provisioned (`createTable/config` covers provisioned mode on its own tables).

## Checklist

- [x] Linked motivation: the last failure after #42; restores the ground-truth job to green.

Not applicable - this is a table billing-mode change, not a test-behaviour change:
- ~~New or modified tests run against real AWS DynamoDB and pass~~ - the throttle is provisioned-capacity-specific and can't be reproduced on DynamoDB Local; this PR's own `DynamoDB (ground truth)` job is the real-AWS validation.
- ~~New or modified tests run against at least one emulator target~~ - no test behaviour changed; on-demand vs provisioned doesn't alter item operations. typecheck passes.

## Tier and scope

Touches one shared-table billing mode (`src/helpers.ts`). No tier, scoring, or results-pipeline change; `ConsumedCapacity` values are unchanged.
