### PR TITLE
feat: pin transaction-write capacity for conditional, check, replay and cancel cases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,9 @@ broadened, and targets brought into the run. Newest first.
 
 ## 2026-06-30
 
-Grew to 820 tests, up 3, completing two sibling-parity gaps where one half of a
-rule was pinned and the other was not. Both were characterised against real
+Grew to 824 tests, up 7, in two parts: two sibling-parity gaps where one half of
+a rule was pinned and the other was not, and the capacity accounting of
+conditional and idempotent transactional writes. All characterised against real
 DynamoDB in eu-west-2.
 
 The first covers the LSI side of the INCLUDE-projection-without-NonKeyAttributes
@@ -18,6 +19,14 @@ The second pins the Query message for Select SPECIFIC_ATTRIBUTES with no
 ProjectionExpression, which Scan already had. Query and Scan enforce the same rule
 but word it differently: Query wraps the phrase in the "1 validation error
 detected:" envelope, Scan returns it bare.
+
+The transaction cases settle what a conditional TransactWriteItems actually costs.
+A passing condition adds no read capacity: a conditional write bills the same 2 WCU
+per sub-1KB item as an unconditional one, and a standalone ConditionCheck costs 2
+WCU, billed as write not read. Idempotent replay splits the accounting - the first
+call reports 2 write capacity units, a same-token replay within the window reports
+2 read capacity units for re-reading the stored result. A failing condition cancels
+the transaction, and the response carries no ConsumedCapacity at all. Answers #27.
 
 ## 2026-06-26
 

--- a/results/tag-manifest.json
+++ b/results/tag-manifest.json
@@ -666,6 +666,10 @@
       "TransactWriteItems — ConsumedCapacity": [
         "transactions",
         "data-plane"
+      ],
+      "TransactWriteItems — ConsumedCapacity: conditional, check, replay, cancel": [
+        "transactions",
+        "data-plane"
       ]
     },
     "tests/tier2/ttl/basic.test.ts": {

--- a/tests/tier2/transactions/transactWrite.test.ts
+++ b/tests/tier2/transactions/transactWrite.test.ts
@@ -1343,3 +1343,137 @@ describe('TransactWriteItems — ConsumedCapacity', { tags: ['transactions', 'da
     expect(total).toBe(4)
   })
 })
+
+// Capacity for the cases the unconditional test above does not cover: a conditional
+// write, a standalone ConditionCheck, an idempotent replay, and a cancelled
+// transaction. All values characterised against real DynamoDB (eu-west-2). See #27.
+describe('TransactWriteItems — ConsumedCapacity: conditional, check, replay, cancel', { tags: ['transactions', 'data-plane'] }, () => {
+  const hashKeys = [
+    { pk: { S: 'tw-cap-uncond' } },
+    { pk: { S: 'tw-cap-cond' } },
+    { pk: { S: 'tw-cap-cc' } },
+    { pk: { S: 'tw-cap-replay' } },
+  ]
+  // The ConditionCheck below needs an item that already exists, on a different table
+  // from the write so the INDEXES breakdown can isolate the check's cost.
+  const ccPresent = { pk: { S: 'tw-cap-cc-present' }, sk: { S: 'x' } }
+
+  const totalCap = (cc?: { CapacityUnits?: number }[]) =>
+    (cc ?? []).reduce((sum, c) => sum + (c.CapacityUnits ?? 0), 0)
+
+  beforeAll(async () => {
+    await ddb.send(
+      new PutItemCommand({ TableName: compositeTableDef.name, Item: ccPresent }),
+    )
+  })
+
+  afterAll(async () => {
+    await cleanupItems(hashTableDef.name, hashKeys)
+    await cleanupItems(compositeTableDef.name, [{ pk: ccPresent.pk, sk: ccPresent.sk }])
+  })
+
+  // A passing condition adds no read capacity: a conditional write costs the same
+  // 2 WCU/item as an unconditional one.
+  it('a passing conditional write costs the same 2 WCU/item as an unconditional one', async () => {
+    const uncond = await ddb.send(
+      new TransactWriteItemsCommand({
+        ReturnConsumedCapacity: 'TOTAL',
+        TransactItems: [
+          { Put: { TableName: hashTableDef.name, Item: { pk: { S: 'tw-cap-uncond' }, v: { N: '1' } } } },
+        ],
+      }),
+    )
+    const cond = await ddb.send(
+      new TransactWriteItemsCommand({
+        ReturnConsumedCapacity: 'TOTAL',
+        TransactItems: [
+          {
+            Put: {
+              TableName: hashTableDef.name,
+              Item: { pk: { S: 'tw-cap-cond' }, v: { N: '1' } },
+              ConditionExpression: 'attribute_not_exists(pk)',
+            },
+          },
+        ],
+      }),
+    )
+    expect(totalCap(cond.ConsumedCapacity)).toBe(totalCap(uncond.ConsumedCapacity))
+    expect(totalCap(cond.ConsumedCapacity)).toBe(2)
+  })
+
+  // A standalone ConditionCheck costs 2 write capacity units - the same as a write,
+  // and billed as write, not read. The check sits on a separate table from the write
+  // so the INDEXES per-table breakdown isolates its cost (a same-table check and write
+  // collapse into one capacity line).
+  it('a standalone ConditionCheck action costs 2 write capacity units', async () => {
+    const res = await ddb.send(
+      new TransactWriteItemsCommand({
+        ReturnConsumedCapacity: 'INDEXES',
+        TransactItems: [
+          { Put: { TableName: hashTableDef.name, Item: { pk: { S: 'tw-cap-cc' }, v: { N: '1' } } } },
+          {
+            ConditionCheck: {
+              TableName: compositeTableDef.name,
+              Key: { pk: { S: 'tw-cap-cc-present' }, sk: { S: 'x' } },
+              ConditionExpression: 'attribute_exists(pk)',
+            },
+          },
+        ],
+      }),
+    )
+    const checkEntry = (res.ConsumedCapacity ?? []).find(
+      (c) => c.TableName === compositeTableDef.name,
+    )
+    expect(checkEntry?.CapacityUnits).toBe(2)
+    expect(checkEntry?.WriteCapacityUnits).toBe(2)
+  })
+
+  // Idempotent replay accounting: the first call reports write capacity; a same-token
+  // replay (in-window) reports read capacity for re-reading the stored result.
+  it('reports write capacity on the first call and read capacity on a same-token replay', async () => {
+    const token = `tw-cap-replay-${Date.now()}`
+    const item = {
+      Put: { TableName: hashTableDef.name, Item: { pk: { S: 'tw-cap-replay' }, v: { N: '1' } } },
+    }
+    const first = await ddb.send(
+      new TransactWriteItemsCommand({ ClientRequestToken: token, ReturnConsumedCapacity: 'INDEXES', TransactItems: [item] }),
+    )
+    const replay = await ddb.send(
+      new TransactWriteItemsCommand({ ClientRequestToken: token, ReturnConsumedCapacity: 'INDEXES', TransactItems: [item] }),
+    )
+    const firstEntry = (first.ConsumedCapacity ?? [])[0]
+    const replayEntry = (replay.ConsumedCapacity ?? [])[0]
+    // First: a transactional write - 2 WCU, no read capacity.
+    expect(firstEntry?.WriteCapacityUnits).toBe(2)
+    expect(firstEntry?.ReadCapacityUnits).toBeUndefined()
+    // Replay: a transactional read of the stored result - 2 RCU, no write capacity.
+    expect(replayEntry?.ReadCapacityUnits).toBe(2)
+    expect(replayEntry?.WriteCapacityUnits).toBeUndefined()
+  })
+
+  // A cancelled conditional transaction surfaces no consumed capacity: the
+  // TransactionCanceledException carries CancellationReasons but no ConsumedCapacity.
+  // (AWS still bills the prepare phase; this pins what the response reports, not billing.)
+  it('a cancelled conditional transaction reports no consumed capacity', async () => {
+    try {
+      await ddb.send(
+        new TransactWriteItemsCommand({
+          ReturnConsumedCapacity: 'TOTAL',
+          TransactItems: [
+            {
+              Put: {
+                TableName: hashTableDef.name,
+                Item: { pk: { S: 'tw-cap-cancel' }, v: { N: '1' } },
+                ConditionExpression: 'attribute_exists(pk)', // fails on a fresh key
+              },
+            },
+          ],
+        }),
+      )
+      expect.unreachable('should have thrown')
+    } catch (err) {
+      expect(err).toBeInstanceOf(TransactionCanceledException)
+      expect('ConsumedCapacity' in (err as object)).toBe(false)
+    }
+  })
+})


### PR DESCRIPTION
## What this changes

Pins the capacity accounting of conditional and idempotent transactional writes, the gap the existing `TransactWriteItems — ConsumedCapacity` block leaves open. Four cases, all characterised against real DynamoDB in eu-west-2:

- A passing conditional write costs the same 2 WCU per sub-1KB item as an unconditional one. The condition adds no read capacity.
- A standalone `ConditionCheck` costs 2 WCU, billed as write rather than read.
- An idempotent same-token replay splits the accounting: the first call reports 2 write capacity units, the replay reports 2 read capacity units for re-reading the stored result.
- A failing condition cancels the transaction, and the response carries no `ConsumedCapacity` at all.

Answers the two questions in #27: whether a conditional write consumes read units on top of write units, and the replay behaviour when the same `ClientRequestToken` comes back.

## Checklist

- [x] New or modified tests run against real AWS DynamoDB and pass
- [x] New or modified tests run against at least one emulator target and behave as expected (a local emulator conforms on the TOTAL-capacity and cancellation cases, and diverges on the per-table `WriteCapacityUnits` breakdown and the replay accounting, recorded as a non-gating divergence)
- [x] Linked issue or a short note explaining the motivation (#27)
- [x] I agree my contribution is licensed under the project's terms (Apache License, Version 2.0)

## ~~Tier and scope~~

- ~~No tier definitions, results pipeline, or target configuration change. The new tests fold into the existing tier2 transactions suite; the results table regenerates on the next merge to `main`.~~

Closes #27.
