### PR TITLE
test: cover sparse secondary-index membership and index-key validation

### DIFF
--- a/tests/tier1/putItem/validation.test.ts
+++ b/tests/tier1/putItem/validation.test.ts
@@ -1,6 +1,10 @@
 import { PutItemCommand } from '@aws-sdk/client-dynamodb'
 import { ddb } from '../../../src/client.js'
-import { hashTableDef, expectDynamoError } from '../../../src/helpers.js'
+import {
+  hashTableDef,
+  compositeTableDef,
+  expectDynamoError,
+} from '../../../src/helpers.js'
 
 describe('PutItem — validation', { tags: ['put-item', 'data-plane'] }, () => {
   it('rejects PutItem to a non-existent table', async () => {
@@ -131,6 +135,52 @@ describe('PutItem — validation', { tags: ['put-item', 'data-plane'] }, () => {
       ),
       'ValidationException',
       'Can not use both expression and non-expression',
+    )
+  })
+
+  // An attribute used as a table or index key must match its declared scalar
+  // type and may not be empty. lsi1sk is declared S and is an index key on the
+  // composite table, so these writes are rejected even though the base-table
+  // keys (pk, sk) are valid.
+  it('rejects a wrong-typed index key attribute', async () => {
+    await expectDynamoError(
+      () => ddb.send(
+        new PutItemCommand({
+          TableName: compositeTableDef.name,
+          Item: { pk: { S: 'idxkey-type' }, sk: { S: 'a' }, lsi1sk: { N: '5' } },
+        }),
+      ),
+      'ValidationException',
+      /Type mismatch for Index Key/,
+    )
+  })
+
+  it('rejects a non-scalar index key attribute', async () => {
+    await expectDynamoError(
+      () => ddb.send(
+        new PutItemCommand({
+          TableName: compositeTableDef.name,
+          Item: {
+            pk: { S: 'idxkey-nonscalar' },
+            sk: { S: 'b' },
+            lsi1sk: { L: [{ S: 'x' }] },
+          },
+        }),
+      ),
+      'ValidationException',
+    )
+  })
+
+  it('rejects an empty-string index key attribute', async () => {
+    await expectDynamoError(
+      () => ddb.send(
+        new PutItemCommand({
+          TableName: compositeTableDef.name,
+          Item: { pk: { S: 'idxkey-empty' }, sk: { S: 'c' }, lsi1sk: { S: '' } },
+        }),
+      ),
+      'ValidationException',
+      /empty string/i,
     )
   })
 })

--- a/tests/tier1/query/gsi.test.ts
+++ b/tests/tier1/query/gsi.test.ts
@@ -133,6 +133,47 @@ describe('Query — GSI', { tags: ['query', 'data-plane', 'gsi'] }, () => {
       }),
     )
   })
+
+  it('sparse composite GSI: an item with the GSI hash key but no range key is excluded', async () => {
+    // Has gsi2's hash key (lsi1sk) but not its range key (lsi2sk), so it belongs
+    // in the hash-only gsi1 yet must be excluded from the composite gsi2.
+    const noRangeItem = {
+      pk: { S: 'gsi-sparse-range' },
+      sk: { S: 'x' },
+      lsi1sk: { S: 'gsi-hash-sparse-range' },
+    }
+    await ddb.send(
+      new PutItemCommand({
+        TableName: compositeTableDef.name,
+        Item: noRangeItem,
+      }),
+    )
+    // Confirm it propagated into the hash-only GSI (so it was written and indexed there).
+    await waitForGsiConsistency({
+      tableName: compositeTableDef.name,
+      indexName: 'gsi1',
+      partitionKey: { name: 'lsi1sk', value: { S: 'gsi-hash-sparse-range' } },
+      expectedCount: 1,
+    })
+
+    const result = await ddb.send(
+      new QueryCommand({
+        TableName: compositeTableDef.name,
+        IndexName: 'gsi2',
+        KeyConditionExpression: 'lsi1sk = :v',
+        ExpressionAttributeValues: { ':v': { S: 'gsi-hash-sparse-range' } },
+      }),
+    )
+
+    expect(result.Items).toHaveLength(0)
+
+    await ddb.send(
+      new DeleteItemCommand({
+        TableName: compositeTableDef.name,
+        Key: { pk: noRangeItem.pk, sk: noRangeItem.sk },
+      }),
+    )
+  })
 })
 
 describe('Query — GSI pagination across tied sort keys', { tags: ['query', 'data-plane', 'gsi'] }, () => {

--- a/tests/tier1/query/lsi.test.ts
+++ b/tests/tier1/query/lsi.test.ts
@@ -214,6 +214,44 @@ describe('Query — LSI', { tags: ['query', 'data-plane', 'lsi'] }, () => {
     expect(result.Items).toHaveLength(0)
     expect(result.Count).toBe(0)
   })
+
+  it('sparse LSI: an item missing the LSI sort key is excluded but stays in the base table', async () => {
+    // Has the base keys but not the LSI sort key (lsi1sk).
+    const noLsiSkItem = { pk: { S: 'lsi-sparse-q' }, sk: { S: 'x' } }
+    await ddb.send(
+      new PutItemCommand({
+        TableName: compositeTableDef.name,
+        Item: noLsiSkItem,
+      }),
+    )
+
+    // Absent from the LSI...
+    const lsiResult = await ddb.send(
+      new QueryCommand({
+        TableName: compositeTableDef.name,
+        IndexName: 'lsi1',
+        KeyConditionExpression: 'pk = :p',
+        ExpressionAttributeValues: { ':p': { S: 'lsi-sparse-q' } },
+        ConsistentRead: true,
+      }),
+    )
+    expect(lsiResult.Items).toHaveLength(0)
+
+    // ...but present in the base table.
+    const baseResult = await ddb.send(
+      new QueryCommand({
+        TableName: compositeTableDef.name,
+        KeyConditionExpression: 'pk = :p',
+        ExpressionAttributeValues: { ':p': { S: 'lsi-sparse-q' } },
+        ConsistentRead: true,
+      }),
+    )
+    expect(baseResult.Items).toHaveLength(1)
+
+    await cleanupItems(compositeTableDef.name, [
+      { pk: noLsiSkItem.pk, sk: noLsiSkItem.sk },
+    ])
+  })
 })
 
 describe('Query — LSI pagination across tied sort keys', { tags: ['query', 'data-plane', 'lsi'] }, () => {

--- a/tests/tier1/scan/gsi.test.ts
+++ b/tests/tier1/scan/gsi.test.ts
@@ -123,4 +123,50 @@ describe('Scan — GSI', { tags: ['scan', 'data-plane', 'gsi'] }, () => {
     expect(result.Items![0].pk?.S).toBe('scan-gsi-1')
     expect(result.ScannedCount!).toBeGreaterThanOrEqual(result.Count!)
   })
+
+  it('sparse composite GSI: an item missing the GSI range key is not scanned', async () => {
+    // Written to the base table and present in the hash-only gsi1, but absent
+    // from a scan of the composite gsi2 because it has no lsi2sk.
+    const noRangeItem = {
+      pk: { S: 'scan-gsi-sparse' },
+      sk: { S: 'x' },
+      lsi1sk: { S: 'scan-gsi-hash-sparse' },
+    }
+    await ddb.send(
+      new PutItemCommand({
+        TableName: compositeTableDef.name,
+        Item: noRangeItem,
+      }),
+    )
+    await waitForGsiConsistency({
+      tableName: compositeTableDef.name,
+      indexName: 'gsi1',
+      partitionKey: { name: 'lsi1sk', value: { S: 'scan-gsi-hash-sparse' } },
+      expectedCount: 1,
+    })
+
+    // Present in the hash-only GSI...
+    const gsi1Scan = await ddb.send(
+      new ScanCommand({
+        TableName: compositeTableDef.name,
+        IndexName: 'gsi1',
+        FilterExpression: 'lsi1sk = :v',
+        ExpressionAttributeValues: { ':v': { S: 'scan-gsi-hash-sparse' } },
+      }),
+    )
+    expect(gsi1Scan.Items!.map((i) => i.pk?.S)).toContain('scan-gsi-sparse')
+
+    // ...but never scanned from the composite GSI.
+    const gsi2Scan = await ddb.send(
+      new ScanCommand({
+        TableName: compositeTableDef.name,
+        IndexName: 'gsi2',
+      }),
+    )
+    expect(gsi2Scan.Items!.map((i) => i.pk?.S)).not.toContain('scan-gsi-sparse')
+
+    await cleanupItems(compositeTableDef.name, [
+      { pk: noRangeItem.pk, sk: noRangeItem.sk },
+    ])
+  })
 })

--- a/tests/tier1/scan/lsi.test.ts
+++ b/tests/tier1/scan/lsi.test.ts
@@ -113,4 +113,40 @@ describe('Scan — LSI', { tags: ['scan', 'data-plane', 'lsi'] }, () => {
       expect(item.data).toBeUndefined()
     }
   })
+
+  it('sparse LSI: an item missing the LSI sort key is not scanned', async () => {
+    // Has the base keys but not the LSI sort key (lsi1sk).
+    const noLsiSkItem = { pk: { S: 'scan-lsi-sparse' }, sk: { S: 'x' } }
+    await ddb.send(
+      new PutItemCommand({
+        TableName: compositeTableDef.name,
+        Item: noLsiSkItem,
+      }),
+    )
+
+    // Absent from an LSI scan...
+    const lsiScan = await ddb.send(
+      new ScanCommand({
+        TableName: compositeTableDef.name,
+        IndexName: 'lsi1',
+        ConsistentRead: true,
+      }),
+    )
+    expect(lsiScan.Items!.map((i) => i.pk?.S)).not.toContain('scan-lsi-sparse')
+
+    // ...but present in a base-table scan.
+    const baseScan = await ddb.send(
+      new ScanCommand({
+        TableName: compositeTableDef.name,
+        ConsistentRead: true,
+        FilterExpression: 'pk = :p',
+        ExpressionAttributeValues: { ':p': { S: 'scan-lsi-sparse' } },
+      }),
+    )
+    expect(baseScan.Items!.map((i) => i.pk?.S)).toContain('scan-lsi-sparse')
+
+    await cleanupItems(compositeTableDef.name, [
+      { pk: noLsiSkItem.pk, sk: noLsiSkItem.sk },
+    ])
+  })
 })


### PR DESCRIPTION
Add tier1 cases for two DynamoDB behaviours. Sparse-index membership: an item carrying a composite GSI or LSI partition key but missing the sort key is excluded from the index while remaining in the base table, asserted through both Query and Scan. Index-key validation: PutItem rejects an index key attribute that is the wrong type, non-scalar, or an empty string. Captured against real DynamoDB.
