### PR TITLE
chore: repoint references to the paritysuite org

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,5 +1,5 @@
 blank_issues_enabled: false
 contact_links:
   - name: Report a security vulnerability
-    url: https://github.com/nubo-db/dynamodb-conformance/security/advisories/new
+    url: https://github.com/paritysuite/dynamodb-conformance/security/advisories/new
     about: Please report vulnerabilities (including a credential accidentally committed) privately through GitHub's security advisories, not as a public issue.

--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,6 @@ dist/
 ground-truth/
 .claude/settings.local.json
 .claude/*.lock
+
+# Knowledge-os link: local only, not for the public repo
+.kos

--- a/.kos
+++ b/.kos
@@ -1,2 +1,0 @@
-product: dynoxide
-project: dynamodb-conformance

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -107,6 +107,6 @@ welcome for anything non-obvious.
 ## Where to discuss
 
 - GitHub Issues:
-  <https://github.com/nubo-db/dynamodb-conformance/issues>
+  <https://github.com/paritysuite/dynamodb-conformance/issues>
 
 Discussions are not currently enabled.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -133,5 +133,5 @@ The conformance suite is licensed under the Apache License 2.0. By submitting a 
 ## Where to ask
 
 GitHub Issues:
-<https://github.com/nubo-db/dynamodb-conformance/issues>. Discussions
+<https://github.com/paritysuite/dynamodb-conformance/issues>. Discussions
 are not currently enabled.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # DynamoDB Conformance Suite
 
-[![CI](https://github.com/nubo-db/dynamodb-conformance/actions/workflows/ci.yml/badge.svg)](https://github.com/nubo-db/dynamodb-conformance/actions/workflows/ci.yml)
+[![CI](https://github.com/paritysuite/dynamodb-conformance/actions/workflows/ci.yml/badge.svg)](https://github.com/paritysuite/dynamodb-conformance/actions/workflows/ci.yml)
 [![Licence: Apache 2.0](https://img.shields.io/badge/licence-Apache%202.0-blue.svg)](LICENSE)
 [![Live results](https://img.shields.io/badge/live%20results-paritysuite.org-brightgreen)](https://paritysuite.org)
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -10,7 +10,7 @@ current `main`.
 
 Report anything security-sensitive privately, not in a public issue. Use
 GitHub's private vulnerability reporting:
-<https://github.com/nubo-db/dynamodb-conformance/security/advisories/new>.
+<https://github.com/paritysuite/dynamodb-conformance/security/advisories/new>.
 
 I aim to acknowledge a report within a few days and will keep you posted on a
 fix or mitigation from there.

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -4,7 +4,7 @@ Need a hand with the conformance suite? Here's where things go.
 
 - **A bug, a wrong test result, or a question about how the suite behaves** -
   open a GitHub issue:
-  <https://github.com/nubo-db/dynamodb-conformance/issues>. If a target's result
+  <https://github.com/paritysuite/dynamodb-conformance/issues>. If a target's result
   looks wrong, the "Report an incorrect or divergent result" template walks you
   through what to include. The key thing is evidence of what real AWS does.
 - **A new target to add** - use the "Suggest a target" issue template.

--- a/package.json
+++ b/package.json
@@ -12,10 +12,10 @@
   "homepage": "https://paritysuite.org",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/nubo-db/dynamodb-conformance.git"
+    "url": "git+https://github.com/paritysuite/dynamodb-conformance.git"
   },
   "bugs": {
-    "url": "https://github.com/nubo-db/dynamodb-conformance/issues"
+    "url": "https://github.com/paritysuite/dynamodb-conformance/issues"
   },
   "license": "Apache-2.0",
   "author": "Martin Hicks <hello@martinhicks.dev>",


### PR DESCRIPTION
The repository now lives at `paritysuite/dynamodb-conformance`. This updates the in-repo references that still pointed at the old location:

- CI badge, `package.json` repository/bugs URLs, and the security / support / contributing / issue-template links now point at `paritysuite/dynamodb-conformance`.
- Dynoxide target links are left unchanged — that's the target's own repo, not a self-reference.
- Removes the `.kos` local tooling marker from the repo and adds it to `.gitignore`.

No behaviour change; references only.
