### PR TITLE
test: pin ConsumedCapacity capacity units for replay and single-item ops (#68, #69, #70)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,34 @@
 A dated log of how the conformance test suite has grown: tests added, tiers
 broadened, and targets brought into the run. Newest first.
 
+## 2026-07-01
+
+Grew to 832 tests, up 8, sharpening how the suite pins ConsumedCapacity capacity
+units on transactional and single-item operations. All characterised against real
+DynamoDB in eu-west-2.
+
+The same-token replay case for TransactWriteItems now uses a ~1.5KB item instead
+of a sub-1KB one. Below 1KB a transactional write (2 * ceil(size / 1KB)) and a
+transactional read (2 * ceil(size / 4KB)) both round to 2, so the old item could
+not tell them apart. At ~1.5KB they separate: the first call reports 4 write
+capacity units, the replay 2 read. That settles what the replay bills - a
+transactional read recomputed against the item size, not the stored write
+magnitude relabelled as read. Answers #68.
+
+ExecuteTransaction gains the ClientRequestToken idempotent-replay coverage
+TransactWriteItems already had. The same statements sent twice under one token
+apply exactly once - a counter incremented inside the transaction reads back 1,
+not 2 - and the accounting splits the same way, 2 write capacity units on the
+first call and 2 read on the replay. Answers #70.
+
+The single-item read/write split turned out to be the opposite of what #69
+assumed. Real DynamoDB returns no top-level ReadCapacityUnits or WriteCapacityUnits
+on GetItem, PutItem, UpdateItem, DeleteItem, Query or Scan; it reports the aggregate
+CapacityUnits alone, under both TOTAL and INDEXES. The split is transactional-only.
+So the pinned claim is the inverse: single-item operations report the aggregate and
+omit the split, with a strongly-consistent read at 1 unit, an eventually-consistent
+read at 0.5, and a small write at 1. Answers #69.
+
 ## 2026-06-30
 
 Grew to 824 tests, up 7, in two parts: two sibling-parity gaps where one half of

--- a/results/tag-manifest.json
+++ b/results/tag-manifest.json
@@ -149,6 +149,10 @@
       "ConsumedCapacity across operations": [
         "get-item",
         "data-plane"
+      ],
+      "ConsumedCapacity — single-item ops report only the aggregate, no read/write split": [
+        "get-item",
+        "data-plane"
       ]
     },
     "tests/tier1/getItem/projection.test.ts": {
@@ -208,6 +212,10 @@
     },
     "tests/tier1/putItem/consumedCapacity.test.ts": {
       "ReturnConsumedCapacity": [
+        "put-item",
+        "data-plane"
+      ],
+      "ReturnConsumedCapacity — PutItem reports only the aggregate, no write-capacity split": [
         "put-item",
         "data-plane"
       ]

--- a/tests/tier1/getItem/consumedCapacity.test.ts
+++ b/tests/tier1/getItem/consumedCapacity.test.ts
@@ -180,3 +180,96 @@ describe('ConsumedCapacity across operations', { tags: ['get-item', 'data-plane'
     expect(tableCapacity!.CapacityUnits).toBeGreaterThan(0)
   })
 })
+
+// Real DynamoDB reports the ReadCapacityUnits / WriteCapacityUnits split only on
+// transactional operations (TransactWriteItems, TransactGetItems, ExecuteTransaction —
+// see tests/tier2/transactions and tests/tier2/partiql/executeTransaction). A plain
+// single-item or single-table operation reports the aggregate CapacityUnits alone, with
+// no read/write breakdown, under both TOTAL and INDEXES. This is the read/update/delete
+// side; the PutItem side lives in tests/tier1/putItem/consumedCapacity.test.ts. Sibling
+// to the transactional split coverage, which asserts the split's presence. Magnitudes
+// characterised against real DynamoDB (eu-west-2). See #69.
+describe('ConsumedCapacity — single-item ops report only the aggregate, no read/write split', { tags: ['get-item', 'data-plane'] }, () => {
+  const present = { pk: { S: 'cc-split-present' } }
+  const delKey = { pk: { S: 'cc-split-del' } }
+
+  beforeAll(async () => {
+    await Promise.all([
+      ddb.send(new PutItemCommand({ TableName: hashTableDef.name, Item: { pk: present.pk, data: { S: 'x' } } })),
+      ddb.send(new PutItemCommand({ TableName: hashTableDef.name, Item: { pk: delKey.pk, data: { S: 'x' } } })),
+      ddb.send(new PutItemCommand({
+        TableName: compositeTableDef.name,
+        Item: { pk: { S: 'cc-split-q' }, sk: { S: 'a' }, lsi1sk: { S: 'l' }, data: { S: 'x' } },
+      })),
+    ])
+  })
+
+  afterAll(async () => {
+    await cleanupItems(hashTableDef.name, [present, delKey])
+    await cleanupItems(compositeTableDef.name, [{ pk: { S: 'cc-split-q' }, sk: { S: 'a' } }])
+  })
+
+  it('a strongly-consistent GetItem reports 1 CapacityUnit and no read/write split', async () => {
+    const res = await ddb.send(new GetItemCommand({
+      TableName: hashTableDef.name,
+      Key: present,
+      ConsistentRead: true,
+      ReturnConsumedCapacity: 'TOTAL',
+    }))
+    expect(res.ConsumedCapacity!.CapacityUnits).toBe(1)
+    expect(res.ConsumedCapacity!.ReadCapacityUnits).toBeUndefined()
+    expect(res.ConsumedCapacity!.WriteCapacityUnits).toBeUndefined()
+  })
+
+  it('an eventually-consistent GetItem reports 0.5 CapacityUnits and no read/write split', async () => {
+    const res = await ddb.send(new GetItemCommand({
+      TableName: hashTableDef.name,
+      Key: present,
+      ReturnConsumedCapacity: 'TOTAL',
+    }))
+    // A half-unit eventually-consistent read is itself a conformance signal.
+    expect(res.ConsumedCapacity!.CapacityUnits).toBe(0.5)
+    expect(res.ConsumedCapacity!.ReadCapacityUnits).toBeUndefined()
+    expect(res.ConsumedCapacity!.WriteCapacityUnits).toBeUndefined()
+  })
+
+  it('a Query under INDEXES omits the split at the top level and on Table', async () => {
+    const res = await ddb.send(new QueryCommand({
+      TableName: compositeTableDef.name,
+      KeyConditionExpression: '#pk = :pk',
+      ExpressionAttributeNames: { '#pk': 'pk' },
+      ExpressionAttributeValues: { ':pk': { S: 'cc-split-q' } },
+      ConsistentRead: true,
+      ReturnConsumedCapacity: 'INDEXES',
+    }))
+    expect(res.ConsumedCapacity!.CapacityUnits).toBe(1)
+    expect(res.ConsumedCapacity!.ReadCapacityUnits).toBeUndefined()
+    expect(res.ConsumedCapacity!.Table!.CapacityUnits).toBe(1)
+    expect(res.ConsumedCapacity!.Table!.ReadCapacityUnits).toBeUndefined()
+  })
+
+  it('an UpdateItem reports 1 CapacityUnit and no read/write split', async () => {
+    const res = await ddb.send(new UpdateItemCommand({
+      TableName: hashTableDef.name,
+      Key: present,
+      UpdateExpression: 'SET #d = :v',
+      ExpressionAttributeNames: { '#d': 'data' },
+      ExpressionAttributeValues: { ':v': { S: 'y' } },
+      ReturnConsumedCapacity: 'TOTAL',
+    }))
+    expect(res.ConsumedCapacity!.CapacityUnits).toBe(1)
+    expect(res.ConsumedCapacity!.WriteCapacityUnits).toBeUndefined()
+    expect(res.ConsumedCapacity!.ReadCapacityUnits).toBeUndefined()
+  })
+
+  it('a DeleteItem reports 1 CapacityUnit and no read/write split', async () => {
+    const res = await ddb.send(new DeleteItemCommand({
+      TableName: hashTableDef.name,
+      Key: delKey,
+      ReturnConsumedCapacity: 'TOTAL',
+    }))
+    expect(res.ConsumedCapacity!.CapacityUnits).toBe(1)
+    expect(res.ConsumedCapacity!.WriteCapacityUnits).toBeUndefined()
+    expect(res.ConsumedCapacity!.ReadCapacityUnits).toBeUndefined()
+  })
+})

--- a/tests/tier1/putItem/consumedCapacity.test.ts
+++ b/tests/tier1/putItem/consumedCapacity.test.ts
@@ -147,3 +147,40 @@ describe('ReturnConsumedCapacity', { tags: ['put-item', 'data-plane'] }, () => {
     expect(typeof result.ConsumedCapacity!.Table!.CapacityUnits).toBe('number')
   })
 })
+
+// The write-capacity counterpart to the read/update/delete coverage in
+// tests/tier1/getItem/consumedCapacity.test.ts: real DynamoDB reports the
+// ReadCapacityUnits / WriteCapacityUnits split only on transactional operations, so a
+// plain PutItem reports the aggregate CapacityUnits alone — no WriteCapacityUnits — under
+// both TOTAL and INDEXES, at the top level and on Table. Magnitude characterised against
+// real DynamoDB (eu-west-2). See #69.
+describe('ReturnConsumedCapacity — PutItem reports only the aggregate, no write-capacity split', { tags: ['put-item', 'data-plane'] }, () => {
+  const keys = [{ pk: { S: 'cc-split-put' } }]
+
+  afterAll(async () => {
+    await cleanupItems(hashTableDef.name, keys)
+  })
+
+  it('PutItem with TOTAL reports 1 CapacityUnit and no read/write split', async () => {
+    const res = await ddb.send(new PutItemCommand({
+      TableName: hashTableDef.name,
+      Item: { pk: { S: 'cc-split-put' }, data: { S: 'x' } },
+      ReturnConsumedCapacity: 'TOTAL',
+    }))
+    expect(res.ConsumedCapacity!.CapacityUnits).toBe(1)
+    expect(res.ConsumedCapacity!.WriteCapacityUnits).toBeUndefined()
+    expect(res.ConsumedCapacity!.ReadCapacityUnits).toBeUndefined()
+  })
+
+  it('PutItem with INDEXES omits the split at the top level and on Table', async () => {
+    const res = await ddb.send(new PutItemCommand({
+      TableName: hashTableDef.name,
+      Item: { pk: { S: 'cc-split-put' }, data: { S: 'x' } },
+      ReturnConsumedCapacity: 'INDEXES',
+    }))
+    expect(res.ConsumedCapacity!.CapacityUnits).toBe(1)
+    expect(res.ConsumedCapacity!.WriteCapacityUnits).toBeUndefined()
+    expect(res.ConsumedCapacity!.Table!.CapacityUnits).toBe(1)
+    expect(res.ConsumedCapacity!.Table!.WriteCapacityUnits).toBeUndefined()
+  })
+})

--- a/tests/tier2/partiql/executeTransaction.test.ts
+++ b/tests/tier2/partiql/executeTransaction.test.ts
@@ -135,6 +135,55 @@ describe('ExecuteTransaction — PartiQL', { tags: ['partiql', 'data-plane'] }, 
     }
   })
 
+  // ExecuteTransaction takes a ClientRequestToken, like TransactWriteItems. A
+  // same-token replay inside the idempotency window returns the stored result
+  // rather than re-running the statements, so the write applies exactly once.
+  // Capacity accounting mirrors TransactWriteItems: the first call reports the
+  // transactional write, the replay a transactional read of the stored result.
+  // Values characterised against real DynamoDB (eu-west-2). See #70.
+  it('idempotent replay under the same ClientRequestToken does not double-apply', async () => {
+    const pk = `txn-idem-${Date.now()}`
+    keysToCleanup.push({ pk: { S: pk } })
+
+    // Seed a counter at 0, then increment it by 1 inside a tokenised transaction.
+    await ddb.send(new ExecuteStatementCommand({
+      Statement: `INSERT INTO "${hashTableDef.name}" VALUE {'pk': '${pk}', 'n': 0}`,
+    }))
+    const token = `et-idem-token-${Date.now()}`
+    const statements = [
+      { Statement: `UPDATE "${hashTableDef.name}" SET n = n + 1 WHERE pk = '${pk}'` },
+    ]
+
+    const first = await ddb.send(new ExecuteTransactionCommand({
+      ClientRequestToken: token,
+      ReturnConsumedCapacity: 'INDEXES',
+      TransactStatements: statements,
+    }))
+    const replay = await ddb.send(new ExecuteTransactionCommand({
+      ClientRequestToken: token,
+      ReturnConsumedCapacity: 'INDEXES',
+      TransactStatements: statements,
+    }))
+
+    // The increment applied exactly once — a replay, not a second execution.
+    const after = await ddb.send(new GetItemCommand({
+      TableName: hashTableDef.name,
+      Key: { pk: { S: pk } },
+      ConsistentRead: true,
+    }))
+    expect(after.Item!.n.N).toBe('1')
+
+    // ExecuteTransaction reports ConsumedCapacity as a per-table array. The first
+    // call is a transactional write (2 WCU, no read); the replay is a
+    // transactional read of the stored result (2 RCU, no write).
+    const firstEntry = (first.ConsumedCapacity ?? [])[0]
+    const replayEntry = (replay.ConsumedCapacity ?? [])[0]
+    expect(firstEntry?.WriteCapacityUnits).toBe(2)
+    expect(firstEntry?.ReadCapacityUnits).toBeUndefined()
+    expect(replayEntry?.ReadCapacityUnits).toBe(2)
+    expect(replayEntry?.WriteCapacityUnits).toBeUndefined()
+  })
+
   it('rejects empty TransactStatements', async () => {
     await expectDynamoError(
       () => ddb.send(new ExecuteTransactionCommand({

--- a/tests/tier2/transactions/transactWrite.test.ts
+++ b/tests/tier2/transactions/transactWrite.test.ts
@@ -1430,10 +1430,20 @@ describe('TransactWriteItems — ConsumedCapacity: conditional, check, replay, c
 
   // Idempotent replay accounting: the first call reports write capacity; a same-token
   // replay (in-window) reports read capacity for re-reading the stored result.
+  //
+  // The item is deliberately >1KB. A sub-1KB item cannot tell the two magnitudes
+  // apart: a transactional write costs 2*ceil(size/1KB) and a transactional read
+  // costs 2*ceil(size/4KB), and both are 2 below 1KB. At ~1.5KB they diverge —
+  // write 2*ceil(1.5KB/1KB) = 4, read 2*ceil(1.5KB/4KB) = 2 — so the replay
+  // reporting 2 proves it recomputes a transactional READ against the item size,
+  // rather than relabelling the stored write magnitude (which would be 4) as read.
+  // Values characterised against real DynamoDB (eu-west-2). See #68.
   it('reports write capacity on the first call and read capacity on a same-token replay', async () => {
     const token = `tw-cap-replay-${Date.now()}`
+    // ~1.5KB value keeps the item in the (1KB, 2KB) band: write rounds to 2 units,
+    // read to 1, so their transactional doublings (4 vs 2) are distinct.
     const item = {
-      Put: { TableName: hashTableDef.name, Item: { pk: { S: 'tw-cap-replay' }, v: { N: '1' } } },
+      Put: { TableName: hashTableDef.name, Item: { pk: { S: 'tw-cap-replay' }, big: { S: 'x'.repeat(1536) } } },
     }
     const first = await ddb.send(
       new TransactWriteItemsCommand({ ClientRequestToken: token, ReturnConsumedCapacity: 'INDEXES', TransactItems: [item] }),
@@ -1443,10 +1453,11 @@ describe('TransactWriteItems — ConsumedCapacity: conditional, check, replay, c
     )
     const firstEntry = (first.ConsumedCapacity ?? [])[0]
     const replayEntry = (replay.ConsumedCapacity ?? [])[0]
-    // First: a transactional write - 2 WCU, no read capacity.
-    expect(firstEntry?.WriteCapacityUnits).toBe(2)
+    // First: a transactional write of a ~1.5KB item - 4 WCU, no read capacity.
+    expect(firstEntry?.WriteCapacityUnits).toBe(4)
     expect(firstEntry?.ReadCapacityUnits).toBeUndefined()
-    // Replay: a transactional read of the stored result - 2 RCU, no write capacity.
+    // Replay: a transactional read of the stored result, recomputed against the
+    // item size - 2 RCU, not the write magnitude of 4, and no write capacity.
     expect(replayEntry?.ReadCapacityUnits).toBe(2)
     expect(replayEntry?.WriteCapacityUnits).toBeUndefined()
   })


### PR DESCRIPTION
## What this changes

Pins three gaps in how the suite checks `ConsumedCapacity` capacity units, all characterised against real DynamoDB in eu-west-2. Closes #68, closes #69, closes #70.

- **#68** - the TransactWriteItems same-token replay test used a sub-1KB item, where a transactional write and read both round to 2 capacity units, so it could not show which one the replay bills. A ~1.5KB item separates them: 4 write units on the first call, 2 read on the replay. That pins the replay as a transactional read recomputed against the item size, not the stored write magnitude relabelled as read.
- **#70** - adds the `ClientRequestToken` idempotent-replay coverage TransactWriteItems already had. The same statements sent twice under one token apply once (a counter reads back 1, not 2), and the capacity splits the same way: 2 write on the first call, 2 read on the replay.
- **#69** - the issue assumed single-item operations return a top-level `ReadCapacityUnits`/`WriteCapacityUnits` split. Real DynamoDB does not. GetItem, PutItem, UpdateItem, DeleteItem, Query and Scan all report only the aggregate `CapacityUnits`, under both TOTAL and INDEXES; the split is transactional-only. So this pins the inverse - single-item ops report the aggregate alone, split absent, with a consistent read at 1 unit, an eventually-consistent read at 0.5, and a small write at 1. Detail in #69.

Verified against real DynamoDB (eu-west-2), the ground-truth gate: all four files pass. Also run against a local emulator target to confirm they are well-formed - the aggregate-only #69 cases pass, and the #68/#70 split assertions diverge exactly as the existing transactional-capacity tests do, since not every target reports the read/write split. The per-target CI jobs record the authoritative results for each engine.

## Checklist

- [x] New or modified tests run against real AWS DynamoDB and pass
- [x] New or modified tests run against at least one emulator target and behave as expected
- [x] Linked issue or a short note explaining the motivation
- [x] I agree my contribution is licensed under the project's terms (Apache License, Version 2.0)
