### PR TITLE
Quieten dependabot: monthly cadence, single aws-sdk group

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,17 +3,21 @@ updates:
   - package-ecosystem: npm
     directory: "/"
     schedule:
-      interval: weekly
+      interval: monthly
     open-pull-requests-limit: 5
     groups:
+      # The AWS SDK ships ~daily; keep every @aws-sdk/* in one group, including
+      # the dev-only clients, so it lands as a single monthly PR.
       aws-sdk:
         patterns:
           - "@aws-sdk/*"
       dev-dependencies:
         dependency-type: development
+        exclude-patterns:
+          - "@aws-sdk/*"
 
   - package-ecosystem: github-actions
     directory: "/"
     schedule:
-      interval: weekly
+      interval: monthly
     open-pull-requests-limit: 5


### PR DESCRIPTION
The AWS SDK ships ~daily and bumps its minor each release, and the bumps were split across the `aws-sdk` and `dev-dependencies` groups, so the suite kept seeing overlapping aws-sdk PRs.

- npm and github-actions updates move to monthly
- every `@aws-sdk/*` (runtime and dev-only clients) is consolidated into the `aws-sdk` group, so the SDK arrives as one PR a month
