### PR TITLE
feat: admit the nesting-depth expression-value split

### DIFF
--- a/registry/splits.json
+++ b/registry/splits.json
@@ -678,6 +678,224 @@
         "date": "2026-07-14",
         "issue": "https://github.com/paritysuite/dynamodb-conformance/issues/85"
       }
+    },
+    {
+      "id": "update-item-nesting-depth-expression-value",
+      "test": {
+        "file": "tests/tier3/limits/nestingDepth.test.ts",
+        "fullName": "Nesting depth — 32-level document limit rejects a 32-level ExpressionAttributeValue with ValidationException"
+      },
+      "behaviour": "A 32-level (leaf at level 33) ExpressionAttributeValue in an UpdateItem ConditionExpression, one level past the documented 32-level nesting cap. Regions that enforce the cap on expression values reject it up front with ValidationException; regions where that stricter validation has not yet rolled out accept the value, evaluate the condition (which is false against the test item), and surface ConditionalCheckFailedException. Same stricter-validation rollout shape as the 2026-06 changes.",
+      "pinned": "eu-west-2",
+      "firstObserved": "2026-07-15",
+      "lastRefreshed": "2026-07-15",
+      "regions": {
+        "eu-west-2": {
+          "outcome": "rejected",
+          "error": {
+            "name": "ValidationException",
+            "message": "Nesting Levels have exceeded supported limits: Attributes in the item have nested levels beyond supported limit"
+          }
+        },
+        "af-south-1": {
+          "outcome": "rejected",
+          "error": {
+            "name": "ConditionalCheckFailedException",
+            "message": "The conditional request failed"
+          }
+        },
+        "ap-east-1": {
+          "outcome": "rejected",
+          "error": {
+            "name": "ConditionalCheckFailedException",
+            "message": "The conditional request failed"
+          }
+        },
+        "ap-northeast-1": {
+          "outcome": "rejected",
+          "error": {
+            "name": "ConditionalCheckFailedException",
+            "message": "The conditional request failed"
+          }
+        },
+        "ap-northeast-3": {
+          "outcome": "rejected",
+          "error": {
+            "name": "ConditionalCheckFailedException",
+            "message": "The conditional request failed"
+          }
+        },
+        "ap-south-1": {
+          "outcome": "rejected",
+          "error": {
+            "name": "ConditionalCheckFailedException",
+            "message": "The conditional request failed"
+          }
+        },
+        "ap-south-2": {
+          "outcome": "rejected",
+          "error": {
+            "name": "ConditionalCheckFailedException",
+            "message": "The conditional request failed"
+          }
+        },
+        "ap-southeast-2": {
+          "outcome": "rejected",
+          "error": {
+            "name": "ConditionalCheckFailedException",
+            "message": "The conditional request failed"
+          }
+        },
+        "ap-southeast-3": {
+          "outcome": "rejected",
+          "error": {
+            "name": "ConditionalCheckFailedException",
+            "message": "The conditional request failed"
+          }
+        },
+        "ap-southeast-4": {
+          "outcome": "rejected",
+          "error": {
+            "name": "ConditionalCheckFailedException",
+            "message": "The conditional request failed"
+          }
+        },
+        "ap-southeast-5": {
+          "outcome": "rejected",
+          "error": {
+            "name": "ConditionalCheckFailedException",
+            "message": "The conditional request failed"
+          }
+        },
+        "ap-southeast-6": {
+          "outcome": "rejected",
+          "error": {
+            "name": "ConditionalCheckFailedException",
+            "message": "The conditional request failed"
+          }
+        },
+        "ap-southeast-7": {
+          "outcome": "rejected",
+          "error": {
+            "name": "ConditionalCheckFailedException",
+            "message": "The conditional request failed"
+          }
+        },
+        "ca-central-1": {
+          "outcome": "rejected",
+          "error": {
+            "name": "ConditionalCheckFailedException",
+            "message": "The conditional request failed"
+          }
+        },
+        "ca-west-1": {
+          "outcome": "rejected",
+          "error": {
+            "name": "ConditionalCheckFailedException",
+            "message": "The conditional request failed"
+          }
+        },
+        "eu-central-2": {
+          "outcome": "rejected",
+          "error": {
+            "name": "ConditionalCheckFailedException",
+            "message": "The conditional request failed"
+          }
+        },
+        "eu-south-1": {
+          "outcome": "rejected",
+          "error": {
+            "name": "ConditionalCheckFailedException",
+            "message": "The conditional request failed"
+          }
+        },
+        "eu-south-2": {
+          "outcome": "rejected",
+          "error": {
+            "name": "ConditionalCheckFailedException",
+            "message": "The conditional request failed"
+          }
+        },
+        "eu-west-1": {
+          "outcome": "rejected",
+          "error": {
+            "name": "ConditionalCheckFailedException",
+            "message": "The conditional request failed"
+          }
+        },
+        "eu-west-3": {
+          "outcome": "rejected",
+          "error": {
+            "name": "ConditionalCheckFailedException",
+            "message": "The conditional request failed"
+          }
+        },
+        "il-central-1": {
+          "outcome": "rejected",
+          "error": {
+            "name": "ConditionalCheckFailedException",
+            "message": "The conditional request failed"
+          }
+        },
+        "me-central-1": {
+          "outcome": "rejected",
+          "error": {
+            "name": "ConditionalCheckFailedException",
+            "message": "The conditional request failed"
+          }
+        },
+        "mx-central-1": {
+          "outcome": "rejected",
+          "error": {
+            "name": "ConditionalCheckFailedException",
+            "message": "The conditional request failed"
+          }
+        },
+        "sa-east-1": {
+          "outcome": "rejected",
+          "error": {
+            "name": "ConditionalCheckFailedException",
+            "message": "The conditional request failed"
+          }
+        },
+        "us-east-1": {
+          "outcome": "rejected",
+          "error": {
+            "name": "ConditionalCheckFailedException",
+            "message": "The conditional request failed"
+          }
+        },
+        "us-east-2": {
+          "outcome": "rejected",
+          "error": {
+            "name": "ConditionalCheckFailedException",
+            "message": "The conditional request failed"
+          }
+        },
+        "us-west-1": {
+          "outcome": "rejected",
+          "error": {
+            "name": "ConditionalCheckFailedException",
+            "message": "The conditional request failed"
+          }
+        },
+        "us-west-2": {
+          "outcome": "rejected",
+          "error": {
+            "name": "ConditionalCheckFailedException",
+            "message": "The conditional request failed"
+          }
+        }
+      },
+      "evidence": [
+        "https://github.com/paritysuite/dynamodb-conformance/actions/runs/29433077383",
+        "https://github.com/paritysuite/dynamodb-conformance/issues/88"
+      ],
+      "admitted": {
+        "by": "Martin Hicks",
+        "date": "2026-07-16",
+        "issue": "https://github.com/paritysuite/dynamodb-conformance/issues/88"
+      }
     }
   ]
 }

--- a/results/summary.json
+++ b/results/summary.json
@@ -286,9 +286,9 @@
           }
         },
         "us-east-1": {
-          "rate": 99,
-          "passed": 931,
-          "failed": 9,
+          "rate": 98.9,
+          "passed": 930,
+          "failed": 10,
           "skipped": 14,
           "indeterminate": 0,
           "count": 954,
@@ -306,8 +306,8 @@
               "i": 0
             },
             "tier3": {
-              "p": 312,
-              "f": 8,
+              "p": 311,
+              "f": 9,
               "s": 0,
               "i": 0
             }


### PR DESCRIPTION
## What this changes

Admits the regional split behind #88. eu-west-2 and five other regions reject a 33-level expression value up front with a ValidationException; the other 27 accept it, so the condition runs and fails with ConditionalCheckFailedException. AWS is enforcing the nesting limit on expression values in some regions and not others, the same uneven rollout as the June changes. Confirmed five times per region by the 2026-07-15 sweep.

Headlines and badges are unchanged. One us-east-1 per-region column moves by a tenth of a percent, which is a strict target correctly failing to match a region that accepts the deeper value.

Closes #88

## Checklist

- ~~New or modified tests run against real AWS DynamoDB and pass~~ (N/A: registry data only)
- ~~New or modified tests run against at least one emulator target and behave as expected~~ (N/A: registry data only)
- [x] Linked issue or a short note explaining the motivation (#88)
- [x] I agree my contribution is licensed under the project's terms (Apache License, Version 2.0)

## Tier and scope

Touches the split registry, which the scoring pipeline reads. Regenerated `results/summary.json` only (per-region detail); the README table and badges are unchanged because the headline scores do not move.
