### PR TITLE
test: cover invalid key values in transact and batch writes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,32 @@
 A dated log of how the conformance test suite has grown: tests added, tiers
 broadened, and targets brought into the run. Newest first.
 
+## 2026-06-22
+
+Grew to 736 tests, up 30, covering what TransactWriteItems and BatchWriteItem do
+with an item whose key value is malformed - the wrong type, non-scalar, or an
+empty string - across both table and index keys. PutItem already covered this;
+the transactional and batch paths covered none of it.
+
+Characterising it against real AWS turned up a split worth pinning. An
+empty-string key value is rejected by up-front input validation, so even inside a
+transaction it surfaces as a top-level ValidationException. A wrong-typed or
+non-scalar key value is caught while the transaction runs, so it comes back as a
+TransactionCanceledException carrying a ValidationError reason rather than a
+top-level error. BatchWriteItem has no cancellation path, so every variant there
+is a plain ValidationException. The tests pin both halves, which catches two
+opposite mistakes: an engine that wraps the empty-string case as a cancellation,
+and one that surfaces the type-mismatch case as a top-level error.
+
+## 2026-06-21
+
+Grew to 706 tests, up 7, tightening secondary-index behaviour in Tier 1. Query
+and Scan on a GSI or LSI now assert sparse membership: an item that omits the
+index key stays off the index but remains on the base table. And PutItem now
+rejects an item whose GSI or LSI key value is the wrong type, non-scalar, or an
+empty string while the base-table keys are valid, holding an index key to its
+declared scalar type the same way a table key is held.
+
 ## 2026-06-09
 
 Real DynamoDB in eu-west-2 reworded a chunk of its validation errors, and the

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dynamodb-conformance",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "description": "Independent conformance test suite for DynamoDB-compatible endpoints",
   "keywords": [
     "dynamodb",

--- a/tests/tier1/batchWriteItem/validation.test.ts
+++ b/tests/tier1/batchWriteItem/validation.test.ts
@@ -1,6 +1,10 @@
 import { BatchWriteItemCommand } from '@aws-sdk/client-dynamodb'
 import { ddb } from '../../../src/client.js'
-import { hashTableDef, expectDynamoError } from '../../../src/helpers.js'
+import {
+  hashTableDef,
+  compositeTableDef,
+  expectDynamoError,
+} from '../../../src/helpers.js'
 
 describe('BatchWriteItem — validation', { tags: ['batch', 'data-plane'] }, () => {
   it('rejects more than 25 items', async () => {
@@ -81,5 +85,118 @@ describe('BatchWriteItem — validation', { tags: ['batch', 'data-plane'] }, () 
       expect(err.name).toBe('ValidationException')
       expect(err.$metadata?.httpStatusCode).toBe(400)
     }
+  })
+
+  // A key attribute (table or index) whose value has the wrong type, is
+  // non-scalar, or is an empty string is rejected. BatchWriteItem validates the
+  // item up front, so every variant is a top-level ValidationException for the
+  // whole request - there is no cancellation path here, unlike TransactWriteItems.
+  // Exact strings are pinned in tests/tier3/error-messages/batchWriteItem.test.ts.
+  it('rejects a wrong-typed table key value', async () => {
+    await expectDynamoError(
+      () => ddb.send(
+        new BatchWriteItemCommand({
+          RequestItems: {
+            [hashTableDef.name]: [
+              { PutRequest: { Item: { pk: { N: '5' } } } },
+            ],
+          },
+        }),
+      ),
+      'ValidationException',
+      /does not match the schema/,
+    )
+  })
+
+  it('rejects a non-scalar table key value', async () => {
+    await expectDynamoError(
+      () => ddb.send(
+        new BatchWriteItemCommand({
+          RequestItems: {
+            [hashTableDef.name]: [
+              { PutRequest: { Item: { pk: { L: [{ S: 'x' }] } } } },
+            ],
+          },
+        }),
+      ),
+      'ValidationException',
+      /does not match the schema/,
+    )
+  })
+
+  it('rejects an empty-string table key value', async () => {
+    await expectDynamoError(
+      () => ddb.send(
+        new BatchWriteItemCommand({
+          RequestItems: {
+            [hashTableDef.name]: [
+              { PutRequest: { Item: { pk: { S: '' } } } },
+            ],
+          },
+        }),
+      ),
+      'ValidationException',
+      /empty string value/i,
+    )
+  })
+
+  it('rejects a wrong-typed index key value', async () => {
+    await expectDynamoError(
+      () => ddb.send(
+        new BatchWriteItemCommand({
+          RequestItems: {
+            [compositeTableDef.name]: [
+              {
+                PutRequest: {
+                  Item: { pk: { S: 'bw-idx-type' }, sk: { S: 'a' }, lsi1sk: { N: '5' } },
+                },
+              },
+            ],
+          },
+        }),
+      ),
+      'ValidationException',
+      /Type mismatch for Index Key/,
+    )
+  })
+
+  it('rejects a non-scalar index key value', async () => {
+    await expectDynamoError(
+      () => ddb.send(
+        new BatchWriteItemCommand({
+          RequestItems: {
+            [compositeTableDef.name]: [
+              {
+                PutRequest: {
+                  Item: { pk: { S: 'bw-idx-nonscalar' }, sk: { S: 'b' }, lsi1sk: { L: [{ S: 'x' }] } },
+                },
+              },
+            ],
+          },
+        }),
+      ),
+      'ValidationException',
+      /Type mismatch for Index Key/,
+    )
+  })
+
+  it('rejects an empty-string index key value', async () => {
+    await expectDynamoError(
+      () => ddb.send(
+        new BatchWriteItemCommand({
+          RequestItems: {
+            [compositeTableDef.name]: [
+              {
+                PutRequest: {
+                  Item: { pk: { S: 'bw-idx-empty' }, sk: { S: 'c' }, lsi1sk: { S: '' } },
+                },
+              },
+            ],
+          },
+        }),
+      ),
+      'ValidationException',
+      /secondary index key/i,
+    )
   })
 })

--- a/tests/tier2/transactions/transactWrite.test.ts
+++ b/tests/tier2/transactions/transactWrite.test.ts
@@ -55,6 +55,15 @@ const hashKeys = [
 
 const compositeKeys = [
   { pk: { S: 'tw-cross-comp' }, sk: { S: 'sk1' } },
+  // Defensive: the invalid-index-key cases below must all fail validation and
+  // write nothing. Clean up anyway so a too-lenient target that wrongly persists
+  // them does not leak rows into later tests.
+  { pk: { S: 'tw-idx-type' }, sk: { S: 'a' } },
+  { pk: { S: 'tw-idx-nonscalar' }, sk: { S: 'b' } },
+  { pk: { S: 'tw-idx-empty' }, sk: { S: 'c' } },
+  { pk: { S: 'tw-idx-upd-type' }, sk: { S: 'a' } },
+  { pk: { S: 'tw-idx-upd-nonscalar' }, sk: { S: 'b' } },
+  { pk: { S: 'tw-idx-upd-empty' }, sk: { S: 'c' } },
 ]
 
 afterAll(async () => {
@@ -688,6 +697,151 @@ describe('TransactWriteItems - validation', { tags: ['transactions', 'data-plane
           }),
         ),
       'ResourceNotFoundException',
+    )
+  })
+
+  // An item carrying a malformed key value (table or index key) is rejected, but
+  // the error SHAPE depends on the fault, and the two halves are opposite traps:
+  //
+  //   - Wrong type / non-scalar: caught during transaction execution, so AWS
+  //     cancels with a TransactionCanceledException whose reason Code is
+  //     'ValidationError'. An engine that "validates up front" and returns a
+  //     top-level ValidationException here diverges from real DynamoDB.
+  //   - Empty string: caught by up-front input validation, so AWS returns a
+  //     top-level ValidationException even inside a transaction. An engine that
+  //     wraps this as a TransactionCanceledException diverges.
+  //
+  // Both directions are asserted below. Exact strings live in
+  // tests/tier3/error-messages/transactWriteItems.test.ts.
+
+  const expectCancelledForValidation = async (transactItems: unknown[]) => {
+    try {
+      await ddb.send(
+        new TransactWriteItemsCommand({ TransactItems: transactItems as never }),
+      )
+      expect.unreachable('should have thrown')
+    } catch (err) {
+      expect(err).toBeInstanceOf(TransactionCanceledException)
+      const txErr = err as TransactionCanceledException
+      // name is TransactionCanceledException, NOT a top-level ValidationException.
+      expect(txErr.name).toBe('TransactionCanceledException')
+      expect(txErr.CancellationReasons?.[0]?.Code).toBe('ValidationError')
+    }
+  }
+
+  it('Put with a wrong-typed table key cancels with a ValidationError reason', async () => {
+    await expectCancelledForValidation([
+      { Put: { TableName: hashTableDef.name, Item: { pk: { N: '5' } } } },
+    ])
+  })
+
+  it('Put with a non-scalar table key cancels with a ValidationError reason', async () => {
+    await expectCancelledForValidation([
+      { Put: { TableName: hashTableDef.name, Item: { pk: { L: [{ S: 'x' }] } } } },
+    ])
+  })
+
+  it('Put with a wrong-typed index key cancels with a ValidationError reason', async () => {
+    await expectCancelledForValidation([
+      {
+        Put: {
+          TableName: compositeTableDef.name,
+          Item: { pk: { S: 'tw-idx-type' }, sk: { S: 'a' }, lsi1sk: { N: '5' } },
+        },
+      },
+    ])
+  })
+
+  it('Put with a non-scalar index key cancels with a ValidationError reason', async () => {
+    await expectCancelledForValidation([
+      {
+        Put: {
+          TableName: compositeTableDef.name,
+          Item: { pk: { S: 'tw-idx-nonscalar' }, sk: { S: 'b' }, lsi1sk: { L: [{ S: 'x' }] } },
+        },
+      },
+    ])
+  })
+
+  it('Update setting a wrong-typed index key cancels with a ValidationError reason', async () => {
+    await expectCancelledForValidation([
+      {
+        Update: {
+          TableName: compositeTableDef.name,
+          Key: { pk: { S: 'tw-idx-upd-type' }, sk: { S: 'a' } },
+          UpdateExpression: 'SET lsi1sk = :v',
+          ExpressionAttributeValues: { ':v': { N: '5' } },
+        },
+      },
+    ])
+  })
+
+  it('Update setting a non-scalar index key cancels with a ValidationError reason', async () => {
+    await expectCancelledForValidation([
+      {
+        Update: {
+          TableName: compositeTableDef.name,
+          Key: { pk: { S: 'tw-idx-upd-nonscalar' }, sk: { S: 'b' } },
+          UpdateExpression: 'SET lsi1sk = :v',
+          ExpressionAttributeValues: { ':v': { L: [{ S: 'x' }] } },
+        },
+      },
+    ])
+  })
+
+  it('Put with an empty-string table key is a top-level ValidationException', async () => {
+    // Not a TransactionCanceledException — expectDynamoError asserts the name is
+    // ValidationException, which a cancellation wrapper would fail.
+    await expectDynamoError(
+      () => ddb.send(
+        new TransactWriteItemsCommand({
+          TransactItems: [
+            { Put: { TableName: hashTableDef.name, Item: { pk: { S: '' } } } },
+          ],
+        }),
+      ),
+      'ValidationException',
+      /empty string value/i,
+    )
+  })
+
+  it('Put with an empty-string index key is a top-level ValidationException', async () => {
+    await expectDynamoError(
+      () => ddb.send(
+        new TransactWriteItemsCommand({
+          TransactItems: [
+            {
+              Put: {
+                TableName: compositeTableDef.name,
+                Item: { pk: { S: 'tw-idx-empty' }, sk: { S: 'c' }, lsi1sk: { S: '' } },
+              },
+            },
+          ],
+        }),
+      ),
+      'ValidationException',
+      /secondary index key/i,
+    )
+  })
+
+  it('Update setting an empty-string index key is a top-level ValidationException', async () => {
+    await expectDynamoError(
+      () => ddb.send(
+        new TransactWriteItemsCommand({
+          TransactItems: [
+            {
+              Update: {
+                TableName: compositeTableDef.name,
+                Key: { pk: { S: 'tw-idx-upd-empty' }, sk: { S: 'c' } },
+                UpdateExpression: 'SET lsi1sk = :v',
+                ExpressionAttributeValues: { ':v': { S: '' } },
+              },
+            },
+          ],
+        }),
+      ),
+      'ValidationException',
+      /secondary index key/i,
     )
   })
 

--- a/tests/tier3/error-messages/batchWriteItem.test.ts
+++ b/tests/tier3/error-messages/batchWriteItem.test.ts
@@ -4,14 +4,27 @@ import {
   ResourceNotFoundException,
 } from '@aws-sdk/client-dynamodb'
 import { ddb } from '../../../src/client.js'
-import { hashTableDef, cleanupItems } from '../../../src/helpers.js'
+import {
+  hashTableDef,
+  compositeTableDef,
+  cleanupItems,
+} from '../../../src/helpers.js'
 
 const keysToCleanup = [
   { pk: { S: 'em-bw-dup' } },
 ]
 
+// Defensive: the invalid-index-key cases below fail validation and write
+// nothing; clean up anyway in case a too-lenient target persists them.
+const compositeKeysToCleanup = [
+  { pk: { S: 'em-bw-idx-type' }, sk: { S: 'a' } },
+  { pk: { S: 'em-bw-idx-nonscalar' }, sk: { S: 'b' } },
+  { pk: { S: 'em-bw-idx-empty' }, sk: { S: 'c' } },
+]
+
 afterAll(async () => {
   await cleanupItems(hashTableDef.name, keysToCleanup)
+  await cleanupItems(compositeTableDef.name, compositeKeysToCleanup)
 })
 
 describe('BatchWriteItem — exact error messages', { tags: ['batch', 'data-plane'] }, () => {
@@ -102,5 +115,90 @@ describe('BatchWriteItem — exact error messages', { tags: ['batch', 'data-plan
         'Requested resource not found',
       )
     }
+  })
+
+  // Invalid key value inside a PutRequest item. BatchWriteItem validates up front,
+  // so every variant is a top-level ValidationException (no cancellation path).
+  // Strings captured from real AWS eu-west-2. The wrong-type and non-scalar table
+  // keys collapse to the generic schema-mismatch message; the index-key messages
+  // name gsi1, the alphabetically-first index lsi1sk keys on compositeTableDef.
+  const expectExactValidation = async (
+    command: BatchWriteItemCommand,
+    message: string,
+  ) => {
+    try {
+      await ddb.send(command)
+      expect.unreachable('should have thrown')
+    } catch (err) {
+      expect(err).toBeInstanceOf(DynamoDBServiceException)
+      expect((err as DynamoDBServiceException).name).toBe('ValidationException')
+      expect((err as DynamoDBServiceException).message).toBe(message)
+    }
+  }
+
+  it('wrong-typed table key: full schema-mismatch message', async () => {
+    await expectExactValidation(
+      new BatchWriteItemCommand({
+        RequestItems: { [hashTableDef.name]: [{ PutRequest: { Item: { pk: { N: '5' } } } }] },
+      }),
+      'The provided key element does not match the schema',
+    )
+  })
+
+  it('non-scalar table key: full schema-mismatch message', async () => {
+    await expectExactValidation(
+      new BatchWriteItemCommand({
+        RequestItems: { [hashTableDef.name]: [{ PutRequest: { Item: { pk: { L: [{ S: 'x' }] } } } }] },
+      }),
+      'The provided key element does not match the schema',
+    )
+  })
+
+  it('empty-string table key: full empty-value message', async () => {
+    await expectExactValidation(
+      new BatchWriteItemCommand({
+        RequestItems: { [hashTableDef.name]: [{ PutRequest: { Item: { pk: { S: '' } } } }] },
+      }),
+      'One or more parameter values are not valid. The AttributeValue for a key attribute cannot contain an empty string value. Key: pk',
+    )
+  })
+
+  it('wrong-typed index key: full type-mismatch message', async () => {
+    await expectExactValidation(
+      new BatchWriteItemCommand({
+        RequestItems: {
+          [compositeTableDef.name]: [
+            { PutRequest: { Item: { pk: { S: 'em-bw-idx-type' }, sk: { S: 'a' }, lsi1sk: { N: '5' } } } },
+          ],
+        },
+      }),
+      'One or more parameter values were invalid: Type mismatch for Index Key lsi1sk Expected: S Actual: N IndexName: gsi1',
+    )
+  })
+
+  it('non-scalar index key: full type-mismatch message', async () => {
+    await expectExactValidation(
+      new BatchWriteItemCommand({
+        RequestItems: {
+          [compositeTableDef.name]: [
+            { PutRequest: { Item: { pk: { S: 'em-bw-idx-nonscalar' }, sk: { S: 'b' }, lsi1sk: { L: [{ S: 'x' }] } } } },
+          ],
+        },
+      }),
+      'One or more parameter values were invalid: Type mismatch for Index Key lsi1sk Expected: S Actual: L IndexName: gsi1',
+    )
+  })
+
+  it('empty-string index key: full secondary-index-key message', async () => {
+    await expectExactValidation(
+      new BatchWriteItemCommand({
+        RequestItems: {
+          [compositeTableDef.name]: [
+            { PutRequest: { Item: { pk: { S: 'em-bw-idx-empty' }, sk: { S: 'c' }, lsi1sk: { S: '' } } } },
+          ],
+        },
+      }),
+      'One or more parameter values are not valid. A value specified for a secondary index key is not supported. The AttributeValue for a key attribute cannot contain an empty string value. IndexName: gsi1, IndexKey: lsi1sk',
+    )
   })
 })

--- a/tests/tier3/error-messages/transactWriteItems.test.ts
+++ b/tests/tier3/error-messages/transactWriteItems.test.ts
@@ -6,7 +6,11 @@ import {
   TransactionCanceledException,
 } from '@aws-sdk/client-dynamodb'
 import { ddb } from '../../../src/client.js'
-import { hashTableDef, cleanupItems } from '../../../src/helpers.js'
+import {
+  hashTableDef,
+  compositeTableDef,
+  cleanupItems,
+} from '../../../src/helpers.js'
 
 const keysToCleanup = [
   { pk: { S: 'em-twi-dup' } },
@@ -16,8 +20,20 @@ const keysToCleanup = [
   { pk: { S: 'em-twi-pos-new' } },
 ]
 
+// Defensive: the invalid-key-value cases below fail validation and write
+// nothing; clean up anyway in case a too-lenient target persists them.
+const compositeKeysToCleanup = [
+  { pk: { S: 'em-twi-idx-type' }, sk: { S: 'a' } },
+  { pk: { S: 'em-twi-idx-nonscalar' }, sk: { S: 'b' } },
+  { pk: { S: 'em-twi-idx-empty' }, sk: { S: 'c' } },
+  { pk: { S: 'em-twi-idx-upd-type' }, sk: { S: 'a' } },
+  { pk: { S: 'em-twi-idx-upd-nonscalar' }, sk: { S: 'b' } },
+  { pk: { S: 'em-twi-idx-upd-empty' }, sk: { S: 'c' } },
+]
+
 afterAll(async () => {
   await cleanupItems(hashTableDef.name, keysToCleanup)
+  await cleanupItems(compositeTableDef.name, compositeKeysToCleanup)
 })
 
 describe('TransactWriteItems — exact error messages', { tags: ['transactions', 'data-plane'] }, () => {
@@ -222,5 +238,175 @@ describe('TransactWriteItems — exact error messages', { tags: ['transactions',
         'The conditional request failed',
       )
     }
+  })
+
+  // Invalid key value (table or index) inside a transact Put/Update. The error
+  // shape splits by fault, captured from real AWS eu-west-2:
+  //   - wrong type / non-scalar: TransactionCanceledException, reason code
+  //     'ValidationError', reason Message carrying the PutItem-style string;
+  //   - empty string: top-level ValidationException (up-front input validation).
+  // Index-key messages name gsi1, the alphabetically-first index lsi1sk keys.
+  const expectCancelledReason = async (
+    command: TransactWriteItemsCommand,
+    reasonMessage: string,
+  ) => {
+    try {
+      await ddb.send(command)
+      expect.unreachable('should have thrown')
+    } catch (err) {
+      expect(err).toBeInstanceOf(TransactionCanceledException)
+      const txErr = err as TransactionCanceledException
+      const expectedReasons = ['ValidationError'] as const
+      expect(txErr.message).toBe(
+        `Transaction cancelled, please refer cancellation reasons for specific reasons [${expectedReasons.join(', ')}]`,
+      )
+      expect(txErr.CancellationReasons?.map((r) => r.Code)).toEqual([
+        ...expectedReasons,
+      ])
+      expect(txErr.CancellationReasons?.[0]?.Message).toBe(reasonMessage)
+    }
+  }
+
+  const expectTopLevelValidation = async (
+    command: TransactWriteItemsCommand,
+    message: string,
+  ) => {
+    try {
+      await ddb.send(command)
+      expect.unreachable('should have thrown')
+    } catch (err) {
+      expect(err).toBeInstanceOf(DynamoDBServiceException)
+      expect((err as DynamoDBServiceException).name).toBe('ValidationException')
+      expect((err as DynamoDBServiceException).message).toBe(message)
+    }
+  }
+
+  it('Put wrong-typed table key: cancelled with full ValidationError reason', async () => {
+    await expectCancelledReason(
+      new TransactWriteItemsCommand({
+        TransactItems: [{ Put: { TableName: hashTableDef.name, Item: { pk: { N: '5' } } } }],
+      }),
+      'One or more parameter values were invalid: Type mismatch for key pk expected: S actual: N',
+    )
+  })
+
+  it('Put non-scalar table key: cancelled with full ValidationError reason', async () => {
+    await expectCancelledReason(
+      new TransactWriteItemsCommand({
+        TransactItems: [{ Put: { TableName: hashTableDef.name, Item: { pk: { L: [{ S: 'x' }] } } } }],
+      }),
+      'One or more parameter values were invalid: Type mismatch for key pk expected: S actual: L',
+    )
+  })
+
+  it('Put wrong-typed index key: cancelled with full ValidationError reason', async () => {
+    await expectCancelledReason(
+      new TransactWriteItemsCommand({
+        TransactItems: [
+          {
+            Put: {
+              TableName: compositeTableDef.name,
+              Item: { pk: { S: 'em-twi-idx-type' }, sk: { S: 'a' }, lsi1sk: { N: '5' } },
+            },
+          },
+        ],
+      }),
+      'One or more parameter values were invalid: Type mismatch for Index Key lsi1sk Expected: S Actual: N IndexName: gsi1',
+    )
+  })
+
+  it('Put non-scalar index key: cancelled with full ValidationError reason', async () => {
+    await expectCancelledReason(
+      new TransactWriteItemsCommand({
+        TransactItems: [
+          {
+            Put: {
+              TableName: compositeTableDef.name,
+              Item: { pk: { S: 'em-twi-idx-nonscalar' }, sk: { S: 'b' }, lsi1sk: { L: [{ S: 'x' }] } },
+            },
+          },
+        ],
+      }),
+      'One or more parameter values were invalid: Type mismatch for Index Key lsi1sk Expected: S Actual: L IndexName: gsi1',
+    )
+  })
+
+  it('Update wrong-typed index key: cancelled with full ValidationError reason', async () => {
+    await expectCancelledReason(
+      new TransactWriteItemsCommand({
+        TransactItems: [
+          {
+            Update: {
+              TableName: compositeTableDef.name,
+              Key: { pk: { S: 'em-twi-idx-upd-type' }, sk: { S: 'a' } },
+              UpdateExpression: 'SET lsi1sk = :v',
+              ExpressionAttributeValues: { ':v': { N: '5' } },
+            },
+          },
+        ],
+      }),
+      'One or more parameter values were invalid: Type mismatch for Index Key lsi1sk Expected: S Actual: N IndexName: gsi1',
+    )
+  })
+
+  it('Update non-scalar index key: cancelled with full ValidationError reason', async () => {
+    await expectCancelledReason(
+      new TransactWriteItemsCommand({
+        TransactItems: [
+          {
+            Update: {
+              TableName: compositeTableDef.name,
+              Key: { pk: { S: 'em-twi-idx-upd-nonscalar' }, sk: { S: 'b' } },
+              UpdateExpression: 'SET lsi1sk = :v',
+              ExpressionAttributeValues: { ':v': { L: [{ S: 'x' }] } },
+            },
+          },
+        ],
+      }),
+      'One or more parameter values were invalid: Type mismatch for Index Key lsi1sk Expected: S Actual: L IndexName: gsi1',
+    )
+  })
+
+  it('Put empty-string table key: top-level ValidationException', async () => {
+    await expectTopLevelValidation(
+      new TransactWriteItemsCommand({
+        TransactItems: [{ Put: { TableName: hashTableDef.name, Item: { pk: { S: '' } } } }],
+      }),
+      'One or more parameter values are not valid. The AttributeValue for a key attribute cannot contain an empty string value. Key: pk',
+    )
+  })
+
+  it('Put empty-string index key: top-level ValidationException', async () => {
+    await expectTopLevelValidation(
+      new TransactWriteItemsCommand({
+        TransactItems: [
+          {
+            Put: {
+              TableName: compositeTableDef.name,
+              Item: { pk: { S: 'em-twi-idx-empty' }, sk: { S: 'c' }, lsi1sk: { S: '' } },
+            },
+          },
+        ],
+      }),
+      'One or more parameter values are not valid. A value specified for a secondary index key is not supported. The AttributeValue for a key attribute cannot contain an empty string value. IndexName: gsi1, IndexKey: lsi1sk',
+    )
+  })
+
+  it('Update empty-string index key: top-level ValidationException', async () => {
+    await expectTopLevelValidation(
+      new TransactWriteItemsCommand({
+        TransactItems: [
+          {
+            Update: {
+              TableName: compositeTableDef.name,
+              Key: { pk: { S: 'em-twi-idx-upd-empty' }, sk: { S: 'c' } },
+              UpdateExpression: 'SET lsi1sk = :v',
+              ExpressionAttributeValues: { ':v': { S: '' } },
+            },
+          },
+        ],
+      }),
+      'One or more parameter values are not valid. The update expression attempted to update a secondary index key to a value that is not supported. The AttributeValue for a key attribute cannot contain an empty string value.',
+    )
   })
 })


### PR DESCRIPTION
## What this changes

Adds conformance coverage for an item with a malformed key value - the wrong type, non-scalar, or an empty string - sent through `TransactWriteItems` and `BatchWriteItem`, for both table and index keys. `PutItem` already covered this; the transactional and batch paths covered none of it. 30 new cases: shape assertions in the operation-tier files, exact-message pins in the Tier 3 error-message files.

These were characterised against real AWS first, which corrected the assumption in the linked issue. The behaviour is a split, not a single rule:

- An **empty-string** key value is rejected by up-front input validation, so even inside a transaction it surfaces as a top-level `ValidationException`.
- A **wrong-typed or non-scalar** key value is caught while the transaction runs, so it comes back as a `TransactionCanceledException` carrying a `ValidationError` reason, not a top-level error.
- `BatchWriteItem` has no cancellation path, so every variant there is a plain `ValidationException` (the wrong-type and non-scalar table keys collapse to the generic schema-mismatch message).

The tests pin both halves, so they catch two opposite divergences: a target that wraps the empty-string case as a cancellation, and one that surfaces the type-mismatch case as a top-level error.

Also backfills the changelog (the 2026-06-21 secondary-index entry had been missed) and bumps the package version to 1.4.0.

Closes #45.

## Checklist

- [x] New or modified tests run against real AWS DynamoDB and pass (73/73 in eu-west-2, including all 30 new cases)
- [ ] New or modified tests run against at least one emulator target and behave as expected
  - Not run locally against an emulator in this change. These pin real-AWS behaviour; a target that hasn't implemented the validation yet is expected to diverge, which is what the cases document. Emulator targets are scored in the results pipeline.
- [x] Linked issue or a short note explaining the motivation (closes #45)
