### PR TITLE
docs: add a convention for citing suite findings

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -97,6 +97,29 @@ If a test is flaky against real DynamoDB (for example GSI
 propagation), use the existing wait/retry helpers rather than adding
 sleeps.
 
+## Citing a suite finding elsewhere
+
+When a finding from this suite is referenced in another project's
+issue tracker, say an engine's own bug report about a divergence
+the suite caught, cite it as an independent source by its public
+identity:
+
+> the Parity Suite ([paritysuite.org](https://paritysuite.org)), an
+> independent DynamoDB conformance suite that scores multiple
+> engines against live AWS DynamoDB
+
+Link to the specific public test, pinned to a commit SHA or tag
+(`.../blob/<sha>/...`, never `.../blob/main/...`, which rots when
+the lines move), not a bare in-repo path. A pinned test link is the
+durable evidence for a specific finding; the target's row on
+paritysuite.org is a live score that moves with every run, so cite
+it only for a general "how this engine scores" claim, never as
+evidence for a fixed bug. Don't frame the suite as the engine's own
+test harness: it is a separate party that scores that engine
+alongside others, and the reference only carries weight if it reads
+that way. The fuller convention, with a copyable block, is "Citing
+a finding" in the README.
+
 ## Commit style
 
 Short subject, lower-case, imperative where possible. A Conventional

--- a/README.md
+++ b/README.md
@@ -407,6 +407,26 @@ Genuinely not covered, with no tests yet:
 - Global Tables
 - DynamoDB Accelerator (DAX)
 
+## Citing a finding
+
+When the suite surfaces a divergence in a target and you want to reference it from that target's own issue tracker, cite the suite as the independent source it is. The reference carries weight precisely because the suite is not the engine's own test harness: it scores every target against the same live-AWS baseline, so "the conformance suite flags this" says more than a self-written test can.
+
+Fill in the bracketed parts. The block is the same whichever engine the finding concerns:
+
+> Found by the Parity Suite ([paritysuite.org](https://paritysuite.org)), an independent DynamoDB conformance suite that scores multiple engines against live AWS DynamoDB.
+>
+> **Operation:** [e.g. CreateTable]
+> **Expected (real DynamoDB, [region, e.g. eu-west-2]):** `[the exact response or error message real AWS returns]`
+> **Observed in [target] [version]:** [what the target did instead]
+> **Suite test:** [public link to the specific test, pinned to a commit or tag]
+
+Two details keep the citation honest:
+
+- **Link the specific test, and pin it.** Use a commit SHA or tag (`.../blob/<sha>/...`), never `.../blob/main/...`: a `main` link rots the moment the file is reformatted or the lines shift, while a pinned link points at the exact assertion for good. Link the test itself, not a bare in-repo path, so it resolves for anyone reading the issue.
+- **Pinned test for a specific finding; site row only for a general claim.** The pinned test is durable evidence that this exact case diverged. The row on [paritysuite.org](https://paritysuite.org) is a live score that moves with every run, so it answers "how does this engine do overall", not "what broke here". Don't cite a moving score as evidence for a fixed bug.
+
+Real AWS DynamoDB is the ground truth here as everywhere: the "expected" line is what AWS does, captured against a named region, not what any emulator does.
+
 ## Community
 
 - [Contributing](CONTRIBUTING.md) and [AGENTS.md](AGENTS.md) - how to add tests and targets.


### PR DESCRIPTION
## What this changes

Adds a "Citing a finding" section to the README and a short pointer in AGENTS.md, setting out how a finding from this suite should be referenced in another project's issue tracker: as an independent source, with a commit-pinned link to the specific test, never a moving score or a bare in-repo path. It is engine-agnostic, so it reads as a convention any target's maintainers can adopt.

## Checklist

- ~~New or modified tests run against real AWS DynamoDB and pass~~ (not applicable: docs-only, no test changes).
- ~~New or modified tests run against at least one emulator target and behave as expected~~ (not applicable: docs-only).
- [x] Linked issue or a short note explaining the motivation (see above).
- [x] I agree my contribution is licensed under the project's terms (Apache License, Version 2.0).
