### PR TITLE
fix: keep local scratch results out of git and the published tooling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,9 @@ ground-truth/
 
 # Knowledge-os link: local only, not for the public repo
 .kos
+
+# Local scratch run output (DYNAMODB_ENDPOINT set, no CONFORMANCE_TARGET - see
+# vitest.config.ts). A reserved non-target slug, never committed; see
+# scripts/lib/score.mjs RESERVED_SLUGS.
+/results/local.json
+/results/local.badge.json

--- a/scripts/badges.mjs
+++ b/scripts/badges.mjs
@@ -17,7 +17,7 @@
 
 import { readdirSync, readFileSync, writeFileSync } from 'node:fs'
 import { basename, join } from 'node:path'
-import { GROUND_TRUTH_SLUG, passRate, scoreResults } from './lib/score.mjs'
+import { GROUND_TRUTH_SLUG, isPublishedTarget, passRate, scoreResults } from './lib/score.mjs'
 
 const RESULTS_DIR = 'results'
 
@@ -32,9 +32,11 @@ export function colour(pct) {
 }
 
 // A target's conformance pass rate, or null when there is nothing to show: the
-// file is not a target result (e.g. tag-manifest.json) or the target ran no
-// scored tests. Real DynamoDB is the ground truth, pinned to 100%.
+// slug is a reserved scratch slug (e.g. local), the file is not a target result
+// (e.g. tag-manifest.json), or the target ran no scored tests. Real DynamoDB is
+// the ground truth, pinned to 100%.
 export function rateFor(slug, raw) {
+  if (!isPublishedTarget(slug)) return null
   if (slug === GROUND_TRUTH_SLUG) return 100
   const scored = scoreResults(raw)
   return scored ? passRate(scored.passed, scored.failed) : null

--- a/scripts/badges.test.mjs
+++ b/scripts/badges.test.mjs
@@ -46,6 +46,11 @@ describe('rateFor', () => {
     expect(rateFor('tag-manifest', { schema: 1 })).toBeNull()
   })
 
+  it('returns null for the reserved local scratch slug', () => {
+    // A real, well-formed run output - excluded by slug, not by structure.
+    expect(rateFor('local', result(5, 0))).toBeNull()
+  })
+
   it('scores a real target as passed / (passed + failed)', () => {
     expect(rateFor('dynoxide', result(2, 1))).toBeCloseTo(66.6667, 3)
   })
@@ -54,6 +59,10 @@ describe('rateFor', () => {
 describe('buildBadge', () => {
   it('returns null when there is nothing to show', () => {
     expect(buildBadge('tag-manifest', { schema: 1 })).toBeNull()
+  })
+
+  it('returns null for the reserved local scratch slug', () => {
+    expect(buildBadge('local', result(5, 0))).toBeNull()
   })
 
   it('emits the shields endpoint shape for the ground truth', () => {

--- a/scripts/lib/score.mjs
+++ b/scripts/lib/score.mjs
@@ -10,6 +10,19 @@
 // results table and the badges so the two can't disagree on which slug it is.
 export const GROUND_TRUTH_SLUG = 'dynamodb'
 
+// Result-file slugs that are never a published target. `local` is the default
+// output of an ad-hoc local run (DYNAMODB_ENDPOINT set with no
+// CONFORMANCE_TARGET - see vitest.config.ts), a scratch file that must not be
+// scored, badged, or listed in the results table. Kept here so the table and
+// the badges agree on what to skip, the same way they share GROUND_TRUTH_SLUG.
+export const RESERVED_SLUGS = new Set(['local'])
+
+// Whether a result-file slug is a published conformance target. False for the
+// reserved scratch slugs above.
+export function isPublishedTarget(slug) {
+  return !RESERVED_SLUGS.has(slug)
+}
+
 export function tierOf(filePath) {
   if (filePath.includes('/tier1/')) return 'tier1'
   if (filePath.includes('/tier2/')) return 'tier2'

--- a/scripts/lib/score.test.mjs
+++ b/scripts/lib/score.test.mjs
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { GROUND_TRUTH_SLUG, passRate, scoreResults, tierOf } from './score.mjs'
+import { GROUND_TRUTH_SLUG, isPublishedTarget, passRate, scoreResults, tierOf } from './score.mjs'
 
 // Build a minimal Vitest-shaped result: one test file per named tier directory,
 // each carrying the given passed/failed/skipped assertion counts.
@@ -64,5 +64,19 @@ describe('passRate', () => {
 describe('GROUND_TRUTH_SLUG', () => {
   it('is dynamodb', () => {
     expect(GROUND_TRUTH_SLUG).toBe('dynamodb')
+  })
+})
+
+describe('isPublishedTarget', () => {
+  it('excludes the reserved local scratch slug', () => {
+    expect(isPublishedTarget('local')).toBe(false)
+  })
+
+  it('keeps real targets, matching the slug exactly rather than by prefix', () => {
+    // dynamodb-local contains "local" but is a real target; an exact-match
+    // reservation must not catch it.
+    expect(isPublishedTarget('dynamodb-local')).toBe(true)
+    expect(isPublishedTarget('dynoxide')).toBe(true)
+    expect(isPublishedTarget(GROUND_TRUTH_SLUG)).toBe(true)
   })
 })

--- a/scripts/summarise.mjs
+++ b/scripts/summarise.mjs
@@ -25,7 +25,7 @@
 
 import { existsSync, readFileSync, readdirSync, writeFileSync } from 'node:fs'
 import { basename, join } from 'node:path'
-import { GROUND_TRUTH_SLUG, passRate, scoreResults } from './lib/score.mjs'
+import { GROUND_TRUTH_SLUG, isPublishedTarget, passRate, scoreResults } from './lib/score.mjs'
 
 const argv = process.argv.slice(2)
 const write = argv.includes('--write')
@@ -83,6 +83,9 @@ let groundTruthDate = '-'
 
 for (const file of files) {
   const slug = basename(file, '.json')
+  // Reserved scratch slugs (e.g. a local dev run's results/local.json) are not
+  // published targets; skip before reading so they never reach the table.
+  if (!isPublishedTarget(slug)) continue
   const raw = JSON.parse(readFileSync(file, 'utf8'))
 
   const runDate = raw.startTime


### PR DESCRIPTION
## What this changes

A local run with `DYNAMODB_ENDPOINT` set and no `CONFORMANCE_TARGET` writes `results/local.json` (per `vitest.config.ts`). That file was neither gitignored nor recognised as a non-target, so it could be committed into this public repo, and it broke `npm run test:tooling` by demanding a `local.badge.json`. This reserves `local` as a scratch slug - skipped by the badge generator and the results table - and gitignores its output. `isPublishedTarget` is unit-tested in `score.test.mjs`, pinning the exact-match guard so a real target like `dynamodb-local` is never caught.

`npm run test:tooling` (69 pass) and `tsc --noEmit` are green.

## Checklist

- ~~New or modified tests run against real AWS DynamoDB and pass~~ - tooling-only change; no conformance tests touched.
- ~~New or modified tests run against at least one emulator target and behave as expected~~ - n/a; the new tests are pure unit tests for the results tooling.
- [x] Linked issue or a short note explaining the motivation (note above)
- [x] I agree my contribution is licensed under the project's terms (Apache License, Version 2.0)

## Tier and scope

Touches the results pipeline (`scripts/badges.mjs`, `scripts/summarise.mjs`, `scripts/lib/score.mjs`) but changes no committed artefacts: `local` never appears in committed results (it is gitignored), so no results-table or badge regeneration is expected.
