### PR TITLE
feat: pin LSI INCLUDE and Query SPECIFIC_ATTRIBUTES rejections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,22 @@
 A dated log of how the conformance test suite has grown: tests added, tiers
 broadened, and targets brought into the run. Newest first.
 
+## 2026-06-30
+
+Grew to 820 tests, up 3, completing two sibling-parity gaps where one half of a
+rule was pinned and the other was not. Both were characterised against real
+DynamoDB in eu-west-2.
+
+The first covers the LSI side of the INCLUDE-projection-without-NonKeyAttributes
+rejection; the GSI side already had it. An LSI declared with ProjectionType
+INCLUDE and no NonKeyAttributes is rejected as a ValidationException in tier1 and
+pinned to the exact message in tier3, the same wording the GSI case returns.
+
+The second pins the Query message for Select SPECIFIC_ATTRIBUTES with no
+ProjectionExpression, which Scan already had. Query and Scan enforce the same rule
+but word it differently: Query wraps the phrase in the "1 validation error
+detected:" envelope, Scan returns it bare.
+
 ## 2026-06-26
 
 Grew to 817 tests, up 55, covering DynamoDB's 32-level document nesting limit,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dynamodb-conformance",
-  "version": "1.6.0",
+  "version": "1.8.0",
   "description": "Independent conformance test suite for DynamoDB-compatible endpoints",
   "keywords": [
     "dynamodb",

--- a/tests/tier1/createTable/lsi.test.ts
+++ b/tests/tier1/createTable/lsi.test.ts
@@ -112,4 +112,35 @@ describe('CreateTable — LSI', { tags: ['create-table', 'control-plane', 'lsi']
       'ValidationException',
     )
   })
+
+  it('rejects an LSI INCLUDE projection without NonKeyAttributes', async () => {
+    await expectDynamoError(
+      () => ddb.send(
+        new CreateTableCommand({
+          TableName: uniqueTableName('ct_lsi_include_nonk'),
+          AttributeDefinitions: [
+            { AttributeName: 'pk', AttributeType: 'S' },
+            { AttributeName: 'sk', AttributeType: 'S' },
+            { AttributeName: 'lsiSk', AttributeType: 'N' },
+          ],
+          KeySchema: [
+            { AttributeName: 'pk', KeyType: 'HASH' },
+            { AttributeName: 'sk', KeyType: 'RANGE' },
+          ],
+          LocalSecondaryIndexes: [
+            {
+              IndexName: 'lsi1',
+              KeySchema: [
+                { AttributeName: 'pk', KeyType: 'HASH' },
+                { AttributeName: 'lsiSk', KeyType: 'RANGE' },
+              ],
+              Projection: { ProjectionType: 'INCLUDE' },
+            },
+          ],
+          BillingMode: 'PAY_PER_REQUEST',
+        }),
+      ),
+      'ValidationException',
+    )
+  })
 })

--- a/tests/tier3/error-messages/createTable.test.ts
+++ b/tests/tier3/error-messages/createTable.test.ts
@@ -287,6 +287,45 @@ describe('CreateTable — exact error messages', { tags: ['create-table', 'contr
     }
   })
 
+  // LSI uses the same Projection model as GSI, so the missing-attributes rejection
+  // is identical. Sibling of the GSI case above.
+  it('LSI INCLUDE projection without NonKeyAttributes: full missing-attributes message', async () => {
+    try {
+      await ddb.send(
+        new CreateTableCommand({
+          TableName: uniqueTableName('em_ct_lsi_include_nonk'),
+          AttributeDefinitions: [
+            { AttributeName: 'pk', AttributeType: 'S' },
+            { AttributeName: 'sk', AttributeType: 'S' },
+            { AttributeName: 'lsiSk', AttributeType: 'N' },
+          ],
+          KeySchema: [
+            { AttributeName: 'pk', KeyType: 'HASH' },
+            { AttributeName: 'sk', KeyType: 'RANGE' },
+          ],
+          BillingMode: 'PAY_PER_REQUEST',
+          LocalSecondaryIndexes: [
+            {
+              IndexName: 'lsi_inc',
+              KeySchema: [
+                { AttributeName: 'pk', KeyType: 'HASH' },
+                { AttributeName: 'lsiSk', KeyType: 'RANGE' },
+              ],
+              Projection: { ProjectionType: 'INCLUDE' },
+            },
+          ],
+        }),
+      )
+      expect.unreachable('should have thrown')
+    } catch (err) {
+      expect(err).toBeInstanceOf(DynamoDBServiceException)
+      expect((err as DynamoDBServiceException).name).toBe('ValidationException')
+      expect((err as DynamoDBServiceException).message).toBe(
+        'One or more parameter values were invalid: ProjectionType is INCLUDE, but NonKeyAttributes is not specified',
+      )
+    }
+  })
+
   it('StreamSpecification StreamEnabled:false with a StreamViewType: full conflict message', async () => {
     try {
       await ddb.send(

--- a/tests/tier3/error-messages/query.test.ts
+++ b/tests/tier3/error-messages/query.test.ts
@@ -209,4 +209,28 @@ describe('Query — exact error messages', { tags: ['query', 'data-plane', 'nega
       )
     }
   })
+
+  // SPECIFIC_ATTRIBUTES needs a ProjectionExpression (or legacy AttributesToGet);
+  // with neither, real DynamoDB rejects before reading. Query and Scan apply the
+  // same rule but word it differently: Query wraps the phrase in the
+  // "1 validation error detected:" envelope, Scan returns it bare (see scan.test.ts).
+  it('Select SPECIFIC_ATTRIBUTES without ProjectionExpression: full required-projection message', async () => {
+    try {
+      await ddb.send(
+        new QueryCommand({
+          TableName: compositeTableDef.name,
+          KeyConditionExpression: 'pk = :v',
+          ExpressionAttributeValues: { ':v': { S: 'val' } },
+          Select: 'SPECIFIC_ATTRIBUTES',
+        }),
+      )
+      expect.unreachable('should have thrown')
+    } catch (err) {
+      expect(err).toBeInstanceOf(DynamoDBServiceException)
+      expect((err as DynamoDBServiceException).name).toBe('ValidationException')
+      expect((err as DynamoDBServiceException).message).toBe(
+        '1 validation error detected: Must specify the AttributesToGet or ProjectionExpression when choosing to get SPECIFIC_ATTRIBUTES',
+      )
+    }
+  })
 })


### PR DESCRIPTION
## What this changes

Closes two sibling-parity gaps where the suite pinned one half of a validation rule and left the other unmeasured.

The GSI `INCLUDE`-without-`NonKeyAttributes` rejection was already covered. This adds the LSI counterpart: the `ValidationException` in tier1 and the exact message in tier3. DynamoDB uses the same `Projection` model for both index types, and real AWS returns the same wording for both.

The `Scan` `SPECIFIC_ATTRIBUTES`-without-projection message was already pinned; this adds the `Query` one. Characterising it against real AWS turned up a wrinkle the issue didn't expect: `Query` and `Scan` enforce the same rule but word it differently. `Scan` returns the bare phrase, `Query` wraps it in the `1 validation error detected:` envelope. The test pins what `Query` actually returns, which is the same `Query`/`Scan` asymmetry the suite already documents for a malformed `ExclusiveStartKey`.

Three new tests, suite now at 820. Bumps to 1.8.0 with a changelog entry.

Closes #64, closes #65.

## Checklist

- [x] New or modified tests run against real AWS DynamoDB and pass - all three green against eu-west-2.
- [x] New or modified tests run against at least one emulator target and behave as expected - ran against a local target; the new cases sit red there by design, because it diverges on these exact rules, exactly as the committed GSI and `Scan` siblings do.
- [x] Linked issue or a short note explaining the motivation - closes #64 and #65.
- [x] I agree my contribution is licensed under the project's terms (Apache License, Version 2.0)
