### PR TITLE
Transact lookup-key error coverage, grounded across four regions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,18 @@
 A dated log of how the conformance test suite has grown: tests added, tiers
 broadened, and targets brought into the run. Newest first.
 
+## 2026-06-24
+
+Grew to 762 tests, up 18, covering a malformed value in the lookup Key of a
+TransactWriteItems Update, Delete, or ConditionCheck - the path a Put item key does
+not take. Captured across four regions (eu-west-2, us-east-1, ap-southeast-2,
+eu-central-1), where every string was identical, so they pin exactly. An empty-string
+Key surfaces as a top-level ValidationException with the same message a Put item key
+gives; a wrong-typed or non-scalar Key cancels with a ValidationError reason carrying
+"The provided key element does not match the schema" - the key-only form, not the
+"Type mismatch for key" message the item-key path returns. The same run confirmed the
+BatchWriteItem table-key schema-mismatch message is region-invariant.
+
 ## 2026-06-23
 
 Grew to 744 tests, up 8, pinning the Select / ProjectionExpression rules on Query

--- a/captures/cross-region-latest.json
+++ b/captures/cross-region-latest.json
@@ -1,5 +1,5 @@
 {
-  "capturedAt": "2026-06-23T12:58:09.004Z",
+  "capturedAt": "2026-06-23T22:33:13.230Z",
   "regions": {
     "us-east-1": {
       "region": "us-east-1",
@@ -14,7 +14,8 @@
           "n": 1,
           "fields": [
             "tableName"
-          ]
+          ],
+          "cancellationReasons": null
         },
         {
           "id": "s_put_table_empty",
@@ -26,7 +27,8 @@
           "n": 1,
           "fields": [
             "tableName"
-          ]
+          ],
+          "cancellationReasons": null
         },
         {
           "id": "s_put_table_long",
@@ -38,7 +40,8 @@
           "n": 1,
           "fields": [
             "tableName"
-          ]
+          ],
+          "cancellationReasons": null
         },
         {
           "id": "s_put_table_badchars",
@@ -50,7 +53,8 @@
           "n": 1,
           "fields": [
             "tableName"
-          ]
+          ],
+          "cancellationReasons": null
         },
         {
           "id": "s_ct_table_short",
@@ -62,7 +66,8 @@
           "n": 1,
           "fields": [
             "tableName"
-          ]
+          ],
+          "cancellationReasons": null
         },
         {
           "id": "c_bw_over25",
@@ -70,11 +75,12 @@
           "note": "BatchWrite 26 requests",
           "threw": true,
           "name": "ValidationException",
-          "message": "1 validation error detected: Value '{_conformance_capdrift_h_1782219489009787182=[WriteRequest(putRequest=PutRequest(item={pk=AttributeValue(s=bw-0, n=null, b=null, iNT=null, dECIMAL=null, dOUBLE=null, sS=null, nS=null, bS=null, iNTSET=null, dECIMALSET=null, dOUBLESET=null, m=null, l=null, nULL=null, bOOL=null)}, workloadProfileName=null), deleteRequest=null), WriteRequest(putRequest=PutRequest(item={pk=AttributeValue(s=bw-1, n=null, b=null, iNT=null, dECIMAL=null, dOUBLE=null, sS=null, nS=null, bS=null, iNTSET=null, dECIMALSET=null, dOUBLESET=null, m=null, l=null, nULL=null, bOOL=null)}, workloadProfileName=null), deleteRequest=null), WriteRequest(putRequest=PutRequest(item={pk=AttributeValue(s=bw-2, n=null, b=null, iNT=null, dECIMAL=null, dOUBLE=null, sS=null, nS=null, bS=null, iNTSET=null, dECIMALSET=null, dOUBLESET=null, m=null, l=null, nULL=null, bOOL=null)}, workloadProfileName=null), deleteRequest=null), WriteRequest(putRequest=PutRequest(item={pk=AttributeValue(s=bw-3, n=null, b=null, iNT=null, dECIMAL=null, dOUBLE=null, sS=null, nS=null, bS=null, iNTSET=null, dECIMALSET=null, dOUBLESET=null, m=null, l=null, nULL=null, bOOL=null)}, workloadProfileName=null), deleteRequest=null), WriteRequest(putRequest=PutRequest(item={pk=AttributeValue(s=bw-4, n=null, b=null, iNT=null, dECIMAL=null, dOUBLE=null, sS=null, nS=null, bS=null, iNTSET=null, dECIMALSET=null, dOUBLESET=null, m=null, l=null, nULL=null, bOOL=null)}, workloadProfileName=null), deleteRequest=null), WriteRequest(putRequest=PutRequest(item={pk=AttributeValue(s=bw-5, n=null, b=null, iNT=null, dECIMAL=null, dOUBLE=null, sS=null, nS=null, bS=null, iNTSET=null, dECIMALSET=null, dOUBLESET=null, m=null, l=null, nULL=null, bOOL=null)}, workloadProfileName=null), deleteRequest=null), WriteRequest(putRequest=PutRequest(item={pk=AttributeValue(s=bw-6, n=null, b=null, iNT=null, dECIMAL=null, dOUBLE=null, sS=null, nS=null, bS=null, iNTSET=null, dECIMALSET=null, dOUBLESET=null, m=null, l=null, nULL=null, bOOL=null)}, workloadProfileName=null), deleteRequest=null), WriteRequest(putRequest=PutRequest(item={pk=AttributeValue(s=bw-7, n=null, b=null, iNT=null, dECIMAL=null, dOUBLE=null, sS=null, nS=null, bS=null, iNTSET=null, dECIMALSET=null, dOUBLESET=null, m=null, l=null, nULL=null, bOOL=null)}, workloadProfileName=null), deleteRequest=null), WriteRequest(putRequest=PutRequest(item={pk=AttributeValue(s=bw-8, n=null, b=null, iNT=null, dECIMAL=null, dOUBLE=null, sS=null, nS=null, bS=null, iNTSET=null, dECIMALSET=null, dOUBLESET=null, m=null, l=null, nULL=null, bOOL=null)}, workloadProfileName=null), deleteRequest=null), WriteRequest(putRequest=PutRequest(item={pk=AttributeValue(s=bw-9, n=null, b=null, iNT=null, dECIMAL=null, dOUBLE=null, sS=null, nS=null, bS=null, iNTSET=null, dECIMALSET=null, dOUBLESET=null, m=null, l=null, nULL=null, bOOL=null)}, workloadProfileName=null), deleteRequest=null), WriteRequest(putRequest=PutRequest(item={pk=AttributeValue(s=bw-10, n=null, b=null, iNT=null, dECIMAL=null, dOUBLE=null, sS=null, nS=null, bS=null, iNTSET=null, dECIMALSET=null, dOUBLESET=null, m=null, l=null, nULL=null, bOOL=null)}, workloadProfileName=null), deleteRequest=null), WriteRequest(putRequest=PutRequest(item={pk=AttributeValue(s=bw-11, n=null, b=null, iNT=null, dECIMAL=null, dOUBLE=null, sS=null, nS=null, bS=null, iNTSET=null, dECIMALSET=null, dOUBLESET=null, m=null, l=null, nULL=null, bOOL=null)}, workloadProfileName=null), deleteRequest=null), WriteRequest(putRequest=PutRequest(item={pk=AttributeValue(s=bw-12, n=null, b=null, iNT=null, dECIMAL=null, dOUBLE=null, sS=null, nS=null, bS=null, iNTSET=null, dECIMALSET=null, dOUBLESET=null, m=null, l=null, nULL=null, bOOL=null)}, workloadProfileName=null), deleteRequest=null), WriteRequest(putRequest=PutRequest(item={pk=AttributeValue(s=bw-13, n=null, b=null, iNT=null, dECIMAL=null, dOUBLE=null, sS=null, nS=null, bS=null, iNTSET=null, dECIMALSET=null, dOUBLESET=null, m=null, l=null, nULL=null, bOOL=null)}, workloadProfileName=null), deleteRequest=null), WriteRequest(putRequest=PutRequest(item={pk=AttributeValue(s=bw-14, n=null, b=null, iNT=null, dECIMAL=null, dOUBLE=null, sS=null, nS=null, bS=null, iNTSET=null, dECIMALSET=null, dOUBLESET=null, m=null, l=null, nULL=null, bOOL=null)}, workloadProfileName=null), deleteRequest=null), WriteRequest(putRequest=PutRequest(item={pk=AttributeValue(s=bw-15, n=null, b=null, iNT=null, dECIMAL=null, dOUBLE=null, sS=null, nS=null, bS=null, iNTSET=null, dECIMALSET=null, dOUBLESET=null, m=null, l=null, nULL=null, bOOL=null)}, workloadProfileName=null), deleteRequest=null), WriteRequest(putRequest=PutRequest(item={pk=AttributeValue(s=bw-16, n=null, b=null, iNT=null, dECIMAL=null, dOUBLE=null, sS=null, nS=null, bS=null, iNTSET=null, dECIMALSET=null, dOUBLESET=null, m=null, l=null, nULL=null, bOOL=null)}, workloadProfileName=null), deleteRequest=null), WriteRequest(putRequest=PutRequest(item={pk=AttributeValue(s=bw-17, n=null, b=null, iNT=null, dECIMAL=null, dOUBLE=null, sS=null, nS=null, bS=null, iNTSET=null, dECIMALSET=null, dOUBLESET=null, m=null, l=null, nULL=null, bOOL=null)}, workloadProfileName=null), deleteRequest=null), WriteRequest(putRequest=PutRequest(item={pk=AttributeValue(s=bw-18, n=null, b=null, iNT=null, dECIMAL=null, dOUBLE=null, sS=null, nS=null, bS=null, iNTSET=null, dECIMALSET=null, dOUBLESET=null, m=null, l=null, nULL=null, bOOL=null)}, workloadProfileName=null), deleteRequest=null), WriteRequest(putRequest=PutRequest(item={pk=AttributeValue(s=bw-19, n=null, b=null, iNT=null, dECIMAL=null, dOUBLE=null, sS=null, nS=null, bS=null, iNTSET=null, dECIMALSET=null, dOUBLESET=null, m=null, l=null, nULL=null, bOOL=null)}, workloadProfileName=null), deleteRequest=null), WriteRequest(putRequest=PutRequest(item={pk=AttributeValue(s=bw-20, n=null, b=null, iNT=null, dECIMAL=null, dOUBLE=null, sS=null, nS=null, bS=null, iNTSET=null, dECIMALSET=null, dOUBLESET=null, m=null, l=null, nULL=null, bOOL=null)}, workloadProfileName=null), deleteRequest=null), WriteRequest(putRequest=PutRequest(item={pk=AttributeValue(s=bw-21, n=null, b=null, iNT=null, dECIMAL=null, dOUBLE=null, sS=null, nS=null, bS=null, iNTSET=null, dECIMALSET=null, dOUBLESET=null, m=null, l=null, nULL=null, bOOL=null)}, workloadProfileName=null), deleteRequest=null), WriteRequest(putRequest=PutRequest(item={pk=AttributeValue(s=bw-22, n=null, b=null, iNT=null, dECIMAL=null, dOUBLE=null, sS=null, nS=null, bS=null, iNTSET=null, dECIMALSET=null, dOUBLESET=null, m=null, l=null, nULL=null, bOOL=null)}, workloadProfileName=null), deleteRequest=null), WriteRequest(putRequest=PutRequest(item={pk=AttributeValue(s=bw-23, n=null, b=null, iNT=null, dECIMAL=null, dOUBLE=null, sS=null, nS=null, bS=null, iNTSET=null, dECIMALSET=null, dOUBLESET=null, m=null, l=null, nULL=null, bOOL=null)}, workloadProfileName=null), deleteRequest=null), WriteRequest(putRequest=PutRequest(item={pk=AttributeValue(s=bw-24, n=null, b=null, iNT=null, dECIMAL=null, dOUBLE=null, sS=null, nS=null, bS=null, iNTSET=null, dECIMALSET=null, dOUBLESET=null, m=null, l=null, nULL=null, bOOL=null)}, workloadProfileName=null), deleteRequest=null), WriteRequest(putRequest=PutRequest(item={pk=AttributeValue(s=bw-25, n=null, b=null, iNT=null, dECIMAL=null, dOUBLE=null, sS=null, nS=null, bS=null, iNTSET=null, dECIMALSET=null, dOUBLESET=null, m=null, l=null, nULL=null, bOOL=null)}, workloadProfileName=null), deleteRequest=null)]}' at 'requestItems' failed to satisfy constraint: Map value must satisfy constraint: [Member must have length less than or equal to 25, Member must have length greater than or equal to 1]",
+          "message": "1 validation error detected: Value '{_conformance_capdrift_h_1782253993233240622=[WriteRequest(putRequest=PutRequest(item={pk=com.amazonaws.dynamodb.v20120810.AttributeValue@483470e1}, workloadProfileName=null), deleteRequest=null), WriteRequest(putRequest=PutRequest(item={pk=com.amazonaws.dynamodb.v20120810.AttributeValue@483474a2}, workloadProfileName=null), deleteRequest=null), WriteRequest(putRequest=PutRequest(item={pk=com.amazonaws.dynamodb.v20120810.AttributeValue@48347863}, workloadProfileName=null), deleteRequest=null), WriteRequest(putRequest=PutRequest(item={pk=com.amazonaws.dynamodb.v20120810.AttributeValue@48347c24}, workloadProfileName=null), deleteRequest=null), WriteRequest(putRequest=PutRequest(item={pk=com.amazonaws.dynamodb.v20120810.AttributeValue@48347fe5}, workloadProfileName=null), deleteRequest=null), WriteRequest(putRequest=PutRequest(item={pk=com.amazonaws.dynamodb.v20120810.AttributeValue@483483a6}, workloadProfileName=null), deleteRequest=null), WriteRequest(putRequest=PutRequest(item={pk=com.amazonaws.dynamodb.v20120810.AttributeValue@48348767}, workloadProfileName=null), deleteRequest=null), WriteRequest(putRequest=PutRequest(item={pk=com.amazonaws.dynamodb.v20120810.AttributeValue@48348b28}, workloadProfileName=null), deleteRequest=null), WriteRequest(putRequest=PutRequest(item={pk=com.amazonaws.dynamodb.v20120810.AttributeValue@48348ee9}, workloadProfileName=null), deleteRequest=null), WriteRequest(putRequest=PutRequest(item={pk=com.amazonaws.dynamodb.v20120810.AttributeValue@483492aa}, workloadProfileName=null), deleteRequest=null), WriteRequest(putRequest=PutRequest(item={pk=com.amazonaws.dynamodb.v20120810.AttributeValue@a81beb00}, workloadProfileName=null), deleteRequest=null), WriteRequest(putRequest=PutRequest(item={pk=com.amazonaws.dynamodb.v20120810.AttributeValue@a81beec1}, workloadProfileName=null), deleteRequest=null), WriteRequest(putRequest=PutRequest(item={pk=com.amazonaws.dynamodb.v20120810.AttributeValue@a81bf282}, workloadProfileName=null), deleteRequest=null), WriteRequest(putRequest=PutRequest(item={pk=com.amazonaws.dynamodb.v20120810.AttributeValue@a81bf643}, workloadProfileName=null), deleteRequest=null), WriteRequest(putRequest=PutRequest(item={pk=com.amazonaws.dynamodb.v20120810.AttributeValue@a81bfa04}, workloadProfileName=null), deleteRequest=null), WriteRequest(putRequest=PutRequest(item={pk=com.amazonaws.dynamodb.v20120810.AttributeValue@a81bfdc5}, workloadProfileName=null), deleteRequest=null), WriteRequest(putRequest=PutRequest(item={pk=com.amazonaws.dynamodb.v20120810.AttributeValue@a81c0186}, workloadProfileName=null), deleteRequest=null), WriteRequest(putRequest=PutRequest(item={pk=com.amazonaws.dynamodb.v20120810.AttributeValue@a81c0547}, workloadProfileName=null), deleteRequest=null), WriteRequest(putRequest=PutRequest(item={pk=com.amazonaws.dynamodb.v20120810.AttributeValue@a81c0908}, workloadProfileName=null), deleteRequest=null), WriteRequest(putRequest=PutRequest(item={pk=com.amazonaws.dynamodb.v20120810.AttributeValue@a81c0cc9}, workloadProfileName=null), deleteRequest=null), WriteRequest(putRequest=PutRequest(item={pk=com.amazonaws.dynamodb.v20120810.AttributeValue@a81c5f5f}, workloadProfileName=null), deleteRequest=null), WriteRequest(putRequest=PutRequest(item={pk=com.amazonaws.dynamodb.v20120810.AttributeValue@a81c6320}, workloadProfileName=null), deleteRequest=null), WriteRequest(putRequest=PutRequest(item={pk=com.amazonaws.dynamodb.v20120810.AttributeValue@a81c66e1}, workloadProfileName=null), deleteRequest=null), WriteRequest(putRequest=PutRequest(item={pk=com.amazonaws.dynamodb.v20120810.AttributeValue@a81c6aa2}, workloadProfileName=null), deleteRequest=null), WriteRequest(putRequest=PutRequest(item={pk=com.amazonaws.dynamodb.v20120810.AttributeValue@a81c6e63}, workloadProfileName=null), deleteRequest=null), WriteRequest(putRequest=PutRequest(item={pk=com.amazonaws.dynamodb.v20120810.AttributeValue@a81c7224}, workloadProfileName=null), deleteRequest=null)]}' at 'requestItems' failed to satisfy constraint: Map value must satisfy constraint: [Member must have length less than or equal to 25, Member must have length greater than or equal to 1]",
           "n": 1,
           "fields": [
             "requestItems"
-          ]
+          ],
+          "cancellationReasons": null
         },
         {
           "id": "c_ct_3keys",
@@ -82,11 +88,12 @@
           "note": "CreateTable 3 keySchema",
           "threw": true,
           "name": "ValidationException",
-          "message": "1 validation error detected: Value '[KeySchemaElement(attributeName=pk, keyType=HASH), KeySchemaElement(attributeName=sk, keyType=RANGE), KeySchemaElement(attributeName=extra, keyType=RANGE)]' at 'keySchema' failed to satisfy constraint: Member must have length less than or equal to 2",
+          "message": "1 validation error detected: Value '[com.amazonaws.dynamodb.v20120810.KeySchemaElement@ad28eb1d, com.amazonaws.dynamodb.v20120810.KeySchemaElement@38b9654b, com.amazonaws.dynamodb.v20120810.KeySchemaElement@3e80eb03]' at 'keySchema' failed to satisfy constraint: Member must have length less than or equal to 2",
           "n": 1,
           "fields": [
             "keySchema"
-          ]
+          ],
+          "cancellationReasons": null
         },
         {
           "id": "b_put_empty_ss",
@@ -96,7 +103,8 @@
           "name": "ValidationException",
           "message": "One or more parameter values were invalid: An string set  may not be empty",
           "n": null,
-          "fields": []
+          "fields": [],
+          "cancellationReasons": null
         },
         {
           "id": "b_put_empty_ns",
@@ -106,7 +114,8 @@
           "name": "ValidationException",
           "message": "One or more parameter values were invalid: An number set  may not be empty",
           "n": null,
-          "fields": []
+          "fields": [],
+          "cancellationReasons": null
         },
         {
           "id": "b_put_dup_ss",
@@ -116,7 +125,8 @@
           "name": "ValidationException",
           "message": "One or more parameter values were invalid: Input collection [a, a] contains duplicates.",
           "n": null,
-          "fields": []
+          "fields": [],
+          "cancellationReasons": null
         },
         {
           "id": "b_put_mix_expr",
@@ -126,7 +136,8 @@
           "name": "ValidationException",
           "message": "Can not use both expression and non-expression parameters in the same request: Non-expression parameters: {Expected} Expression parameters: {ConditionExpression}",
           "n": null,
-          "fields": []
+          "fields": [],
+          "cancellationReasons": null
         },
         {
           "id": "b_put_eav_no_expr",
@@ -136,7 +147,8 @@
           "name": "ValidationException",
           "message": "ExpressionAttributeValues can only be specified when using expressions: ConditionExpression is null",
           "n": null,
-          "fields": []
+          "fields": [],
+          "cancellationReasons": null
         },
         {
           "id": "b_put_redundant_parens",
@@ -146,7 +158,8 @@
           "name": "ValidationException",
           "message": "Invalid ConditionExpression: The expression has redundant parentheses;",
           "n": null,
-          "fields": []
+          "fields": [],
+          "cancellationReasons": null
         },
         {
           "id": "b_put_contains_dup",
@@ -156,7 +169,8 @@
           "name": "ValidationException",
           "message": "Invalid ConditionExpression: The first operand must be distinct from the remaining operands for this operator or function; operator: contains, first operand: [data]",
           "n": null,
-          "fields": []
+          "fields": [],
+          "cancellationReasons": null
         },
         {
           "id": "u_upd_hashkey",
@@ -166,7 +180,8 @@
           "name": "ValidationException",
           "message": "One or more parameter values were invalid: Cannot update attribute pk. This attribute is part of the key",
           "n": null,
-          "fields": []
+          "fields": [],
+          "cancellationReasons": null
         },
         {
           "id": "u_upd_syntax",
@@ -176,7 +191,8 @@
           "name": "ValidationException",
           "message": "Invalid UpdateExpression: Syntax error; token: \"INVALID\", near: \"INVALID SYNTAX\"",
           "n": null,
-          "fields": []
+          "fields": [],
+          "cancellationReasons": null
         },
         {
           "id": "u_upd_unused_ean",
@@ -186,7 +202,8 @@
           "name": "ValidationException",
           "message": "Value provided in ExpressionAttributeNames unused in expressions: keys: {#unused}",
           "n": null,
-          "fields": []
+          "fields": [],
+          "cancellationReasons": null
         },
         {
           "id": "u_upd_unused_eav",
@@ -196,7 +213,8 @@
           "name": "ValidationException",
           "message": "Value provided in ExpressionAttributeValues unused in expressions: keys: {:unused}",
           "n": null,
-          "fields": []
+          "fields": [],
+          "cancellationReasons": null
         },
         {
           "id": "u_upd_missing_eav",
@@ -206,7 +224,8 @@
           "name": "ValidationException",
           "message": "Invalid UpdateExpression: An expression attribute value used in expression is not defined; attribute value: :v",
           "n": null,
-          "fields": []
+          "fields": [],
+          "cancellationReasons": null
         },
         {
           "id": "u_upd_mix",
@@ -216,7 +235,8 @@
           "name": "ValidationException",
           "message": "Can not use both expression and non-expression parameters in the same request: Non-expression parameters: {AttributeUpdates} Expression parameters: {UpdateExpression}",
           "n": null,
-          "fields": []
+          "fields": [],
+          "cancellationReasons": null
         },
         {
           "id": "u_upd_empty",
@@ -226,7 +246,8 @@
           "name": "ValidationException",
           "message": "Invalid UpdateExpression: The expression can not be empty;",
           "n": null,
-          "fields": []
+          "fields": [],
+          "cancellationReasons": null
         },
         {
           "id": "u_upd_rangekey",
@@ -236,7 +257,8 @@
           "name": "ValidationException",
           "message": "One or more parameter values were invalid: Cannot update attribute sk. This attribute is part of the key",
           "n": null,
-          "fields": []
+          "fields": [],
+          "cancellationReasons": null
         },
         {
           "id": "o_put_empty_table_empty_item",
@@ -248,7 +270,8 @@
           "n": 1,
           "fields": [
             "tableName"
-          ]
+          ],
+          "cancellationReasons": null
         },
         {
           "id": "o_put_empty_table_bad_rv",
@@ -261,7 +284,8 @@
           "fields": [
             "returnValues",
             "tableName"
-          ]
+          ],
+          "cancellationReasons": null
         },
         {
           "id": "o_put_three_bad_enums",
@@ -275,7 +299,8 @@
             "returnValues",
             "returnConsumedCapacity",
             "returnItemCollectionMetrics"
-          ]
+          ],
+          "cancellationReasons": null
         },
         {
           "id": "o_del_empty_table",
@@ -287,7 +312,8 @@
           "n": 1,
           "fields": [
             "tableName"
-          ]
+          ],
+          "cancellationReasons": null
         },
         {
           "id": "o_del_two_bad_enums",
@@ -300,7 +326,8 @@
           "fields": [
             "returnValues",
             "returnConsumedCapacity"
-          ]
+          ],
+          "cancellationReasons": null
         },
         {
           "id": "o_upd_empty_table",
@@ -312,7 +339,8 @@
           "n": 1,
           "fields": [
             "tableName"
-          ]
+          ],
+          "cancellationReasons": null
         },
         {
           "id": "o_upd_two_bad_enums",
@@ -325,6 +353,224 @@
           "fields": [
             "returnConsumedCapacity",
             "returnValues"
+          ],
+          "cancellationReasons": null
+        },
+        {
+          "id": "bw_table_wrongtype",
+          "family": "batch-key",
+          "note": "BatchWrite PutRequest pk wrong type (N on S)",
+          "threw": true,
+          "name": "ValidationException",
+          "message": "The provided key element does not match the schema",
+          "n": null,
+          "fields": [],
+          "cancellationReasons": null
+        },
+        {
+          "id": "bw_table_nonscalar",
+          "family": "batch-key",
+          "note": "BatchWrite PutRequest pk non-scalar (L)",
+          "threw": true,
+          "name": "ValidationException",
+          "message": "The provided key element does not match the schema",
+          "n": null,
+          "fields": [],
+          "cancellationReasons": null
+        },
+        {
+          "id": "del_key_empty",
+          "family": "lookup-key",
+          "note": "DeleteItem Key pk empty",
+          "threw": true,
+          "name": "ValidationException",
+          "message": "One or more parameter values are not valid. The AttributeValue for a key attribute cannot contain an empty string value. Key: pk",
+          "n": null,
+          "fields": [],
+          "cancellationReasons": null
+        },
+        {
+          "id": "get_key_empty",
+          "family": "lookup-key",
+          "note": "GetItem Key pk empty",
+          "threw": true,
+          "name": "ValidationException",
+          "message": "One or more parameter values are not valid. The AttributeValue for a key attribute cannot contain an empty string value. Key: pk",
+          "n": null,
+          "fields": [],
+          "cancellationReasons": null
+        },
+        {
+          "id": "del_key_wrongtype",
+          "family": "lookup-key",
+          "note": "DeleteItem Key pk wrongtype",
+          "threw": true,
+          "name": "ValidationException",
+          "message": "The provided key element does not match the schema",
+          "n": null,
+          "fields": [],
+          "cancellationReasons": null
+        },
+        {
+          "id": "get_key_wrongtype",
+          "family": "lookup-key",
+          "note": "GetItem Key pk wrongtype",
+          "threw": true,
+          "name": "ValidationException",
+          "message": "The provided key element does not match the schema",
+          "n": null,
+          "fields": [],
+          "cancellationReasons": null
+        },
+        {
+          "id": "del_key_nonscalar",
+          "family": "lookup-key",
+          "note": "DeleteItem Key pk nonscalar",
+          "threw": true,
+          "name": "ValidationException",
+          "message": "The provided key element does not match the schema",
+          "n": null,
+          "fields": [],
+          "cancellationReasons": null
+        },
+        {
+          "id": "get_key_nonscalar",
+          "family": "lookup-key",
+          "note": "GetItem Key pk nonscalar",
+          "threw": true,
+          "name": "ValidationException",
+          "message": "The provided key element does not match the schema",
+          "n": null,
+          "fields": [],
+          "cancellationReasons": null
+        },
+        {
+          "id": "twi_upd_key_empty",
+          "family": "transact-key",
+          "note": "TransactWrite Update Key pk empty",
+          "threw": true,
+          "name": "ValidationException",
+          "message": "One or more parameter values are not valid. The AttributeValue for a key attribute cannot contain an empty string value. Key: pk",
+          "n": null,
+          "fields": [],
+          "cancellationReasons": null
+        },
+        {
+          "id": "twi_del_key_empty",
+          "family": "transact-key",
+          "note": "TransactWrite Delete Key pk empty",
+          "threw": true,
+          "name": "ValidationException",
+          "message": "One or more parameter values are not valid. The AttributeValue for a key attribute cannot contain an empty string value. Key: pk",
+          "n": null,
+          "fields": [],
+          "cancellationReasons": null
+        },
+        {
+          "id": "twi_cc_key_empty",
+          "family": "transact-key",
+          "note": "TransactWrite ConditionCheck Key pk empty",
+          "threw": true,
+          "name": "ValidationException",
+          "message": "One or more parameter values are not valid. The AttributeValue for a key attribute cannot contain an empty string value. Key: pk",
+          "n": null,
+          "fields": [],
+          "cancellationReasons": null
+        },
+        {
+          "id": "twi_upd_key_wrongtype",
+          "family": "transact-key",
+          "note": "TransactWrite Update Key pk wrongtype",
+          "threw": true,
+          "name": "TransactionCanceledException",
+          "message": "Transaction cancelled, please refer cancellation reasons for specific reasons [ValidationError]",
+          "n": null,
+          "fields": [],
+          "cancellationReasons": [
+            {
+              "Code": "ValidationError",
+              "Message": "The provided key element does not match the schema"
+            }
+          ]
+        },
+        {
+          "id": "twi_del_key_wrongtype",
+          "family": "transact-key",
+          "note": "TransactWrite Delete Key pk wrongtype",
+          "threw": true,
+          "name": "TransactionCanceledException",
+          "message": "Transaction cancelled, please refer cancellation reasons for specific reasons [ValidationError]",
+          "n": null,
+          "fields": [],
+          "cancellationReasons": [
+            {
+              "Code": "ValidationError",
+              "Message": "The provided key element does not match the schema"
+            }
+          ]
+        },
+        {
+          "id": "twi_cc_key_wrongtype",
+          "family": "transact-key",
+          "note": "TransactWrite ConditionCheck Key pk wrongtype",
+          "threw": true,
+          "name": "TransactionCanceledException",
+          "message": "Transaction cancelled, please refer cancellation reasons for specific reasons [ValidationError]",
+          "n": null,
+          "fields": [],
+          "cancellationReasons": [
+            {
+              "Code": "ValidationError",
+              "Message": "The provided key element does not match the schema"
+            }
+          ]
+        },
+        {
+          "id": "twi_upd_key_nonscalar",
+          "family": "transact-key",
+          "note": "TransactWrite Update Key pk nonscalar",
+          "threw": true,
+          "name": "TransactionCanceledException",
+          "message": "Transaction cancelled, please refer cancellation reasons for specific reasons [ValidationError]",
+          "n": null,
+          "fields": [],
+          "cancellationReasons": [
+            {
+              "Code": "ValidationError",
+              "Message": "The provided key element does not match the schema"
+            }
+          ]
+        },
+        {
+          "id": "twi_del_key_nonscalar",
+          "family": "transact-key",
+          "note": "TransactWrite Delete Key pk nonscalar",
+          "threw": true,
+          "name": "TransactionCanceledException",
+          "message": "Transaction cancelled, please refer cancellation reasons for specific reasons [ValidationError]",
+          "n": null,
+          "fields": [],
+          "cancellationReasons": [
+            {
+              "Code": "ValidationError",
+              "Message": "The provided key element does not match the schema"
+            }
+          ]
+        },
+        {
+          "id": "twi_cc_key_nonscalar",
+          "family": "transact-key",
+          "note": "TransactWrite ConditionCheck Key pk nonscalar",
+          "threw": true,
+          "name": "TransactionCanceledException",
+          "message": "Transaction cancelled, please refer cancellation reasons for specific reasons [ValidationError]",
+          "n": null,
+          "fields": [],
+          "cancellationReasons": [
+            {
+              "Code": "ValidationError",
+              "Message": "The provided key element does not match the schema"
+            }
           ]
         }
       ],
@@ -347,7 +593,8 @@
           "n": 1,
           "fields": [
             "tableName"
-          ]
+          ],
+          "cancellationReasons": null
         },
         {
           "id": "s_put_table_empty",
@@ -359,7 +606,8 @@
           "n": 1,
           "fields": [
             "tableName"
-          ]
+          ],
+          "cancellationReasons": null
         },
         {
           "id": "s_put_table_long",
@@ -371,7 +619,8 @@
           "n": 1,
           "fields": [
             "tableName"
-          ]
+          ],
+          "cancellationReasons": null
         },
         {
           "id": "s_put_table_badchars",
@@ -383,7 +632,8 @@
           "n": 1,
           "fields": [
             "tableName"
-          ]
+          ],
+          "cancellationReasons": null
         },
         {
           "id": "s_ct_table_short",
@@ -395,7 +645,8 @@
           "n": 1,
           "fields": [
             "tableName"
-          ]
+          ],
+          "cancellationReasons": null
         },
         {
           "id": "c_bw_over25",
@@ -403,11 +654,12 @@
           "note": "BatchWrite 26 requests",
           "threw": true,
           "name": "ValidationException",
-          "message": "1 validation error detected: Value '{_conformance_capdrift_h_1782219498502155717=[WriteRequest(putRequest=PutRequest(item={pk=AttributeValue(s=bw-0, n=null, b=null, iNT=null, dECIMAL=null, dOUBLE=null, sS=null, nS=null, bS=null, iNTSET=null, dECIMALSET=null, dOUBLESET=null, m=null, l=null, nULL=null, bOOL=null)}, workloadProfileName=null), deleteRequest=null), WriteRequest(putRequest=PutRequest(item={pk=AttributeValue(s=bw-1, n=null, b=null, iNT=null, dECIMAL=null, dOUBLE=null, sS=null, nS=null, bS=null, iNTSET=null, dECIMALSET=null, dOUBLESET=null, m=null, l=null, nULL=null, bOOL=null)}, workloadProfileName=null), deleteRequest=null), WriteRequest(putRequest=PutRequest(item={pk=AttributeValue(s=bw-2, n=null, b=null, iNT=null, dECIMAL=null, dOUBLE=null, sS=null, nS=null, bS=null, iNTSET=null, dECIMALSET=null, dOUBLESET=null, m=null, l=null, nULL=null, bOOL=null)}, workloadProfileName=null), deleteRequest=null), WriteRequest(putRequest=PutRequest(item={pk=AttributeValue(s=bw-3, n=null, b=null, iNT=null, dECIMAL=null, dOUBLE=null, sS=null, nS=null, bS=null, iNTSET=null, dECIMALSET=null, dOUBLESET=null, m=null, l=null, nULL=null, bOOL=null)}, workloadProfileName=null), deleteRequest=null), WriteRequest(putRequest=PutRequest(item={pk=AttributeValue(s=bw-4, n=null, b=null, iNT=null, dECIMAL=null, dOUBLE=null, sS=null, nS=null, bS=null, iNTSET=null, dECIMALSET=null, dOUBLESET=null, m=null, l=null, nULL=null, bOOL=null)}, workloadProfileName=null), deleteRequest=null), WriteRequest(putRequest=PutRequest(item={pk=AttributeValue(s=bw-5, n=null, b=null, iNT=null, dECIMAL=null, dOUBLE=null, sS=null, nS=null, bS=null, iNTSET=null, dECIMALSET=null, dOUBLESET=null, m=null, l=null, nULL=null, bOOL=null)}, workloadProfileName=null), deleteRequest=null), WriteRequest(putRequest=PutRequest(item={pk=AttributeValue(s=bw-6, n=null, b=null, iNT=null, dECIMAL=null, dOUBLE=null, sS=null, nS=null, bS=null, iNTSET=null, dECIMALSET=null, dOUBLESET=null, m=null, l=null, nULL=null, bOOL=null)}, workloadProfileName=null), deleteRequest=null), WriteRequest(putRequest=PutRequest(item={pk=AttributeValue(s=bw-7, n=null, b=null, iNT=null, dECIMAL=null, dOUBLE=null, sS=null, nS=null, bS=null, iNTSET=null, dECIMALSET=null, dOUBLESET=null, m=null, l=null, nULL=null, bOOL=null)}, workloadProfileName=null), deleteRequest=null), WriteRequest(putRequest=PutRequest(item={pk=AttributeValue(s=bw-8, n=null, b=null, iNT=null, dECIMAL=null, dOUBLE=null, sS=null, nS=null, bS=null, iNTSET=null, dECIMALSET=null, dOUBLESET=null, m=null, l=null, nULL=null, bOOL=null)}, workloadProfileName=null), deleteRequest=null), WriteRequest(putRequest=PutRequest(item={pk=AttributeValue(s=bw-9, n=null, b=null, iNT=null, dECIMAL=null, dOUBLE=null, sS=null, nS=null, bS=null, iNTSET=null, dECIMALSET=null, dOUBLESET=null, m=null, l=null, nULL=null, bOOL=null)}, workloadProfileName=null), deleteRequest=null), WriteRequest(putRequest=PutRequest(item={pk=AttributeValue(s=bw-10, n=null, b=null, iNT=null, dECIMAL=null, dOUBLE=null, sS=null, nS=null, bS=null, iNTSET=null, dECIMALSET=null, dOUBLESET=null, m=null, l=null, nULL=null, bOOL=null)}, workloadProfileName=null), deleteRequest=null), WriteRequest(putRequest=PutRequest(item={pk=AttributeValue(s=bw-11, n=null, b=null, iNT=null, dECIMAL=null, dOUBLE=null, sS=null, nS=null, bS=null, iNTSET=null, dECIMALSET=null, dOUBLESET=null, m=null, l=null, nULL=null, bOOL=null)}, workloadProfileName=null), deleteRequest=null), WriteRequest(putRequest=PutRequest(item={pk=AttributeValue(s=bw-12, n=null, b=null, iNT=null, dECIMAL=null, dOUBLE=null, sS=null, nS=null, bS=null, iNTSET=null, dECIMALSET=null, dOUBLESET=null, m=null, l=null, nULL=null, bOOL=null)}, workloadProfileName=null), deleteRequest=null), WriteRequest(putRequest=PutRequest(item={pk=AttributeValue(s=bw-13, n=null, b=null, iNT=null, dECIMAL=null, dOUBLE=null, sS=null, nS=null, bS=null, iNTSET=null, dECIMALSET=null, dOUBLESET=null, m=null, l=null, nULL=null, bOOL=null)}, workloadProfileName=null), deleteRequest=null), WriteRequest(putRequest=PutRequest(item={pk=AttributeValue(s=bw-14, n=null, b=null, iNT=null, dECIMAL=null, dOUBLE=null, sS=null, nS=null, bS=null, iNTSET=null, dECIMALSET=null, dOUBLESET=null, m=null, l=null, nULL=null, bOOL=null)}, workloadProfileName=null), deleteRequest=null), WriteRequest(putRequest=PutRequest(item={pk=AttributeValue(s=bw-15, n=null, b=null, iNT=null, dECIMAL=null, dOUBLE=null, sS=null, nS=null, bS=null, iNTSET=null, dECIMALSET=null, dOUBLESET=null, m=null, l=null, nULL=null, bOOL=null)}, workloadProfileName=null), deleteRequest=null), WriteRequest(putRequest=PutRequest(item={pk=AttributeValue(s=bw-16, n=null, b=null, iNT=null, dECIMAL=null, dOUBLE=null, sS=null, nS=null, bS=null, iNTSET=null, dECIMALSET=null, dOUBLESET=null, m=null, l=null, nULL=null, bOOL=null)}, workloadProfileName=null), deleteRequest=null), WriteRequest(putRequest=PutRequest(item={pk=AttributeValue(s=bw-17, n=null, b=null, iNT=null, dECIMAL=null, dOUBLE=null, sS=null, nS=null, bS=null, iNTSET=null, dECIMALSET=null, dOUBLESET=null, m=null, l=null, nULL=null, bOOL=null)}, workloadProfileName=null), deleteRequest=null), WriteRequest(putRequest=PutRequest(item={pk=AttributeValue(s=bw-18, n=null, b=null, iNT=null, dECIMAL=null, dOUBLE=null, sS=null, nS=null, bS=null, iNTSET=null, dECIMALSET=null, dOUBLESET=null, m=null, l=null, nULL=null, bOOL=null)}, workloadProfileName=null), deleteRequest=null), WriteRequest(putRequest=PutRequest(item={pk=AttributeValue(s=bw-19, n=null, b=null, iNT=null, dECIMAL=null, dOUBLE=null, sS=null, nS=null, bS=null, iNTSET=null, dECIMALSET=null, dOUBLESET=null, m=null, l=null, nULL=null, bOOL=null)}, workloadProfileName=null), deleteRequest=null), WriteRequest(putRequest=PutRequest(item={pk=AttributeValue(s=bw-20, n=null, b=null, iNT=null, dECIMAL=null, dOUBLE=null, sS=null, nS=null, bS=null, iNTSET=null, dECIMALSET=null, dOUBLESET=null, m=null, l=null, nULL=null, bOOL=null)}, workloadProfileName=null), deleteRequest=null), WriteRequest(putRequest=PutRequest(item={pk=AttributeValue(s=bw-21, n=null, b=null, iNT=null, dECIMAL=null, dOUBLE=null, sS=null, nS=null, bS=null, iNTSET=null, dECIMALSET=null, dOUBLESET=null, m=null, l=null, nULL=null, bOOL=null)}, workloadProfileName=null), deleteRequest=null), WriteRequest(putRequest=PutRequest(item={pk=AttributeValue(s=bw-22, n=null, b=null, iNT=null, dECIMAL=null, dOUBLE=null, sS=null, nS=null, bS=null, iNTSET=null, dECIMALSET=null, dOUBLESET=null, m=null, l=null, nULL=null, bOOL=null)}, workloadProfileName=null), deleteRequest=null), WriteRequest(putRequest=PutRequest(item={pk=AttributeValue(s=bw-23, n=null, b=null, iNT=null, dECIMAL=null, dOUBLE=null, sS=null, nS=null, bS=null, iNTSET=null, dECIMALSET=null, dOUBLESET=null, m=null, l=null, nULL=null, bOOL=null)}, workloadProfileName=null), deleteRequest=null), WriteRequest(putRequest=PutRequest(item={pk=AttributeValue(s=bw-24, n=null, b=null, iNT=null, dECIMAL=null, dOUBLE=null, sS=null, nS=null, bS=null, iNTSET=null, dECIMALSET=null, dOUBLESET=null, m=null, l=null, nULL=null, bOOL=null)}, workloadProfileName=null), deleteRequest=null), WriteRequest(putRequest=PutRequest(item={pk=AttributeValue(s=bw-25, n=null, b=null, iNT=null, dECIMAL=null, dOUBLE=null, sS=null, nS=null, bS=null, iNTSET=null, dECIMALSET=null, dOUBLESET=null, m=null, l=null, nULL=null, bOOL=null)}, workloadProfileName=null), deleteRequest=null)]}' at 'requestItems' failed to satisfy constraint: Map value must satisfy constraint: [Member must have length less than or equal to 25, Member must have length greater than or equal to 1]",
+          "message": "1 validation error detected: Value '{_conformance_capdrift_h_1782254008600161973=[WriteRequest(putRequest=PutRequest(item={pk=AttributeValue(s=bw-0, n=null, b=null, iNT=null, dECIMAL=null, dOUBLE=null, sS=null, nS=null, bS=null, iNTSET=null, dECIMALSET=null, dOUBLESET=null, m=null, l=null, nULL=null, bOOL=null)}, workloadProfileName=null), deleteRequest=null), WriteRequest(putRequest=PutRequest(item={pk=AttributeValue(s=bw-1, n=null, b=null, iNT=null, dECIMAL=null, dOUBLE=null, sS=null, nS=null, bS=null, iNTSET=null, dECIMALSET=null, dOUBLESET=null, m=null, l=null, nULL=null, bOOL=null)}, workloadProfileName=null), deleteRequest=null), WriteRequest(putRequest=PutRequest(item={pk=AttributeValue(s=bw-2, n=null, b=null, iNT=null, dECIMAL=null, dOUBLE=null, sS=null, nS=null, bS=null, iNTSET=null, dECIMALSET=null, dOUBLESET=null, m=null, l=null, nULL=null, bOOL=null)}, workloadProfileName=null), deleteRequest=null), WriteRequest(putRequest=PutRequest(item={pk=AttributeValue(s=bw-3, n=null, b=null, iNT=null, dECIMAL=null, dOUBLE=null, sS=null, nS=null, bS=null, iNTSET=null, dECIMALSET=null, dOUBLESET=null, m=null, l=null, nULL=null, bOOL=null)}, workloadProfileName=null), deleteRequest=null), WriteRequest(putRequest=PutRequest(item={pk=AttributeValue(s=bw-4, n=null, b=null, iNT=null, dECIMAL=null, dOUBLE=null, sS=null, nS=null, bS=null, iNTSET=null, dECIMALSET=null, dOUBLESET=null, m=null, l=null, nULL=null, bOOL=null)}, workloadProfileName=null), deleteRequest=null), WriteRequest(putRequest=PutRequest(item={pk=AttributeValue(s=bw-5, n=null, b=null, iNT=null, dECIMAL=null, dOUBLE=null, sS=null, nS=null, bS=null, iNTSET=null, dECIMALSET=null, dOUBLESET=null, m=null, l=null, nULL=null, bOOL=null)}, workloadProfileName=null), deleteRequest=null), WriteRequest(putRequest=PutRequest(item={pk=AttributeValue(s=bw-6, n=null, b=null, iNT=null, dECIMAL=null, dOUBLE=null, sS=null, nS=null, bS=null, iNTSET=null, dECIMALSET=null, dOUBLESET=null, m=null, l=null, nULL=null, bOOL=null)}, workloadProfileName=null), deleteRequest=null), WriteRequest(putRequest=PutRequest(item={pk=AttributeValue(s=bw-7, n=null, b=null, iNT=null, dECIMAL=null, dOUBLE=null, sS=null, nS=null, bS=null, iNTSET=null, dECIMALSET=null, dOUBLESET=null, m=null, l=null, nULL=null, bOOL=null)}, workloadProfileName=null), deleteRequest=null), WriteRequest(putRequest=PutRequest(item={pk=AttributeValue(s=bw-8, n=null, b=null, iNT=null, dECIMAL=null, dOUBLE=null, sS=null, nS=null, bS=null, iNTSET=null, dECIMALSET=null, dOUBLESET=null, m=null, l=null, nULL=null, bOOL=null)}, workloadProfileName=null), deleteRequest=null), WriteRequest(putRequest=PutRequest(item={pk=AttributeValue(s=bw-9, n=null, b=null, iNT=null, dECIMAL=null, dOUBLE=null, sS=null, nS=null, bS=null, iNTSET=null, dECIMALSET=null, dOUBLESET=null, m=null, l=null, nULL=null, bOOL=null)}, workloadProfileName=null), deleteRequest=null), WriteRequest(putRequest=PutRequest(item={pk=AttributeValue(s=bw-10, n=null, b=null, iNT=null, dECIMAL=null, dOUBLE=null, sS=null, nS=null, bS=null, iNTSET=null, dECIMALSET=null, dOUBLESET=null, m=null, l=null, nULL=null, bOOL=null)}, workloadProfileName=null), deleteRequest=null), WriteRequest(putRequest=PutRequest(item={pk=AttributeValue(s=bw-11, n=null, b=null, iNT=null, dECIMAL=null, dOUBLE=null, sS=null, nS=null, bS=null, iNTSET=null, dECIMALSET=null, dOUBLESET=null, m=null, l=null, nULL=null, bOOL=null)}, workloadProfileName=null), deleteRequest=null), WriteRequest(putRequest=PutRequest(item={pk=AttributeValue(s=bw-12, n=null, b=null, iNT=null, dECIMAL=null, dOUBLE=null, sS=null, nS=null, bS=null, iNTSET=null, dECIMALSET=null, dOUBLESET=null, m=null, l=null, nULL=null, bOOL=null)}, workloadProfileName=null), deleteRequest=null), WriteRequest(putRequest=PutRequest(item={pk=AttributeValue(s=bw-13, n=null, b=null, iNT=null, dECIMAL=null, dOUBLE=null, sS=null, nS=null, bS=null, iNTSET=null, dECIMALSET=null, dOUBLESET=null, m=null, l=null, nULL=null, bOOL=null)}, workloadProfileName=null), deleteRequest=null), WriteRequest(putRequest=PutRequest(item={pk=AttributeValue(s=bw-14, n=null, b=null, iNT=null, dECIMAL=null, dOUBLE=null, sS=null, nS=null, bS=null, iNTSET=null, dECIMALSET=null, dOUBLESET=null, m=null, l=null, nULL=null, bOOL=null)}, workloadProfileName=null), deleteRequest=null), WriteRequest(putRequest=PutRequest(item={pk=AttributeValue(s=bw-15, n=null, b=null, iNT=null, dECIMAL=null, dOUBLE=null, sS=null, nS=null, bS=null, iNTSET=null, dECIMALSET=null, dOUBLESET=null, m=null, l=null, nULL=null, bOOL=null)}, workloadProfileName=null), deleteRequest=null), WriteRequest(putRequest=PutRequest(item={pk=AttributeValue(s=bw-16, n=null, b=null, iNT=null, dECIMAL=null, dOUBLE=null, sS=null, nS=null, bS=null, iNTSET=null, dECIMALSET=null, dOUBLESET=null, m=null, l=null, nULL=null, bOOL=null)}, workloadProfileName=null), deleteRequest=null), WriteRequest(putRequest=PutRequest(item={pk=AttributeValue(s=bw-17, n=null, b=null, iNT=null, dECIMAL=null, dOUBLE=null, sS=null, nS=null, bS=null, iNTSET=null, dECIMALSET=null, dOUBLESET=null, m=null, l=null, nULL=null, bOOL=null)}, workloadProfileName=null), deleteRequest=null), WriteRequest(putRequest=PutRequest(item={pk=AttributeValue(s=bw-18, n=null, b=null, iNT=null, dECIMAL=null, dOUBLE=null, sS=null, nS=null, bS=null, iNTSET=null, dECIMALSET=null, dOUBLESET=null, m=null, l=null, nULL=null, bOOL=null)}, workloadProfileName=null), deleteRequest=null), WriteRequest(putRequest=PutRequest(item={pk=AttributeValue(s=bw-19, n=null, b=null, iNT=null, dECIMAL=null, dOUBLE=null, sS=null, nS=null, bS=null, iNTSET=null, dECIMALSET=null, dOUBLESET=null, m=null, l=null, nULL=null, bOOL=null)}, workloadProfileName=null), deleteRequest=null), WriteRequest(putRequest=PutRequest(item={pk=AttributeValue(s=bw-20, n=null, b=null, iNT=null, dECIMAL=null, dOUBLE=null, sS=null, nS=null, bS=null, iNTSET=null, dECIMALSET=null, dOUBLESET=null, m=null, l=null, nULL=null, bOOL=null)}, workloadProfileName=null), deleteRequest=null), WriteRequest(putRequest=PutRequest(item={pk=AttributeValue(s=bw-21, n=null, b=null, iNT=null, dECIMAL=null, dOUBLE=null, sS=null, nS=null, bS=null, iNTSET=null, dECIMALSET=null, dOUBLESET=null, m=null, l=null, nULL=null, bOOL=null)}, workloadProfileName=null), deleteRequest=null), WriteRequest(putRequest=PutRequest(item={pk=AttributeValue(s=bw-22, n=null, b=null, iNT=null, dECIMAL=null, dOUBLE=null, sS=null, nS=null, bS=null, iNTSET=null, dECIMALSET=null, dOUBLESET=null, m=null, l=null, nULL=null, bOOL=null)}, workloadProfileName=null), deleteRequest=null), WriteRequest(putRequest=PutRequest(item={pk=AttributeValue(s=bw-23, n=null, b=null, iNT=null, dECIMAL=null, dOUBLE=null, sS=null, nS=null, bS=null, iNTSET=null, dECIMALSET=null, dOUBLESET=null, m=null, l=null, nULL=null, bOOL=null)}, workloadProfileName=null), deleteRequest=null), WriteRequest(putRequest=PutRequest(item={pk=AttributeValue(s=bw-24, n=null, b=null, iNT=null, dECIMAL=null, dOUBLE=null, sS=null, nS=null, bS=null, iNTSET=null, dECIMALSET=null, dOUBLESET=null, m=null, l=null, nULL=null, bOOL=null)}, workloadProfileName=null), deleteRequest=null), WriteRequest(putRequest=PutRequest(item={pk=AttributeValue(s=bw-25, n=null, b=null, iNT=null, dECIMAL=null, dOUBLE=null, sS=null, nS=null, bS=null, iNTSET=null, dECIMALSET=null, dOUBLESET=null, m=null, l=null, nULL=null, bOOL=null)}, workloadProfileName=null), deleteRequest=null)]}' at 'requestItems' failed to satisfy constraint: Map value must satisfy constraint: [Member must have length less than or equal to 25, Member must have length greater than or equal to 1]",
           "n": 1,
           "fields": [
             "requestItems"
-          ]
+          ],
+          "cancellationReasons": null
         },
         {
           "id": "c_ct_3keys",
@@ -419,7 +671,8 @@
           "n": 1,
           "fields": [
             "keySchema"
-          ]
+          ],
+          "cancellationReasons": null
         },
         {
           "id": "b_put_empty_ss",
@@ -429,7 +682,8 @@
           "name": "ValidationException",
           "message": "One or more parameter values were invalid: An string set  may not be empty",
           "n": null,
-          "fields": []
+          "fields": [],
+          "cancellationReasons": null
         },
         {
           "id": "b_put_empty_ns",
@@ -439,7 +693,8 @@
           "name": "ValidationException",
           "message": "One or more parameter values were invalid: An number set  may not be empty",
           "n": null,
-          "fields": []
+          "fields": [],
+          "cancellationReasons": null
         },
         {
           "id": "b_put_dup_ss",
@@ -449,7 +704,8 @@
           "name": "ValidationException",
           "message": "One or more parameter values were invalid: Input collection [a, a] contains duplicates.",
           "n": null,
-          "fields": []
+          "fields": [],
+          "cancellationReasons": null
         },
         {
           "id": "b_put_mix_expr",
@@ -459,7 +715,8 @@
           "name": "ValidationException",
           "message": "Can not use both expression and non-expression parameters in the same request: Non-expression parameters: {Expected} Expression parameters: {ConditionExpression}",
           "n": null,
-          "fields": []
+          "fields": [],
+          "cancellationReasons": null
         },
         {
           "id": "b_put_eav_no_expr",
@@ -469,7 +726,8 @@
           "name": "ValidationException",
           "message": "ExpressionAttributeValues can only be specified when using expressions: ConditionExpression is null",
           "n": null,
-          "fields": []
+          "fields": [],
+          "cancellationReasons": null
         },
         {
           "id": "b_put_redundant_parens",
@@ -479,7 +737,8 @@
           "name": "ValidationException",
           "message": "Invalid ConditionExpression: The expression has redundant parentheses;",
           "n": null,
-          "fields": []
+          "fields": [],
+          "cancellationReasons": null
         },
         {
           "id": "b_put_contains_dup",
@@ -489,7 +748,8 @@
           "name": "ValidationException",
           "message": "Invalid ConditionExpression: The first operand must be distinct from the remaining operands for this operator or function; operator: contains, first operand: [data]",
           "n": null,
-          "fields": []
+          "fields": [],
+          "cancellationReasons": null
         },
         {
           "id": "u_upd_hashkey",
@@ -499,7 +759,8 @@
           "name": "ValidationException",
           "message": "One or more parameter values were invalid: Cannot update attribute pk. This attribute is part of the key",
           "n": null,
-          "fields": []
+          "fields": [],
+          "cancellationReasons": null
         },
         {
           "id": "u_upd_syntax",
@@ -509,7 +770,8 @@
           "name": "ValidationException",
           "message": "Invalid UpdateExpression: Syntax error; token: \"INVALID\", near: \"INVALID SYNTAX\"",
           "n": null,
-          "fields": []
+          "fields": [],
+          "cancellationReasons": null
         },
         {
           "id": "u_upd_unused_ean",
@@ -519,7 +781,8 @@
           "name": "ValidationException",
           "message": "Value provided in ExpressionAttributeNames unused in expressions: keys: {#unused}",
           "n": null,
-          "fields": []
+          "fields": [],
+          "cancellationReasons": null
         },
         {
           "id": "u_upd_unused_eav",
@@ -529,7 +792,8 @@
           "name": "ValidationException",
           "message": "Value provided in ExpressionAttributeValues unused in expressions: keys: {:unused}",
           "n": null,
-          "fields": []
+          "fields": [],
+          "cancellationReasons": null
         },
         {
           "id": "u_upd_missing_eav",
@@ -539,7 +803,8 @@
           "name": "ValidationException",
           "message": "Invalid UpdateExpression: An expression attribute value used in expression is not defined; attribute value: :v",
           "n": null,
-          "fields": []
+          "fields": [],
+          "cancellationReasons": null
         },
         {
           "id": "u_upd_mix",
@@ -549,7 +814,8 @@
           "name": "ValidationException",
           "message": "Can not use both expression and non-expression parameters in the same request: Non-expression parameters: {AttributeUpdates} Expression parameters: {UpdateExpression}",
           "n": null,
-          "fields": []
+          "fields": [],
+          "cancellationReasons": null
         },
         {
           "id": "u_upd_empty",
@@ -559,7 +825,8 @@
           "name": "ValidationException",
           "message": "Invalid UpdateExpression: The expression can not be empty;",
           "n": null,
-          "fields": []
+          "fields": [],
+          "cancellationReasons": null
         },
         {
           "id": "u_upd_rangekey",
@@ -569,7 +836,8 @@
           "name": "ValidationException",
           "message": "One or more parameter values were invalid: Cannot update attribute sk. This attribute is part of the key",
           "n": null,
-          "fields": []
+          "fields": [],
+          "cancellationReasons": null
         },
         {
           "id": "o_put_empty_table_empty_item",
@@ -581,7 +849,8 @@
           "n": 1,
           "fields": [
             "tableName"
-          ]
+          ],
+          "cancellationReasons": null
         },
         {
           "id": "o_put_empty_table_bad_rv",
@@ -594,7 +863,8 @@
           "fields": [
             "returnValues",
             "tableName"
-          ]
+          ],
+          "cancellationReasons": null
         },
         {
           "id": "o_put_three_bad_enums",
@@ -608,7 +878,8 @@
             "returnValues",
             "returnConsumedCapacity",
             "returnItemCollectionMetrics"
-          ]
+          ],
+          "cancellationReasons": null
         },
         {
           "id": "o_del_empty_table",
@@ -620,7 +891,8 @@
           "n": 1,
           "fields": [
             "tableName"
-          ]
+          ],
+          "cancellationReasons": null
         },
         {
           "id": "o_del_two_bad_enums",
@@ -633,7 +905,8 @@
           "fields": [
             "returnValues",
             "returnConsumedCapacity"
-          ]
+          ],
+          "cancellationReasons": null
         },
         {
           "id": "o_upd_empty_table",
@@ -645,7 +918,8 @@
           "n": 1,
           "fields": [
             "tableName"
-          ]
+          ],
+          "cancellationReasons": null
         },
         {
           "id": "o_upd_two_bad_enums",
@@ -658,6 +932,224 @@
           "fields": [
             "returnConsumedCapacity",
             "returnValues"
+          ],
+          "cancellationReasons": null
+        },
+        {
+          "id": "bw_table_wrongtype",
+          "family": "batch-key",
+          "note": "BatchWrite PutRequest pk wrong type (N on S)",
+          "threw": true,
+          "name": "ValidationException",
+          "message": "The provided key element does not match the schema",
+          "n": null,
+          "fields": [],
+          "cancellationReasons": null
+        },
+        {
+          "id": "bw_table_nonscalar",
+          "family": "batch-key",
+          "note": "BatchWrite PutRequest pk non-scalar (L)",
+          "threw": true,
+          "name": "ValidationException",
+          "message": "The provided key element does not match the schema",
+          "n": null,
+          "fields": [],
+          "cancellationReasons": null
+        },
+        {
+          "id": "del_key_empty",
+          "family": "lookup-key",
+          "note": "DeleteItem Key pk empty",
+          "threw": true,
+          "name": "ValidationException",
+          "message": "One or more parameter values are not valid. The AttributeValue for a key attribute cannot contain an empty string value. Key: pk",
+          "n": null,
+          "fields": [],
+          "cancellationReasons": null
+        },
+        {
+          "id": "get_key_empty",
+          "family": "lookup-key",
+          "note": "GetItem Key pk empty",
+          "threw": true,
+          "name": "ValidationException",
+          "message": "One or more parameter values are not valid. The AttributeValue for a key attribute cannot contain an empty string value. Key: pk",
+          "n": null,
+          "fields": [],
+          "cancellationReasons": null
+        },
+        {
+          "id": "del_key_wrongtype",
+          "family": "lookup-key",
+          "note": "DeleteItem Key pk wrongtype",
+          "threw": true,
+          "name": "ValidationException",
+          "message": "The provided key element does not match the schema",
+          "n": null,
+          "fields": [],
+          "cancellationReasons": null
+        },
+        {
+          "id": "get_key_wrongtype",
+          "family": "lookup-key",
+          "note": "GetItem Key pk wrongtype",
+          "threw": true,
+          "name": "ValidationException",
+          "message": "The provided key element does not match the schema",
+          "n": null,
+          "fields": [],
+          "cancellationReasons": null
+        },
+        {
+          "id": "del_key_nonscalar",
+          "family": "lookup-key",
+          "note": "DeleteItem Key pk nonscalar",
+          "threw": true,
+          "name": "ValidationException",
+          "message": "The provided key element does not match the schema",
+          "n": null,
+          "fields": [],
+          "cancellationReasons": null
+        },
+        {
+          "id": "get_key_nonscalar",
+          "family": "lookup-key",
+          "note": "GetItem Key pk nonscalar",
+          "threw": true,
+          "name": "ValidationException",
+          "message": "The provided key element does not match the schema",
+          "n": null,
+          "fields": [],
+          "cancellationReasons": null
+        },
+        {
+          "id": "twi_upd_key_empty",
+          "family": "transact-key",
+          "note": "TransactWrite Update Key pk empty",
+          "threw": true,
+          "name": "ValidationException",
+          "message": "One or more parameter values are not valid. The AttributeValue for a key attribute cannot contain an empty string value. Key: pk",
+          "n": null,
+          "fields": [],
+          "cancellationReasons": null
+        },
+        {
+          "id": "twi_del_key_empty",
+          "family": "transact-key",
+          "note": "TransactWrite Delete Key pk empty",
+          "threw": true,
+          "name": "ValidationException",
+          "message": "One or more parameter values are not valid. The AttributeValue for a key attribute cannot contain an empty string value. Key: pk",
+          "n": null,
+          "fields": [],
+          "cancellationReasons": null
+        },
+        {
+          "id": "twi_cc_key_empty",
+          "family": "transact-key",
+          "note": "TransactWrite ConditionCheck Key pk empty",
+          "threw": true,
+          "name": "ValidationException",
+          "message": "One or more parameter values are not valid. The AttributeValue for a key attribute cannot contain an empty string value. Key: pk",
+          "n": null,
+          "fields": [],
+          "cancellationReasons": null
+        },
+        {
+          "id": "twi_upd_key_wrongtype",
+          "family": "transact-key",
+          "note": "TransactWrite Update Key pk wrongtype",
+          "threw": true,
+          "name": "TransactionCanceledException",
+          "message": "Transaction cancelled, please refer cancellation reasons for specific reasons [ValidationError]",
+          "n": null,
+          "fields": [],
+          "cancellationReasons": [
+            {
+              "Code": "ValidationError",
+              "Message": "The provided key element does not match the schema"
+            }
+          ]
+        },
+        {
+          "id": "twi_del_key_wrongtype",
+          "family": "transact-key",
+          "note": "TransactWrite Delete Key pk wrongtype",
+          "threw": true,
+          "name": "TransactionCanceledException",
+          "message": "Transaction cancelled, please refer cancellation reasons for specific reasons [ValidationError]",
+          "n": null,
+          "fields": [],
+          "cancellationReasons": [
+            {
+              "Code": "ValidationError",
+              "Message": "The provided key element does not match the schema"
+            }
+          ]
+        },
+        {
+          "id": "twi_cc_key_wrongtype",
+          "family": "transact-key",
+          "note": "TransactWrite ConditionCheck Key pk wrongtype",
+          "threw": true,
+          "name": "TransactionCanceledException",
+          "message": "Transaction cancelled, please refer cancellation reasons for specific reasons [ValidationError]",
+          "n": null,
+          "fields": [],
+          "cancellationReasons": [
+            {
+              "Code": "ValidationError",
+              "Message": "The provided key element does not match the schema"
+            }
+          ]
+        },
+        {
+          "id": "twi_upd_key_nonscalar",
+          "family": "transact-key",
+          "note": "TransactWrite Update Key pk nonscalar",
+          "threw": true,
+          "name": "TransactionCanceledException",
+          "message": "Transaction cancelled, please refer cancellation reasons for specific reasons [ValidationError]",
+          "n": null,
+          "fields": [],
+          "cancellationReasons": [
+            {
+              "Code": "ValidationError",
+              "Message": "The provided key element does not match the schema"
+            }
+          ]
+        },
+        {
+          "id": "twi_del_key_nonscalar",
+          "family": "transact-key",
+          "note": "TransactWrite Delete Key pk nonscalar",
+          "threw": true,
+          "name": "TransactionCanceledException",
+          "message": "Transaction cancelled, please refer cancellation reasons for specific reasons [ValidationError]",
+          "n": null,
+          "fields": [],
+          "cancellationReasons": [
+            {
+              "Code": "ValidationError",
+              "Message": "The provided key element does not match the schema"
+            }
+          ]
+        },
+        {
+          "id": "twi_cc_key_nonscalar",
+          "family": "transact-key",
+          "note": "TransactWrite ConditionCheck Key pk nonscalar",
+          "threw": true,
+          "name": "TransactionCanceledException",
+          "message": "Transaction cancelled, please refer cancellation reasons for specific reasons [ValidationError]",
+          "n": null,
+          "fields": [],
+          "cancellationReasons": [
+            {
+              "Code": "ValidationError",
+              "Message": "The provided key element does not match the schema"
+            }
           ]
         }
       ],
@@ -680,7 +1172,8 @@
           "n": 1,
           "fields": [
             "tableName"
-          ]
+          ],
+          "cancellationReasons": null
         },
         {
           "id": "s_put_table_empty",
@@ -692,7 +1185,8 @@
           "n": 1,
           "fields": [
             "TableName"
-          ]
+          ],
+          "cancellationReasons": null
         },
         {
           "id": "s_put_table_long",
@@ -704,7 +1198,8 @@
           "n": 1,
           "fields": [
             "tableName"
-          ]
+          ],
+          "cancellationReasons": null
         },
         {
           "id": "s_put_table_badchars",
@@ -716,7 +1211,8 @@
           "n": 1,
           "fields": [
             "tableName"
-          ]
+          ],
+          "cancellationReasons": null
         },
         {
           "id": "s_ct_table_short",
@@ -728,7 +1224,8 @@
           "n": 1,
           "fields": [
             "tableName"
-          ]
+          ],
+          "cancellationReasons": null
         },
         {
           "id": "c_bw_over25",
@@ -736,11 +1233,12 @@
           "note": "BatchWrite 26 requests",
           "threw": true,
           "name": "ValidationException",
-          "message": "1 validation error detected: Value '{_conformance_capdrift_h_1782219512108900170=[WriteRequest(putRequest=PutRequest(item={pk=com.amazonaws.dynamodb.v20120810.AttributeValue@483470e1}, workloadProfileName=null), deleteRequest=null), WriteRequest(putRequest=PutRequest(item={pk=com.amazonaws.dynamodb.v20120810.AttributeValue@483474a2}, workloadProfileName=null), deleteRequest=null), WriteRequest(putRequest=PutRequest(item={pk=com.amazonaws.dynamodb.v20120810.AttributeValue@48347863}, workloadProfileName=null), deleteRequest=null), WriteRequest(putRequest=PutRequest(item={pk=com.amazonaws.dynamodb.v20120810.AttributeValue@48347c24}, workloadProfileName=null), deleteRequest=null), WriteRequest(putRequest=PutRequest(item={pk=com.amazonaws.dynamodb.v20120810.AttributeValue@48347fe5}, workloadProfileName=null), deleteRequest=null), WriteRequest(putRequest=PutRequest(item={pk=com.amazonaws.dynamodb.v20120810.AttributeValue@483483a6}, workloadProfileName=null), deleteRequest=null), WriteRequest(putRequest=PutRequest(item={pk=com.amazonaws.dynamodb.v20120810.AttributeValue@48348767}, workloadProfileName=null), deleteRequest=null), WriteRequest(putRequest=PutRequest(item={pk=com.amazonaws.dynamodb.v20120810.AttributeValue@48348b28}, workloadProfileName=null), deleteRequest=null), WriteRequest(putRequest=PutRequest(item={pk=com.amazonaws.dynamodb.v20120810.AttributeValue@48348ee9}, workloadProfileName=null), deleteRequest=null), WriteRequest(putRequest=PutRequest(item={pk=com.amazonaws.dynamodb.v20120810.AttributeValue@483492aa}, workloadProfileName=null), deleteRequest=null), WriteRequest(putRequest=PutRequest(item={pk=com.amazonaws.dynamodb.v20120810.AttributeValue@a81beb00}, workloadProfileName=null), deleteRequest=null), WriteRequest(putRequest=PutRequest(item={pk=com.amazonaws.dynamodb.v20120810.AttributeValue@a81beec1}, workloadProfileName=null), deleteRequest=null), WriteRequest(putRequest=PutRequest(item={pk=com.amazonaws.dynamodb.v20120810.AttributeValue@a81bf282}, workloadProfileName=null), deleteRequest=null), WriteRequest(putRequest=PutRequest(item={pk=com.amazonaws.dynamodb.v20120810.AttributeValue@a81bf643}, workloadProfileName=null), deleteRequest=null), WriteRequest(putRequest=PutRequest(item={pk=com.amazonaws.dynamodb.v20120810.AttributeValue@a81bfa04}, workloadProfileName=null), deleteRequest=null), WriteRequest(putRequest=PutRequest(item={pk=com.amazonaws.dynamodb.v20120810.AttributeValue@a81bfdc5}, workloadProfileName=null), deleteRequest=null), WriteRequest(putRequest=PutRequest(item={pk=com.amazonaws.dynamodb.v20120810.AttributeValue@a81c0186}, workloadProfileName=null), deleteRequest=null), WriteRequest(putRequest=PutRequest(item={pk=com.amazonaws.dynamodb.v20120810.AttributeValue@a81c0547}, workloadProfileName=null), deleteRequest=null), WriteRequest(putRequest=PutRequest(item={pk=com.amazonaws.dynamodb.v20120810.AttributeValue@a81c0908}, workloadProfileName=null), deleteRequest=null), WriteRequest(putRequest=PutRequest(item={pk=com.amazonaws.dynamodb.v20120810.AttributeValue@a81c0cc9}, workloadProfileName=null), deleteRequest=null), WriteRequest(putRequest=PutRequest(item={pk=com.amazonaws.dynamodb.v20120810.AttributeValue@a81c5f5f}, workloadProfileName=null), deleteRequest=null), WriteRequest(putRequest=PutRequest(item={pk=com.amazonaws.dynamodb.v20120810.AttributeValue@a81c6320}, workloadProfileName=null), deleteRequest=null), WriteRequest(putRequest=PutRequest(item={pk=com.amazonaws.dynamodb.v20120810.AttributeValue@a81c66e1}, workloadProfileName=null), deleteRequest=null), WriteRequest(putRequest=PutRequest(item={pk=com.amazonaws.dynamodb.v20120810.AttributeValue@a81c6aa2}, workloadProfileName=null), deleteRequest=null), WriteRequest(putRequest=PutRequest(item={pk=com.amazonaws.dynamodb.v20120810.AttributeValue@a81c6e63}, workloadProfileName=null), deleteRequest=null), WriteRequest(putRequest=PutRequest(item={pk=com.amazonaws.dynamodb.v20120810.AttributeValue@a81c7224}, workloadProfileName=null), deleteRequest=null)]}' at 'requestItems' failed to satisfy constraint: Map value must satisfy constraint: [Member must have length less than or equal to 25, Member must have length greater than or equal to 1]",
+          "message": "1 validation error detected: Value '{_conformance_capdrift_h_1782254032459785839=[WriteRequest(putRequest=PutRequest(item={pk=AttributeValue(s=bw-0, n=null, b=null, iNT=null, dECIMAL=null, dOUBLE=null, sS=null, nS=null, bS=null, iNTSET=null, dECIMALSET=null, dOUBLESET=null, m=null, l=null, nULL=null, bOOL=null)}, workloadProfileName=null), deleteRequest=null), WriteRequest(putRequest=PutRequest(item={pk=AttributeValue(s=bw-1, n=null, b=null, iNT=null, dECIMAL=null, dOUBLE=null, sS=null, nS=null, bS=null, iNTSET=null, dECIMALSET=null, dOUBLESET=null, m=null, l=null, nULL=null, bOOL=null)}, workloadProfileName=null), deleteRequest=null), WriteRequest(putRequest=PutRequest(item={pk=AttributeValue(s=bw-2, n=null, b=null, iNT=null, dECIMAL=null, dOUBLE=null, sS=null, nS=null, bS=null, iNTSET=null, dECIMALSET=null, dOUBLESET=null, m=null, l=null, nULL=null, bOOL=null)}, workloadProfileName=null), deleteRequest=null), WriteRequest(putRequest=PutRequest(item={pk=AttributeValue(s=bw-3, n=null, b=null, iNT=null, dECIMAL=null, dOUBLE=null, sS=null, nS=null, bS=null, iNTSET=null, dECIMALSET=null, dOUBLESET=null, m=null, l=null, nULL=null, bOOL=null)}, workloadProfileName=null), deleteRequest=null), WriteRequest(putRequest=PutRequest(item={pk=AttributeValue(s=bw-4, n=null, b=null, iNT=null, dECIMAL=null, dOUBLE=null, sS=null, nS=null, bS=null, iNTSET=null, dECIMALSET=null, dOUBLESET=null, m=null, l=null, nULL=null, bOOL=null)}, workloadProfileName=null), deleteRequest=null), WriteRequest(putRequest=PutRequest(item={pk=AttributeValue(s=bw-5, n=null, b=null, iNT=null, dECIMAL=null, dOUBLE=null, sS=null, nS=null, bS=null, iNTSET=null, dECIMALSET=null, dOUBLESET=null, m=null, l=null, nULL=null, bOOL=null)}, workloadProfileName=null), deleteRequest=null), WriteRequest(putRequest=PutRequest(item={pk=AttributeValue(s=bw-6, n=null, b=null, iNT=null, dECIMAL=null, dOUBLE=null, sS=null, nS=null, bS=null, iNTSET=null, dECIMALSET=null, dOUBLESET=null, m=null, l=null, nULL=null, bOOL=null)}, workloadProfileName=null), deleteRequest=null), WriteRequest(putRequest=PutRequest(item={pk=AttributeValue(s=bw-7, n=null, b=null, iNT=null, dECIMAL=null, dOUBLE=null, sS=null, nS=null, bS=null, iNTSET=null, dECIMALSET=null, dOUBLESET=null, m=null, l=null, nULL=null, bOOL=null)}, workloadProfileName=null), deleteRequest=null), WriteRequest(putRequest=PutRequest(item={pk=AttributeValue(s=bw-8, n=null, b=null, iNT=null, dECIMAL=null, dOUBLE=null, sS=null, nS=null, bS=null, iNTSET=null, dECIMALSET=null, dOUBLESET=null, m=null, l=null, nULL=null, bOOL=null)}, workloadProfileName=null), deleteRequest=null), WriteRequest(putRequest=PutRequest(item={pk=AttributeValue(s=bw-9, n=null, b=null, iNT=null, dECIMAL=null, dOUBLE=null, sS=null, nS=null, bS=null, iNTSET=null, dECIMALSET=null, dOUBLESET=null, m=null, l=null, nULL=null, bOOL=null)}, workloadProfileName=null), deleteRequest=null), WriteRequest(putRequest=PutRequest(item={pk=AttributeValue(s=bw-10, n=null, b=null, iNT=null, dECIMAL=null, dOUBLE=null, sS=null, nS=null, bS=null, iNTSET=null, dECIMALSET=null, dOUBLESET=null, m=null, l=null, nULL=null, bOOL=null)}, workloadProfileName=null), deleteRequest=null), WriteRequest(putRequest=PutRequest(item={pk=AttributeValue(s=bw-11, n=null, b=null, iNT=null, dECIMAL=null, dOUBLE=null, sS=null, nS=null, bS=null, iNTSET=null, dECIMALSET=null, dOUBLESET=null, m=null, l=null, nULL=null, bOOL=null)}, workloadProfileName=null), deleteRequest=null), WriteRequest(putRequest=PutRequest(item={pk=AttributeValue(s=bw-12, n=null, b=null, iNT=null, dECIMAL=null, dOUBLE=null, sS=null, nS=null, bS=null, iNTSET=null, dECIMALSET=null, dOUBLESET=null, m=null, l=null, nULL=null, bOOL=null)}, workloadProfileName=null), deleteRequest=null), WriteRequest(putRequest=PutRequest(item={pk=AttributeValue(s=bw-13, n=null, b=null, iNT=null, dECIMAL=null, dOUBLE=null, sS=null, nS=null, bS=null, iNTSET=null, dECIMALSET=null, dOUBLESET=null, m=null, l=null, nULL=null, bOOL=null)}, workloadProfileName=null), deleteRequest=null), WriteRequest(putRequest=PutRequest(item={pk=AttributeValue(s=bw-14, n=null, b=null, iNT=null, dECIMAL=null, dOUBLE=null, sS=null, nS=null, bS=null, iNTSET=null, dECIMALSET=null, dOUBLESET=null, m=null, l=null, nULL=null, bOOL=null)}, workloadProfileName=null), deleteRequest=null), WriteRequest(putRequest=PutRequest(item={pk=AttributeValue(s=bw-15, n=null, b=null, iNT=null, dECIMAL=null, dOUBLE=null, sS=null, nS=null, bS=null, iNTSET=null, dECIMALSET=null, dOUBLESET=null, m=null, l=null, nULL=null, bOOL=null)}, workloadProfileName=null), deleteRequest=null), WriteRequest(putRequest=PutRequest(item={pk=AttributeValue(s=bw-16, n=null, b=null, iNT=null, dECIMAL=null, dOUBLE=null, sS=null, nS=null, bS=null, iNTSET=null, dECIMALSET=null, dOUBLESET=null, m=null, l=null, nULL=null, bOOL=null)}, workloadProfileName=null), deleteRequest=null), WriteRequest(putRequest=PutRequest(item={pk=AttributeValue(s=bw-17, n=null, b=null, iNT=null, dECIMAL=null, dOUBLE=null, sS=null, nS=null, bS=null, iNTSET=null, dECIMALSET=null, dOUBLESET=null, m=null, l=null, nULL=null, bOOL=null)}, workloadProfileName=null), deleteRequest=null), WriteRequest(putRequest=PutRequest(item={pk=AttributeValue(s=bw-18, n=null, b=null, iNT=null, dECIMAL=null, dOUBLE=null, sS=null, nS=null, bS=null, iNTSET=null, dECIMALSET=null, dOUBLESET=null, m=null, l=null, nULL=null, bOOL=null)}, workloadProfileName=null), deleteRequest=null), WriteRequest(putRequest=PutRequest(item={pk=AttributeValue(s=bw-19, n=null, b=null, iNT=null, dECIMAL=null, dOUBLE=null, sS=null, nS=null, bS=null, iNTSET=null, dECIMALSET=null, dOUBLESET=null, m=null, l=null, nULL=null, bOOL=null)}, workloadProfileName=null), deleteRequest=null), WriteRequest(putRequest=PutRequest(item={pk=AttributeValue(s=bw-20, n=null, b=null, iNT=null, dECIMAL=null, dOUBLE=null, sS=null, nS=null, bS=null, iNTSET=null, dECIMALSET=null, dOUBLESET=null, m=null, l=null, nULL=null, bOOL=null)}, workloadProfileName=null), deleteRequest=null), WriteRequest(putRequest=PutRequest(item={pk=AttributeValue(s=bw-21, n=null, b=null, iNT=null, dECIMAL=null, dOUBLE=null, sS=null, nS=null, bS=null, iNTSET=null, dECIMALSET=null, dOUBLESET=null, m=null, l=null, nULL=null, bOOL=null)}, workloadProfileName=null), deleteRequest=null), WriteRequest(putRequest=PutRequest(item={pk=AttributeValue(s=bw-22, n=null, b=null, iNT=null, dECIMAL=null, dOUBLE=null, sS=null, nS=null, bS=null, iNTSET=null, dECIMALSET=null, dOUBLESET=null, m=null, l=null, nULL=null, bOOL=null)}, workloadProfileName=null), deleteRequest=null), WriteRequest(putRequest=PutRequest(item={pk=AttributeValue(s=bw-23, n=null, b=null, iNT=null, dECIMAL=null, dOUBLE=null, sS=null, nS=null, bS=null, iNTSET=null, dECIMALSET=null, dOUBLESET=null, m=null, l=null, nULL=null, bOOL=null)}, workloadProfileName=null), deleteRequest=null), WriteRequest(putRequest=PutRequest(item={pk=AttributeValue(s=bw-24, n=null, b=null, iNT=null, dECIMAL=null, dOUBLE=null, sS=null, nS=null, bS=null, iNTSET=null, dECIMALSET=null, dOUBLESET=null, m=null, l=null, nULL=null, bOOL=null)}, workloadProfileName=null), deleteRequest=null), WriteRequest(putRequest=PutRequest(item={pk=AttributeValue(s=bw-25, n=null, b=null, iNT=null, dECIMAL=null, dOUBLE=null, sS=null, nS=null, bS=null, iNTSET=null, dECIMALSET=null, dOUBLESET=null, m=null, l=null, nULL=null, bOOL=null)}, workloadProfileName=null), deleteRequest=null)]}' at 'requestItems' failed to satisfy constraint: Map value must satisfy constraint: [Member must have length less than or equal to 25, Member must have length greater than or equal to 1]",
           "n": 1,
           "fields": [
             "requestItems"
-          ]
+          ],
+          "cancellationReasons": null
         },
         {
           "id": "c_ct_3keys",
@@ -748,11 +1246,12 @@
           "note": "CreateTable 3 keySchema",
           "threw": true,
           "name": "ValidationException",
-          "message": "1 validation error detected: Value '[com.amazonaws.dynamodb.v20120810.KeySchemaElement@ad28eb1d, com.amazonaws.dynamodb.v20120810.KeySchemaElement@38b9654b, com.amazonaws.dynamodb.v20120810.KeySchemaElement@3e80eb03]' at 'keySchema' failed to satisfy constraint: Member must have length less than or equal to 2",
+          "message": "1 validation error detected: Value '[KeySchemaElement(attributeName=pk, keyType=HASH), KeySchemaElement(attributeName=sk, keyType=RANGE), KeySchemaElement(attributeName=extra, keyType=RANGE)]' at 'keySchema' failed to satisfy constraint: Member must have length less than or equal to 2",
           "n": 1,
           "fields": [
             "keySchema"
-          ]
+          ],
+          "cancellationReasons": null
         },
         {
           "id": "b_put_empty_ss",
@@ -762,7 +1261,8 @@
           "name": "ValidationException",
           "message": "1 validation error detected: One or more parameter values were invalid: An string set  may not be empty",
           "n": 1,
-          "fields": []
+          "fields": [],
+          "cancellationReasons": null
         },
         {
           "id": "b_put_empty_ns",
@@ -772,7 +1272,8 @@
           "name": "ValidationException",
           "message": "1 validation error detected: One or more parameter values were invalid: An number set  may not be empty",
           "n": 1,
-          "fields": []
+          "fields": [],
+          "cancellationReasons": null
         },
         {
           "id": "b_put_dup_ss",
@@ -782,7 +1283,8 @@
           "name": "ValidationException",
           "message": "1 validation error detected: One or more parameter values were invalid: Input collection [\"a\", \"a\"] contains duplicates.",
           "n": 1,
-          "fields": []
+          "fields": [],
+          "cancellationReasons": null
         },
         {
           "id": "b_put_mix_expr",
@@ -792,7 +1294,8 @@
           "name": "ValidationException",
           "message": "1 validation error detected: Can not use both expression and non-expression parameters in the same request: Non-expression parameters: {Expected} Expression parameters: {ConditionExpression}",
           "n": 1,
-          "fields": []
+          "fields": [],
+          "cancellationReasons": null
         },
         {
           "id": "b_put_eav_no_expr",
@@ -802,7 +1305,8 @@
           "name": "ValidationException",
           "message": "1 validation error detected: ExpressionAttributeValues can only be specified when using expressions",
           "n": 1,
-          "fields": []
+          "fields": [],
+          "cancellationReasons": null
         },
         {
           "id": "b_put_redundant_parens",
@@ -812,7 +1316,8 @@
           "name": "ValidationException",
           "message": "1 validation error detected: Invalid ConditionExpression: The expression has redundant parentheses;",
           "n": 1,
-          "fields": []
+          "fields": [],
+          "cancellationReasons": null
         },
         {
           "id": "b_put_contains_dup",
@@ -822,7 +1327,8 @@
           "name": "ValidationException",
           "message": "1 validation error detected: Invalid ConditionExpression: The first operand must be distinct from the remaining operands for this operator or function; operator: contains, first operand: [data]",
           "n": 1,
-          "fields": []
+          "fields": [],
+          "cancellationReasons": null
         },
         {
           "id": "u_upd_hashkey",
@@ -832,7 +1338,8 @@
           "name": "ValidationException",
           "message": "One or more parameter values were invalid: Cannot update attribute pk. This attribute is part of the key",
           "n": null,
-          "fields": []
+          "fields": [],
+          "cancellationReasons": null
         },
         {
           "id": "u_upd_syntax",
@@ -842,7 +1349,8 @@
           "name": "ValidationException",
           "message": "1 validation error detected: Invalid UpdateExpression: Syntax error; token: \"INVALID\", near: \"INVALID SYNTAX\"",
           "n": 1,
-          "fields": []
+          "fields": [],
+          "cancellationReasons": null
         },
         {
           "id": "u_upd_unused_ean",
@@ -852,7 +1360,8 @@
           "name": "ValidationException",
           "message": "1 validation error detected: Value provided in ExpressionAttributeNames unused in expressions: keys: {#unused}",
           "n": 1,
-          "fields": []
+          "fields": [],
+          "cancellationReasons": null
         },
         {
           "id": "u_upd_unused_eav",
@@ -862,7 +1371,8 @@
           "name": "ValidationException",
           "message": "1 validation error detected: Value provided in ExpressionAttributeValues unused in expressions: keys: {:unused}",
           "n": 1,
-          "fields": []
+          "fields": [],
+          "cancellationReasons": null
         },
         {
           "id": "u_upd_missing_eav",
@@ -872,7 +1382,8 @@
           "name": "ValidationException",
           "message": "1 validation error detected: Invalid UpdateExpression: An expression attribute value used in expression is not defined; attribute value: :v",
           "n": 1,
-          "fields": []
+          "fields": [],
+          "cancellationReasons": null
         },
         {
           "id": "u_upd_mix",
@@ -882,7 +1393,8 @@
           "name": "ValidationException",
           "message": "1 validation error detected: Can not use both expression and non-expression parameters in the same request: Non-expression parameters: {AttributeUpdates} Expression parameters: {UpdateExpression}",
           "n": 1,
-          "fields": []
+          "fields": [],
+          "cancellationReasons": null
         },
         {
           "id": "u_upd_empty",
@@ -892,7 +1404,8 @@
           "name": "ValidationException",
           "message": "1 validation error detected: Invalid UpdateExpression: The expression can not be empty;",
           "n": 1,
-          "fields": []
+          "fields": [],
+          "cancellationReasons": null
         },
         {
           "id": "u_upd_rangekey",
@@ -902,7 +1415,8 @@
           "name": "ValidationException",
           "message": "One or more parameter values were invalid: Cannot update attribute sk. This attribute is part of the key",
           "n": null,
-          "fields": []
+          "fields": [],
+          "cancellationReasons": null
         },
         {
           "id": "o_put_empty_table_empty_item",
@@ -914,7 +1428,8 @@
           "n": 1,
           "fields": [
             "TableName"
-          ]
+          ],
+          "cancellationReasons": null
         },
         {
           "id": "o_put_empty_table_bad_rv",
@@ -926,7 +1441,8 @@
           "n": 1,
           "fields": [
             "TableName"
-          ]
+          ],
+          "cancellationReasons": null
         },
         {
           "id": "o_put_three_bad_enums",
@@ -938,7 +1454,8 @@
           "n": 3,
           "fields": [
             "returnConsumedCapacity"
-          ]
+          ],
+          "cancellationReasons": null
         },
         {
           "id": "o_del_empty_table",
@@ -950,7 +1467,8 @@
           "n": 1,
           "fields": [
             "TableName"
-          ]
+          ],
+          "cancellationReasons": null
         },
         {
           "id": "o_del_two_bad_enums",
@@ -962,7 +1480,8 @@
           "n": 2,
           "fields": [
             "returnConsumedCapacity"
-          ]
+          ],
+          "cancellationReasons": null
         },
         {
           "id": "o_upd_empty_table",
@@ -974,7 +1493,8 @@
           "n": 1,
           "fields": [
             "TableName"
-          ]
+          ],
+          "cancellationReasons": null
         },
         {
           "id": "o_upd_two_bad_enums",
@@ -984,7 +1504,225 @@
           "name": "ValidationException",
           "message": "1 validation error detected: Failed to satisfy constraint: Member must satisfy enum value set: [ALL_OLD, UPDATED_OLD, ALL_NEW, UPDATE_NEW, NONE]",
           "n": 1,
-          "fields": []
+          "fields": [],
+          "cancellationReasons": null
+        },
+        {
+          "id": "bw_table_wrongtype",
+          "family": "batch-key",
+          "note": "BatchWrite PutRequest pk wrong type (N on S)",
+          "threw": true,
+          "name": "ValidationException",
+          "message": "The provided key element does not match the schema",
+          "n": null,
+          "fields": [],
+          "cancellationReasons": null
+        },
+        {
+          "id": "bw_table_nonscalar",
+          "family": "batch-key",
+          "note": "BatchWrite PutRequest pk non-scalar (L)",
+          "threw": true,
+          "name": "ValidationException",
+          "message": "The provided key element does not match the schema",
+          "n": null,
+          "fields": [],
+          "cancellationReasons": null
+        },
+        {
+          "id": "del_key_empty",
+          "family": "lookup-key",
+          "note": "DeleteItem Key pk empty",
+          "threw": true,
+          "name": "ValidationException",
+          "message": "One or more parameter values are not valid. The AttributeValue for a key attribute cannot contain an empty string value. Key: pk",
+          "n": null,
+          "fields": [],
+          "cancellationReasons": null
+        },
+        {
+          "id": "get_key_empty",
+          "family": "lookup-key",
+          "note": "GetItem Key pk empty",
+          "threw": true,
+          "name": "ValidationException",
+          "message": "One or more parameter values are not valid. The AttributeValue for a key attribute cannot contain an empty string value. Key: pk",
+          "n": null,
+          "fields": [],
+          "cancellationReasons": null
+        },
+        {
+          "id": "del_key_wrongtype",
+          "family": "lookup-key",
+          "note": "DeleteItem Key pk wrongtype",
+          "threw": true,
+          "name": "ValidationException",
+          "message": "The provided key element does not match the schema",
+          "n": null,
+          "fields": [],
+          "cancellationReasons": null
+        },
+        {
+          "id": "get_key_wrongtype",
+          "family": "lookup-key",
+          "note": "GetItem Key pk wrongtype",
+          "threw": true,
+          "name": "ValidationException",
+          "message": "The provided key element does not match the schema",
+          "n": null,
+          "fields": [],
+          "cancellationReasons": null
+        },
+        {
+          "id": "del_key_nonscalar",
+          "family": "lookup-key",
+          "note": "DeleteItem Key pk nonscalar",
+          "threw": true,
+          "name": "ValidationException",
+          "message": "The provided key element does not match the schema",
+          "n": null,
+          "fields": [],
+          "cancellationReasons": null
+        },
+        {
+          "id": "get_key_nonscalar",
+          "family": "lookup-key",
+          "note": "GetItem Key pk nonscalar",
+          "threw": true,
+          "name": "ValidationException",
+          "message": "The provided key element does not match the schema",
+          "n": null,
+          "fields": [],
+          "cancellationReasons": null
+        },
+        {
+          "id": "twi_upd_key_empty",
+          "family": "transact-key",
+          "note": "TransactWrite Update Key pk empty",
+          "threw": true,
+          "name": "ValidationException",
+          "message": "One or more parameter values are not valid. The AttributeValue for a key attribute cannot contain an empty string value. Key: pk",
+          "n": null,
+          "fields": [],
+          "cancellationReasons": null
+        },
+        {
+          "id": "twi_del_key_empty",
+          "family": "transact-key",
+          "note": "TransactWrite Delete Key pk empty",
+          "threw": true,
+          "name": "ValidationException",
+          "message": "One or more parameter values are not valid. The AttributeValue for a key attribute cannot contain an empty string value. Key: pk",
+          "n": null,
+          "fields": [],
+          "cancellationReasons": null
+        },
+        {
+          "id": "twi_cc_key_empty",
+          "family": "transact-key",
+          "note": "TransactWrite ConditionCheck Key pk empty",
+          "threw": true,
+          "name": "ValidationException",
+          "message": "One or more parameter values are not valid. The AttributeValue for a key attribute cannot contain an empty string value. Key: pk",
+          "n": null,
+          "fields": [],
+          "cancellationReasons": null
+        },
+        {
+          "id": "twi_upd_key_wrongtype",
+          "family": "transact-key",
+          "note": "TransactWrite Update Key pk wrongtype",
+          "threw": true,
+          "name": "TransactionCanceledException",
+          "message": "Transaction cancelled, please refer cancellation reasons for specific reasons [ValidationError]",
+          "n": null,
+          "fields": [],
+          "cancellationReasons": [
+            {
+              "Code": "ValidationError",
+              "Message": "The provided key element does not match the schema"
+            }
+          ]
+        },
+        {
+          "id": "twi_del_key_wrongtype",
+          "family": "transact-key",
+          "note": "TransactWrite Delete Key pk wrongtype",
+          "threw": true,
+          "name": "TransactionCanceledException",
+          "message": "Transaction cancelled, please refer cancellation reasons for specific reasons [ValidationError]",
+          "n": null,
+          "fields": [],
+          "cancellationReasons": [
+            {
+              "Code": "ValidationError",
+              "Message": "The provided key element does not match the schema"
+            }
+          ]
+        },
+        {
+          "id": "twi_cc_key_wrongtype",
+          "family": "transact-key",
+          "note": "TransactWrite ConditionCheck Key pk wrongtype",
+          "threw": true,
+          "name": "TransactionCanceledException",
+          "message": "Transaction cancelled, please refer cancellation reasons for specific reasons [ValidationError]",
+          "n": null,
+          "fields": [],
+          "cancellationReasons": [
+            {
+              "Code": "ValidationError",
+              "Message": "The provided key element does not match the schema"
+            }
+          ]
+        },
+        {
+          "id": "twi_upd_key_nonscalar",
+          "family": "transact-key",
+          "note": "TransactWrite Update Key pk nonscalar",
+          "threw": true,
+          "name": "TransactionCanceledException",
+          "message": "Transaction cancelled, please refer cancellation reasons for specific reasons [ValidationError]",
+          "n": null,
+          "fields": [],
+          "cancellationReasons": [
+            {
+              "Code": "ValidationError",
+              "Message": "The provided key element does not match the schema"
+            }
+          ]
+        },
+        {
+          "id": "twi_del_key_nonscalar",
+          "family": "transact-key",
+          "note": "TransactWrite Delete Key pk nonscalar",
+          "threw": true,
+          "name": "TransactionCanceledException",
+          "message": "Transaction cancelled, please refer cancellation reasons for specific reasons [ValidationError]",
+          "n": null,
+          "fields": [],
+          "cancellationReasons": [
+            {
+              "Code": "ValidationError",
+              "Message": "The provided key element does not match the schema"
+            }
+          ]
+        },
+        {
+          "id": "twi_cc_key_nonscalar",
+          "family": "transact-key",
+          "note": "TransactWrite ConditionCheck Key pk nonscalar",
+          "threw": true,
+          "name": "TransactionCanceledException",
+          "message": "Transaction cancelled, please refer cancellation reasons for specific reasons [ValidationError]",
+          "n": null,
+          "fields": [],
+          "cancellationReasons": [
+            {
+              "Code": "ValidationError",
+              "Message": "The provided key element does not match the schema"
+            }
+          ]
         }
       ],
       "nullRoundTrip": {

--- a/scripts/capture-validation-messages.mjs
+++ b/scripts/capture-validation-messages.mjs
@@ -29,6 +29,7 @@ import {
   UpdateItemCommand,
   DeleteItemCommand,
   BatchWriteItemCommand,
+  TransactWriteItemsCommand,
 } from '@aws-sdk/client-dynamodb'
 
 const DEFAULT_REGIONS = ['eu-west-2', 'eu-central-1', 'us-east-1', 'ap-southeast-2']
@@ -57,7 +58,12 @@ async function probe(id, family, note, fn) {
     return { id, family, note, threw: false, name: null, message: null, n: null, fields: [] }
   } catch (e) {
     const message = e?.message ?? null
-    return { id, family, note, threw: true, name: e?.name ?? null, message, ...parse(message) }
+    // The reason Message is what the Tier 3 transact tests pin; the top-level
+    // message is only the static cancellation wrapper.
+    const cancellationReasons = Array.isArray(e?.CancellationReasons)
+      ? e.CancellationReasons.map((r) => ({ Code: r?.Code ?? null, Message: r?.Message ?? null }))
+      : null
+    return { id, family, note, threw: true, name: e?.name ?? null, message, ...parse(message), cancellationReasons }
   }
 }
 
@@ -111,6 +117,33 @@ async function captureRegion(region) {
     await p('o_del_two_bad_enums', 'ordering', 'DeleteItem 2 invalid enums', () => ddb.send(new DeleteItemCommand({ TableName: '_conformance_valid_table_name', Key: { pk: { S: 'test' } }, ReturnValues: 'INVALID', ReturnConsumedCapacity: 'INVALID' })))
     await p('o_upd_empty_table', 'ordering', "UpdateItem TableName='' Key={}", () => ddb.send(new UpdateItemCommand({ TableName: '', Key: {} })))
     await p('o_upd_two_bad_enums', 'ordering', 'UpdateItem 2 invalid enums', () => ddb.send(new UpdateItemCommand({ TableName: '_conformance_valid_table_name', Key: { pk: { S: 'test' } }, ReturnValues: 'INVALID', ReturnConsumedCapacity: 'INVALID' })))
+
+    // Invalid key-VALUE coverage for the batch / lookup / transact paths (dynoxide #97, #98).
+    // batch-key (#97): real AWS collapses wrong-type and non-scalar table keys to the
+    // generic schema-mismatch message, not PutItem's 'Type mismatch for key' form.
+    await p('bw_table_wrongtype', 'batch-key', 'BatchWrite PutRequest pk wrong type (N on S)', () => ddb.send(new BatchWriteItemCommand({ RequestItems: { [H]: [{ PutRequest: { Item: { pk: { N: '5' } } } }] } })))
+    await p('bw_table_nonscalar', 'batch-key', 'BatchWrite PutRequest pk non-scalar (L)', () => ddb.send(new BatchWriteItemCommand({ RequestItems: { [H]: [{ PutRequest: { Item: { pk: { L: [{ S: 'x' }] } } } }] } })))
+
+    const badKeys = [
+      ['empty', { S: '' }],
+      ['wrongtype', { N: '5' }],
+      ['nonscalar', { L: [{ S: 'x' }] }],
+    ]
+
+    // lookup-key baseline: the non-transactional behaviour the #98 transact hypothesis
+    // mirrors, captured so the mirror is falsifiable. A read may return no item, not throw.
+    for (const [k, val] of badKeys) {
+      await p(`del_key_${k}`, 'lookup-key', `DeleteItem Key pk ${k}`, () => ddb.send(new DeleteItemCommand({ TableName: H, Key: { pk: val } })))
+      await p(`get_key_${k}`, 'lookup-key', `GetItem Key pk ${k}`, () => ddb.send(new GetItemCommand({ TableName: H, Key: { pk: val } })))
+    }
+
+    // transact-key (#98): the validate_key_only path. ConditionCheck carries an extra
+    // condition stage, so its rows are verified independently of Update / Delete.
+    for (const [k, val] of badKeys) {
+      await p(`twi_upd_key_${k}`, 'transact-key', `TransactWrite Update Key pk ${k}`, () => ddb.send(new TransactWriteItemsCommand({ TransactItems: [{ Update: { TableName: H, Key: { pk: val }, UpdateExpression: 'SET attr1 = :v', ExpressionAttributeValues: { ':v': { S: 'x' } } } }] })))
+      await p(`twi_del_key_${k}`, 'transact-key', `TransactWrite Delete Key pk ${k}`, () => ddb.send(new TransactWriteItemsCommand({ TransactItems: [{ Delete: { TableName: H, Key: { pk: val } } }] })))
+      await p(`twi_cc_key_${k}`, 'transact-key', `TransactWrite ConditionCheck Key pk ${k}`, () => ddb.send(new TransactWriteItemsCommand({ TransactItems: [{ ConditionCheck: { TableName: H, Key: { pk: val }, ConditionExpression: 'attribute_not_exists(pk)' } }] })))
+    }
 
     // { NULL: false } round-trip
     let nullRoundTrip

--- a/scripts/capture-validation-messages.mjs
+++ b/scripts/capture-validation-messages.mjs
@@ -118,8 +118,8 @@ async function captureRegion(region) {
     await p('o_upd_empty_table', 'ordering', "UpdateItem TableName='' Key={}", () => ddb.send(new UpdateItemCommand({ TableName: '', Key: {} })))
     await p('o_upd_two_bad_enums', 'ordering', 'UpdateItem 2 invalid enums', () => ddb.send(new UpdateItemCommand({ TableName: '_conformance_valid_table_name', Key: { pk: { S: 'test' } }, ReturnValues: 'INVALID', ReturnConsumedCapacity: 'INVALID' })))
 
-    // Invalid key-VALUE coverage for the batch / lookup / transact paths (dynoxide #97, #98).
-    // batch-key (#97): real AWS collapses wrong-type and non-scalar table keys to the
+    // Invalid key-VALUE coverage for the batch / lookup / transact paths.
+    // batch-key: real AWS collapses wrong-type and non-scalar table keys to the
     // generic schema-mismatch message, not PutItem's 'Type mismatch for key' form.
     await p('bw_table_wrongtype', 'batch-key', 'BatchWrite PutRequest pk wrong type (N on S)', () => ddb.send(new BatchWriteItemCommand({ RequestItems: { [H]: [{ PutRequest: { Item: { pk: { N: '5' } } } }] } })))
     await p('bw_table_nonscalar', 'batch-key', 'BatchWrite PutRequest pk non-scalar (L)', () => ddb.send(new BatchWriteItemCommand({ RequestItems: { [H]: [{ PutRequest: { Item: { pk: { L: [{ S: 'x' }] } } } }] } })))
@@ -130,14 +130,14 @@ async function captureRegion(region) {
       ['nonscalar', { L: [{ S: 'x' }] }],
     ]
 
-    // lookup-key baseline: the non-transactional behaviour the #98 transact hypothesis
-    // mirrors, captured so the mirror is falsifiable. A read may return no item, not throw.
+    // lookup-key baseline: the non-transactional behaviour the transact lookup-key
+    // cases mirror, captured alongside them. A read may return no item, not throw.
     for (const [k, val] of badKeys) {
       await p(`del_key_${k}`, 'lookup-key', `DeleteItem Key pk ${k}`, () => ddb.send(new DeleteItemCommand({ TableName: H, Key: { pk: val } })))
       await p(`get_key_${k}`, 'lookup-key', `GetItem Key pk ${k}`, () => ddb.send(new GetItemCommand({ TableName: H, Key: { pk: val } })))
     }
 
-    // transact-key (#98): the validate_key_only path. ConditionCheck carries an extra
+    // transact-key: the key-only validation path. ConditionCheck carries an extra
     // condition stage, so its rows are verified independently of Update / Delete.
     for (const [k, val] of badKeys) {
       await p(`twi_upd_key_${k}`, 'transact-key', `TransactWrite Update Key pk ${k}`, () => ddb.send(new TransactWriteItemsCommand({ TransactItems: [{ Update: { TableName: H, Key: { pk: val }, UpdateExpression: 'SET attr1 = :v', ExpressionAttributeValues: { ':v': { S: 'x' } } } }] })))

--- a/tests/tier2/transactions/transactWrite.test.ts
+++ b/tests/tier2/transactions/transactWrite.test.ts
@@ -845,6 +845,45 @@ describe('TransactWriteItems - validation', { tags: ['transactions', 'data-plane
     )
   })
 
+  // A malformed VALUE in the lookup Key of an Update / Delete / ConditionCheck
+  // (the key-only validation path, distinct from a Put item key). Four-region
+  // capture (2026-06-23): empty string -> top-level ValidationException; wrong-type
+  // / non-scalar -> cancelled with a ValidationError reason. The two helpers are
+  // opposite guards — expectDynamoError fails an engine that wraps the empty-string
+  // case as a cancellation, expectCancelledForValidation fails one that surfaces the
+  // type cases as a top-level error. ConditionCheck behaves like the others. Exact
+  // strings: tests/tier3/error-messages/transactWriteItems.test.ts.
+  const updKey = (key: unknown) => ({ Update: { TableName: hashTableDef.name, Key: { pk: key }, UpdateExpression: 'SET attr1 = :v', ExpressionAttributeValues: { ':v': { S: 'x' } } } })
+  const delKey = (key: unknown) => ({ Delete: { TableName: hashTableDef.name, Key: { pk: key } } })
+  const ccKey = (key: unknown) => ({ ConditionCheck: { TableName: hashTableDef.name, Key: { pk: key }, ConditionExpression: 'attribute_not_exists(pk)' } })
+
+  const expectKeyTopLevelValidation = (transactItem: unknown) =>
+    expectDynamoError(
+      () => ddb.send(new TransactWriteItemsCommand({ TransactItems: [transactItem] as never })),
+      'ValidationException',
+      /empty string value/i,
+    )
+
+  it('Update with an empty-string Key is a top-level ValidationException', () =>
+    expectKeyTopLevelValidation(updKey({ S: '' })))
+  it('Delete with an empty-string Key is a top-level ValidationException', () =>
+    expectKeyTopLevelValidation(delKey({ S: '' })))
+  it('ConditionCheck with an empty-string Key is a top-level ValidationException', () =>
+    expectKeyTopLevelValidation(ccKey({ S: '' })))
+
+  it('Update with a wrong-typed Key cancels with a ValidationError reason', () =>
+    expectCancelledForValidation([updKey({ N: '5' })]))
+  it('Update with a non-scalar Key cancels with a ValidationError reason', () =>
+    expectCancelledForValidation([updKey({ L: [{ S: 'x' }] })]))
+  it('Delete with a wrong-typed Key cancels with a ValidationError reason', () =>
+    expectCancelledForValidation([delKey({ N: '5' })]))
+  it('Delete with a non-scalar Key cancels with a ValidationError reason', () =>
+    expectCancelledForValidation([delKey({ L: [{ S: 'x' }] })]))
+  it('ConditionCheck with a wrong-typed Key cancels with a ValidationError reason', () =>
+    expectCancelledForValidation([ccKey({ N: '5' })]))
+  it('ConditionCheck with a non-scalar Key cancels with a ValidationError reason', () =>
+    expectCancelledForValidation([ccKey({ L: [{ S: 'x' }] })]))
+
   it('Update with attribute_exists rejects non-existent item', async () => {
     // TransactWriteItems Update with attribute_exists(pk) on a key that does
     // not exist must cancel the transaction — not silently create the item.

--- a/tests/tier3/error-messages/batchWriteItem.test.ts
+++ b/tests/tier3/error-messages/batchWriteItem.test.ts
@@ -119,9 +119,11 @@ describe('BatchWriteItem — exact error messages', { tags: ['batch', 'data-plan
 
   // Invalid key value inside a PutRequest item. BatchWriteItem validates up front,
   // so every variant is a top-level ValidationException (no cancellation path).
-  // Strings captured from real AWS eu-west-2. The wrong-type and non-scalar table
-  // keys collapse to the generic schema-mismatch message; the index-key messages
-  // name gsi1, the alphabetically-first index lsi1sk keys on compositeTableDef.
+  // Strings captured from real AWS, invariant across four regions (eu-west-2,
+  // us-east-1, ap-southeast-2, eu-central-1; 2026-06-23) — so the table-key
+  // schema-mismatch message is the contract, not a region-local wording.
+  // Index-key messages name gsi1, the alphabetically-first index lsi1sk keys on
+  // compositeTableDef.
   const expectExactValidation = async (
     command: BatchWriteItemCommand,
     message: string,

--- a/tests/tier3/error-messages/transactWriteItems.test.ts
+++ b/tests/tier3/error-messages/transactWriteItems.test.ts
@@ -409,4 +409,36 @@ describe('TransactWriteItems — exact error messages', { tags: ['transactions',
       'One or more parameter values are not valid. The update expression attempted to update a secondary index key to a value that is not supported. The AttributeValue for a key attribute cannot contain an empty string value.',
     )
   })
+
+  // Exact messages for a malformed lookup Key on transact Update / Delete /
+  // ConditionCheck (the key-only validation path). Four-region capture (2026-06-23),
+  // all invariant, so rung 1 .toBe(). Empty string carries the same message as a Put
+  // item key; wrong-type and non-scalar cancel with the schema-mismatch reason, NOT
+  // the Put 'Type mismatch for key' form.
+  const emptyKeyMsg = 'One or more parameter values are not valid. The AttributeValue for a key attribute cannot contain an empty string value. Key: pk'
+  const schemaMismatchMsg = 'The provided key element does not match the schema'
+  const cmd = (item: unknown) => new TransactWriteItemsCommand({ TransactItems: [item] as never })
+  const updKey = (key: unknown) => ({ Update: { TableName: hashTableDef.name, Key: { pk: key }, UpdateExpression: 'SET attr1 = :v', ExpressionAttributeValues: { ':v': { S: 'x' } } } })
+  const delKey = (key: unknown) => ({ Delete: { TableName: hashTableDef.name, Key: { pk: key } } })
+  const ccKey = (key: unknown) => ({ ConditionCheck: { TableName: hashTableDef.name, Key: { pk: key }, ConditionExpression: 'attribute_not_exists(pk)' } })
+
+  it('Update empty-string Key: top-level empty-value message', () =>
+    expectTopLevelValidation(cmd(updKey({ S: '' })), emptyKeyMsg))
+  it('Delete empty-string Key: top-level empty-value message', () =>
+    expectTopLevelValidation(cmd(delKey({ S: '' })), emptyKeyMsg))
+  it('ConditionCheck empty-string Key: top-level empty-value message', () =>
+    expectTopLevelValidation(cmd(ccKey({ S: '' })), emptyKeyMsg))
+
+  it('Update wrong-typed Key: cancelled with schema-mismatch reason', () =>
+    expectCancelledReason(cmd(updKey({ N: '5' })), schemaMismatchMsg))
+  it('Update non-scalar Key: cancelled with schema-mismatch reason', () =>
+    expectCancelledReason(cmd(updKey({ L: [{ S: 'x' }] })), schemaMismatchMsg))
+  it('Delete wrong-typed Key: cancelled with schema-mismatch reason', () =>
+    expectCancelledReason(cmd(delKey({ N: '5' })), schemaMismatchMsg))
+  it('Delete non-scalar Key: cancelled with schema-mismatch reason', () =>
+    expectCancelledReason(cmd(delKey({ L: [{ S: 'x' }] })), schemaMismatchMsg))
+  it('ConditionCheck wrong-typed Key: cancelled with schema-mismatch reason', () =>
+    expectCancelledReason(cmd(ccKey({ N: '5' })), schemaMismatchMsg))
+  it('ConditionCheck non-scalar Key: cancelled with schema-mismatch reason', () =>
+    expectCancelledReason(cmd(ccKey({ L: [{ S: 'x' }] })), schemaMismatchMsg))
 })


### PR DESCRIPTION
Adds coverage for malformed lookup-`Key` values on `TransactWriteItems` `Update`/`Delete`/`ConditionCheck`, and confirms the `BatchWriteItem` table-key message across regions.

Captured against real AWS in four regions (eu-west-2, us-east-1, ap-southeast-2, eu-central-1); every string was identical across all four, so they pin exactly.

- Empty-string lookup `Key` → top-level `ValidationException` (`...cannot contain an empty string value. Key: pk`).
- Wrong-type / non-scalar lookup `Key` → `TransactionCanceledException`, reason `ValidationError` / `The provided key element does not match the schema` (the key-only form, distinct from the `PutItem` `Type mismatch for key` message).
- Batch wrong-type / non-scalar table key → `The provided key element does not match the schema`, now confirmed region-invariant.

Changes:
- `transactWrite` (tier 2): 9 shape cases; `transactWriteItems` (tier 3): 9 exact-message pins.
- Capture harness gains batch/lookup/transact key probes and records `CancellationReasons`; `cross-region-latest.json` refreshed.

Verified against real AWS eu-west-2: the three affected files pass (80/80); `tsc` clean.