### PR TITLE
Run the GSI lifecycle suite against real AWS

### DIFF
--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -204,6 +204,171 @@ jobs:
           name: integration-results
           path: results/
 
+  test-dynamodb-gsi:
+    name: DynamoDB GSI lifecycle (non-gating)
+    # The 14 UpdateTable GSI lifecycle tests. Every one adds or removes a GSI on
+    # an existing table, and real AWS backfills each index for minutes: a full
+    # green run was measured at 10,182s (~2h50m) in eu-west-2 on 2026-07-13, a
+    # slow backfill night. That does not fit the gating job's 2h credential
+    # window, which is why the file has been excluded from `test:gating` and
+    # left to a manual per-PR run since 2026-05-26 - the one part of the suite
+    # with no automated real-AWS observation behind it.
+    #
+    # This lane closes that: its own 6h credentials, its own timeout, off the
+    # gate. It exists so real DynamoDB's published row is evidenced across the
+    # whole suite rather than only across the gating subset.
+    needs: test-dynamodb-integrations
+    if: always() && (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch')
+    continue-on-error: true
+    runs-on: ubuntu-latest
+    # Under GitHub's own 6h ceiling on a hosted job, so the step is killed by
+    # this timeout (leaving the cleanup below to run) rather than by the runner
+    # vanishing mid-backfill with tables still live.
+    timeout-minutes: 350
+    # Same group as the gating job: that job's cleanup deletes every
+    # _conformance_ table by prefix, and a GSI backfill running here would be
+    # deleted out from under itself. Queue, never cancel.
+    concurrency:
+      group: conformance-aws
+      cancel-in-progress: false
+    permissions:
+      id-token: write
+      contents: read
+    environment: conformance-testing
+
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 24
+          cache: npm
+
+      - run: npm ci
+
+      - name: Configure AWS credentials via OIDC
+        uses: aws-actions/configure-aws-credentials@v6
+        with:
+          role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
+          aws-region: eu-west-2
+          # 6h, against the ~2h50m observed worst case. The margin is the point:
+          # a backfill night worse than the one on record must still finish
+          # rather than expire mid-wait, because an expired credential surfaces
+          # as an indeterminate - "not observed" - which is the exact silence
+          # this lane exists to remove.
+          role-duration-seconds: 21600
+
+      - name: Run the GSI lifecycle suite
+        continue-on-error: true
+        env:
+          # Names the run, and with it the indeterminate sidecar
+          # (src/indeterminate-sink.ts resultSlug), so the sidecar pairs with
+          # ground-truth/gsi.json rather than orphaning itself as
+          # dynamodb.indeterminate.json. Real AWS is still the endpoint:
+          # that is decided by DYNAMODB_ENDPOINT being unset, not by this.
+          CONFORMANCE_TARGET: gsi
+          CONFORMANCE_RESULTS_DIR: ground-truth
+          AWS_REGION: eu-west-2
+          # No CONFORMANCE_RETRY here, unlike the gating job. A retried GSI test
+          # re-runs a multi-minute backfill, so absorbing a flake could add
+          # tens of minutes to an already long run. A red here is non-gating
+          # and triaged from the artefact instead.
+        run: npm run test:gsi -- --reporter=json --outputFile=ground-truth/gsi.json
+
+      - name: Sanitize account IDs
+        if: always()
+        run: node scripts/sanitize-arns.mjs
+
+      - name: Cleanup conformance tables
+        if: always()
+        timeout-minutes: 10
+        run: |
+          aws dynamodb list-tables --query "TableNames[?starts_with(@, '_conformance_')]" --output text | \
+          tr '\t' '\n' | \
+          xargs -P4 -I{} aws dynamodb delete-table --table-name {} 2>/dev/null || true
+
+      # Written to ground-truth/ and uploaded under a non `results-*` name for
+      # the same reason the sweep's per-region files are: this is ground truth,
+      # not a target, and the Update Results Table overlay must never fold it
+      # into results/ as a phantom target row.
+      - name: Upload GSI ground truth
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: ground-truth-gsi
+          path: ground-truth/
+
+  ground-truth-coverage:
+    name: Ground-truth coverage
+    # The published DynamoDB row is synthesised at 100% across the full suite
+    # size rather than scored from a results file, because real DynamoDB
+    # defines correctness and cannot disagree with itself. That is the design.
+    # What it assumes is that every test HAS been run against real AWS
+    # somewhere - and real-AWS coverage is split across three lanes for runtime
+    # reasons. This job unions them and checks the assumption holds.
+    #
+    # It is deliberately NOT continue-on-error. Every other real-AWS lane here
+    # is non-gating because a slow AWS call is not a conformance signal; a hole
+    # in ground truth is the opposite - it means the table is claiming
+    # something nobody observed, which is the one failure that must not be
+    # quiet.
+    needs: [test-dynamodb, test-dynamodb-integrations, test-dynamodb-gsi]
+    if: always() && (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      actions: read
+
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 24
+
+      # The emulator targets are the reference: they run the full `npm test`,
+      # so between them they define the suite size the published row claims.
+      - name: Download every run artefact
+        uses: actions/download-artifact@v7
+        with:
+          path: /tmp/artifacts
+
+      - name: Reconcile real-AWS coverage against the published suite size
+        run: |
+          shopt -s nullglob
+          refs=()
+          # Each results-<target> artefact carries that target's fresh file plus
+          # stale committed copies of every other target, so take only each
+          # artefact's own - the same rule the Update Results Table overlay
+          # applies. A stale copy would still be a full-suite run and so would
+          # not move the max, but reconciling against last week's file is not a
+          # thing to leave to luck.
+          for d in /tmp/artifacts/results-*/; do
+            target=$(basename "$d"); target=${target#results-}
+            # results-dynamodb is ground truth, not a reference full-suite run.
+            [ "$target" = "dynamodb" ] && continue
+            [ -f "$d$target.json" ] && refs+=(--reference "$d$target.json")
+          done
+
+          observed=()
+          for f in /tmp/artifacts/results-dynamodb/dynamodb.json \
+                   /tmp/artifacts/integration-results/dynamodb.json \
+                   /tmp/artifacts/ground-truth-gsi/gsi.json; do
+            [ -f "$f" ] && observed+=("$f")
+          done
+
+          # A lane that produced nothing is the gap, not a reason to skip the
+          # check: silence here is exactly what would let an unobserved test
+          # keep counting. Report which lanes are missing, then let the
+          # reconciliation fail on their tests.
+          if [ ${#observed[@]} -lt 3 ]; then
+            echo "::warning::Only ${#observed[@]} of 3 real-AWS lanes produced results."
+          fi
+          if [ ${#refs[@]} -eq 0 ] || [ ${#observed[@]} -eq 0 ]; then
+            echo "::error::No reference or no real-AWS results to reconcile."
+            exit 1
+          fi
+
+          node scripts/ground-truth-coverage.mjs "${refs[@]}" "${observed[@]}"
+
   capture-cross-region:
     name: Cross-region drift capture (non-gating)
     # Capture real AWS's negative-input wording in the candidate regions each

--- a/README.md
+++ b/README.md
@@ -260,7 +260,27 @@ npm test
 
 The full suite includes 14 UpdateTable GSI lifecycle tests that add and remove Global Secondary Indexes from existing tables. On real DynamoDB, each GSI creation triggers a backfill that usually takes 5-15 minutes even on empty tables, and has been observed taking 25+ on a slow night. These tests are important for conformance but they dominate runtime against real AWS.
 
-`test:quick` excludes the GSI lifecycle tests for faster local iteration. CI's gating real-DynamoDB job runs `test:gating`, which drops the GSI lifecycle tests *and* the S3 and Kinesis integration suites (see "Operations no emulator implements" below), so a slow async import can't redden the build. Those integration suites still run against real AWS in a separate non-gating job via `npm run test:integrations`. Emulator targets run the full `npm test` since GSI creation is instant locally. If you're modifying GSI-related code, run the full suite against real DynamoDB manually before merging.
+`test:quick` excludes the GSI lifecycle tests for faster local iteration. CI's gating real-DynamoDB job runs `test:gating`, which drops the GSI lifecycle tests *and* the S3 and Kinesis integration suites (see "Operations no emulator implements" below), so a slow async import can't redden the build. Emulator targets run the full `npm test` since GSI creation is instant locally.
+
+Nothing is dropped from real AWS by being off the gate, only moved. Real-AWS
+coverage runs in three lanes, split by runtime rather than by importance:
+
+| Lane | Scope | Gates the build |
+|------|-------|-----------------|
+| `test:gating` | the suite minus the two below | yes |
+| `test:integrations` | S3 export/import, Kinesis | no |
+| `test:gsi` | the 14 UpdateTable GSI lifecycle tests | no |
+
+The GSI lane exists because a full green run of that file was measured at
+2h50m against real AWS on a slow backfill night, far longer than the gating
+run can absorb. It gets a lane sized for it instead of being skipped.
+
+Because the published DynamoDB row is scored across the whole suite, the
+**Ground-truth coverage** job unions the three lanes after every scheduled run
+and fails if any test in the suite has no real-AWS observation behind it. Run
+it yourself with `node scripts/ground-truth-coverage.mjs --reference
+results/<emulator>.json <ground-truth files>`. A hole in ground truth is the
+one thing here that is never allowed to be quiet.
 
 ## Design principles
 
@@ -412,7 +432,9 @@ behaviour has value - and they all carry the `cloud-only` tag, so
 
 Import/Export and Kinesis lean on slow async control-plane calls that make poor
 gate material, so they run in a separate non-gating job via
-`npm run test:integrations` rather than on the gating run.
+`npm run test:integrations` rather than on the gating run. They still run
+against real AWS every scheduled run, and the ground-truth coverage check
+fails if they don't.
 
 Genuinely not covered, with no tests yet:
 

--- a/ground-truth/README.md
+++ b/ground-truth/README.md
@@ -8,6 +8,13 @@ sidecar - see `src/indeterminate-sink.ts`). The weekly sweep
 artifacts; `npm run test:capture-ground-truth` writes an ad-hoc local capture
 here as `latest.json`.
 
+`gsi.json` is the one non-region file: the GSI lifecycle lane
+(`test:gsi` in `.github/workflows/conformance.yml`) writes eu-west-2's
+observation of the 14 UpdateTable GSI tests here, because those run in their
+own 6h credential window rather than on the gating job. It is ground truth for
+the same reason the region files are, and it is kept out of `results/` for the
+same reason too.
+
 The JSON files are gitignored: they are run output, not curated state. Only
 this README is tracked.
 

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "test:quick": "vitest run --exclude 'tests/tier2/updateTable/gsi.test.ts'",
     "test:gating": "vitest run --exclude 'tests/tier2/updateTable/gsi.test.ts' --exclude 'tests/tier2/export/exportImport.test.ts' --exclude 'tests/tier2/kinesis/streamingDestination.test.ts'",
     "test:integrations": "vitest run tests/tier2/export/exportImport.test.ts tests/tier2/kinesis/streamingDestination.test.ts",
+    "test:gsi": "vitest run tests/tier2/updateTable/gsi.test.ts",
     "test:watch": "vitest",
     "test:tier1": "vitest run --include 'tests/tier1/**/*.test.ts'",
     "test:tier2": "vitest run --include 'tests/tier2/**/*.test.ts'",

--- a/scripts/ground-truth-coverage.mjs
+++ b/scripts/ground-truth-coverage.mjs
@@ -1,0 +1,146 @@
+#!/usr/bin/env node
+
+/**
+ * Reconcile what real DynamoDB was actually observed on against what the
+ * published table claims for it.
+ *
+ * The ground-truth row is synthesised, not scored: scripts/summarise.mjs pins
+ * it to 100% across the full suite size, because real DynamoDB defines
+ * correctness and cannot disagree with itself. That is the design, and this
+ * script does not touch it. What the design assumes is that every test in the
+ * suite has in fact been run against real AWS somewhere - otherwise the row
+ * spans tests nobody ever observed, and the assumption quietly becomes a claim.
+ *
+ * Real AWS coverage is split across three lanes, for runtime reasons rather
+ * than conceptual ones:
+ *
+ *   - the gating job          (`test:gating`)      -> most of the suite
+ *   - the integrations lane   (`test:integrations`) -> S3 export/import, Kinesis
+ *   - the GSI lifecycle lane  (`test:gsi`)          -> UpdateTable GSI backfills
+ *
+ * Union those and you should have the whole suite. This script checks that,
+ * against a reference run that did execute everything (any emulator target -
+ * they all run the full `npm test`). Anything in the reference with no
+ * real-AWS observation behind it is reported, and the exit code is non-zero.
+ *
+ * Usage:
+ *   node scripts/ground-truth-coverage.mjs \
+ *     --reference results/dynoxide.json --reference results/dynalite.json \
+ *     results/dynamodb.json ground-truth/gsi.json integration-results/dynamodb.json
+ *
+ * `--reference` may be repeated, and the LARGEST is used - deliberately the
+ * same rule as summarise.mjs's `suiteSize = Math.max(...)`, which is what the
+ * published row's denominator actually is. Reconciling against anything else
+ * would check a number the table does not claim. Passing every emulator's
+ * results also means one emulator job failing does not silently shrink the
+ * reference and hide a gap.
+ *
+ * Verdicts are irrelevant here: a test that ran and failed was still observed.
+ * The question is only whether real AWS was ever asked.
+ */
+
+import { readFileSync } from 'node:fs'
+
+/**
+ * Every test identity in a Vitest JSON document, as `<file>::<fullName>`.
+ *
+ * Keyed on the file path as well as the name because `fullName` is only unique
+ * within a file - two files may both have a `basic > rejects a missing key` -
+ * and a collision here would silently mark an unobserved test as covered. File
+ * paths are absolutised by the runner, so they are reduced to their repo
+ * relative form first: the reference and the ground-truth runs come from
+ * different checkouts on different machines.
+ */
+export function testIdentities(doc) {
+  if (!Array.isArray(doc?.testResults)) {
+    throw new Error('not a Vitest JSON result: missing testResults')
+  }
+  const ids = new Set()
+  for (const tr of doc.testResults) {
+    for (const ar of tr.assertionResults ?? []) {
+      ids.add(`${relativeTestPath(tr.name)}::${ar.fullName}`)
+    }
+  }
+  return ids
+}
+
+/** Reduce a runner-absolutised path to its `tests/...` form. */
+export function relativeTestPath(name) {
+  const at = name.indexOf('tests/')
+  return at === -1 ? name : name.slice(at)
+}
+
+/**
+ * Tests present in the reference run but absent from every ground-truth run.
+ * Sorted so the report is stable and diffable.
+ */
+export function uncovered(reference, groundTruthDocs) {
+  const observed = new Set()
+  for (const doc of groundTruthDocs) {
+    for (const id of testIdentities(doc)) observed.add(id)
+  }
+  return [...testIdentities(reference)].filter((id) => !observed.has(id)).sort()
+}
+
+export function parseArgs(argv) {
+  const files = []
+  const references = []
+  for (let i = 0; i < argv.length; i++) {
+    if (argv[i] === '--reference') {
+      references.push(argv[++i])
+      continue
+    }
+    files.push(argv[i])
+  }
+  return { references, files }
+}
+
+/**
+ * The largest of the candidate references, mirroring summarise.mjs's
+ * `suiteSize = Math.max(...)`. Returns the document, not the path, so callers
+ * do not read twice.
+ */
+export function widestReference(docs) {
+  return docs.reduce((widest, doc) =>
+    testIdentities(doc).size > testIdentities(widest).size ? doc : widest,
+  )
+}
+
+function main(argv) {
+  const { references, files } = parseArgs(argv)
+  if (references.length === 0 || files.length === 0) {
+    console.error(
+      'usage: ground-truth-coverage.mjs --reference <full-suite.json>... <ground-truth.json>...',
+    )
+    return 2
+  }
+
+  const read = (f) => JSON.parse(readFileSync(f, 'utf8'))
+  const referenceDoc = widestReference(references.map(read))
+  const gaps = uncovered(referenceDoc, files.map(read))
+  const total = testIdentities(referenceDoc).size
+
+  if (gaps.length === 0) {
+    console.log(
+      `Real AWS was observed on all ${total} tests, across ${files.length} run(s). ` +
+        `The synthesised ground-truth row spans nothing unobserved.`,
+    )
+    return 0
+  }
+
+  console.error(
+    `${gaps.length} of ${total} tests have no real-AWS observation behind them.\n` +
+      `The published ground-truth row spans the full suite, so these are ` +
+      `currently claimed rather than evidenced:\n`,
+  )
+  for (const id of gaps) console.error(`  ${id}`)
+  console.error(
+    `\nEither a lane did not run (check the run's artefacts) or a test file is ` +
+      `excluded from all three. See ground-truth/README.md.`,
+  )
+  return 1
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  process.exit(main(process.argv.slice(2)))
+}

--- a/scripts/ground-truth-coverage.test.mjs
+++ b/scripts/ground-truth-coverage.test.mjs
@@ -1,0 +1,133 @@
+import { describe, it, expect } from 'vitest'
+import {
+  parseArgs,
+  relativeTestPath,
+  testIdentities,
+  uncovered,
+  widestReference,
+} from './ground-truth-coverage.mjs'
+
+// Minimal Vitest-shaped result: { '<file>': ['fullName', ...] }.
+const doc = (files) => ({
+  testResults: Object.entries(files).map(([name, names]) => ({
+    name,
+    assertionResults: names.map((fullName) => ({ fullName, status: 'passed' })),
+  })),
+})
+
+const FULL = doc({
+  '/runner/repo/tests/tier1/putItem/basic.test.ts': ['PutItem > writes an item'],
+  '/runner/repo/tests/tier2/updateTable/gsi.test.ts': ['UpdateTable — add GSI > adds a hash-only GSI'],
+  '/runner/repo/tests/tier2/kinesis/streamingDestination.test.ts': ['Kinesis > enables a destination'],
+})
+
+describe('relativeTestPath', () => {
+  it('reduces a runner-absolutised path to its repo-relative form', () => {
+    expect(relativeTestPath('/home/runner/work/x/y/tests/tier1/a.test.ts')).toBe(
+      'tests/tier1/a.test.ts',
+    )
+  })
+
+  it('leaves a path with no tests/ segment alone rather than mangling it', () => {
+    expect(relativeTestPath('weird.test.ts')).toBe('weird.test.ts')
+  })
+})
+
+describe('testIdentities', () => {
+  it('keys on file and full name together', () => {
+    expect(testIdentities(doc({ '/r/tests/tier1/a.test.ts': ['s > t'] }))).toEqual(
+      new Set(['tests/tier1/a.test.ts::s > t']),
+    )
+  })
+
+  it('does not conflate same-named tests living in different files', () => {
+    const ids = testIdentities(
+      doc({
+        '/r/tests/tier1/a.test.ts': ['basic > rejects a missing key'],
+        '/r/tests/tier1/b.test.ts': ['basic > rejects a missing key'],
+      }),
+    )
+    // Two distinct identities, not one: collapsing them would let a test in b
+    // be marked observed on the strength of a run that only covered a.
+    expect(ids.size).toBe(2)
+  })
+
+  it('rejects a document that is not a Vitest result', () => {
+    expect(() => testIdentities({ schema: 1 })).toThrow(/missing testResults/)
+  })
+})
+
+describe('uncovered', () => {
+  it('reports nothing when the lanes together cover the whole suite', () => {
+    const gating = doc({ '/ci/tests/tier1/putItem/basic.test.ts': ['PutItem > writes an item'] })
+    const gsi = doc({
+      '/ci/tests/tier2/updateTable/gsi.test.ts': ['UpdateTable — add GSI > adds a hash-only GSI'],
+    })
+    const integrations = doc({
+      '/ci/tests/tier2/kinesis/streamingDestination.test.ts': ['Kinesis > enables a destination'],
+    })
+    expect(uncovered(FULL, [gating, gsi, integrations])).toEqual([])
+  })
+
+  it('names the tests a missing lane leaves unobserved', () => {
+    // The GSI lane did not run: its 1 test has no real-AWS observation, which
+    // is exactly the silence this check exists to break.
+    const gating = doc({ '/ci/tests/tier1/putItem/basic.test.ts': ['PutItem > writes an item'] })
+    const integrations = doc({
+      '/ci/tests/tier2/kinesis/streamingDestination.test.ts': ['Kinesis > enables a destination'],
+    })
+    expect(uncovered(FULL, [gating, integrations])).toEqual([
+      'tests/tier2/updateTable/gsi.test.ts::UpdateTable — add GSI > adds a hash-only GSI',
+    ])
+  })
+
+  it('counts a failed test as observed: a red answer is still an answer', () => {
+    const observedButRed = {
+      testResults: [
+        {
+          name: '/ci/tests/tier1/putItem/basic.test.ts',
+          assertionResults: [{ fullName: 'PutItem > writes an item', status: 'failed' }],
+        },
+      ],
+    }
+    const reference = doc({
+      '/r/tests/tier1/putItem/basic.test.ts': ['PutItem > writes an item'],
+    })
+    expect(uncovered(reference, [observedButRed])).toEqual([])
+  })
+
+  it('matches across checkouts, where absolute paths differ', () => {
+    const reference = doc({ '/home/runner/work/a/b/tests/tier1/a.test.ts': ['s > t'] })
+    const groundTruth = doc({ '/Users/dev/Projects/repo/tests/tier1/a.test.ts': ['s > t'] })
+    expect(uncovered(reference, [groundTruth])).toEqual([])
+  })
+
+  it('reports the whole suite when no ground truth is supplied at all', () => {
+    expect(uncovered(FULL, [])).toHaveLength(3)
+  })
+})
+
+describe('parseArgs', () => {
+  it('collects repeated references separately from the ground-truth files', () => {
+    expect(parseArgs(['--reference', 'a.json', '--reference', 'b.json', 'gt.json'])).toEqual({
+      references: ['a.json', 'b.json'],
+      files: ['gt.json'],
+    })
+  })
+})
+
+describe('widestReference', () => {
+  it('picks the largest, matching the published denominator', () => {
+    const small = doc({ '/r/tests/tier1/a.test.ts': ['s > one'] })
+    const large = doc({ '/r/tests/tier1/a.test.ts': ['s > one', 's > two'] })
+    expect(testIdentities(widestReference([small, large])).size).toBe(2)
+  })
+
+  it('a truncated emulator run cannot shrink the reference and mask a gap', () => {
+    // dynalite dying after one test must not make the check pass by comparing
+    // the ground truth against a one-test suite.
+    const truncated = doc({ '/r/tests/tier1/a.test.ts': ['s > one'] })
+    const gaps = uncovered(widestReference([truncated, FULL]), [])
+    expect(gaps).toHaveLength(3)
+  })
+})


### PR DESCRIPTION
## What this changes

The 14 UpdateTable GSI lifecycle tests have never run against real DynamoDB in
CI. A full green run was measured at 2h50m on a slow backfill night, far longer
than the gating job can absorb, so the file was excluded and left to a manual
run before merging. This gives them their own non-gating lane, and adds a check
that notices if any part of the suite loses its real-AWS observation again.

Real-AWS coverage now runs in three lanes: `test:gating`, `test:integrations`
(S3 export/import, Kinesis) and the new `test:gsi`. The GSI lane joins the
shared AWS concurrency group, because the gating job's cleanup deletes every
`_conformance_` table by prefix and would otherwise remove a table mid-backfill.
`CONFORMANCE_TARGET` is set to `gsi` rather than `dynamodb` so the indeterminate
sidecar pairs with `ground-truth/gsi.json` instead of orphaning itself.

`scripts/ground-truth-coverage.mjs` unions the three lanes after each scheduled
run and fails when any test in the suite has no real-AWS observation behind it.
It reconciles against the largest emulator run, the same rule the published
denominator uses, so it checks exactly the number the table claims. Passing
every emulator means one failed target job cannot quietly shrink the reference
and hide a gap.

It is the only real-AWS job here that is not `continue-on-error`. A slow AWS
call is not a conformance signal, but a hole in ground truth means the table is
claiming something nobody observed.

Scoring is unchanged: `summarise.mjs` has no diff and the published totals do
not move.

## Verification

Against the committed results files the check reports exactly the 17 tests with
no ground-truth observation and exits 1; with all three lanes present it reports
954/954 and exits 0. Both paths were run, along with the workflow's artefact
selection logic against a simulated layout, since each `results-*` artefact
carries stale copies of the other targets.

The lane itself is unproven until a dispatch runs it end to end. The 2h50m
figure comes from an earlier manual run, not from this workflow.

## Checklist

- ~~New or modified tests run against real AWS DynamoDB and pass~~
  - No conformance tests are added or modified. This is CI wiring plus a
    tooling script, covered by the tooling suite.
- ~~New or modified tests run against at least one emulator target and behave
  as expected~~
  - As above.
- [x] Linked issue or a short note explaining the motivation
- [x] I agree my contribution is licensed under the project's terms
  (Apache License, Version 2.0)

## Tier and scope

No tier definitions change and no scoring change: `summarise.mjs` is untouched
and the published table should not move. No regenerated artefacts are expected
from this PR. The new coverage job only runs on a schedule or a manual
dispatch, so a pull request never spends real-AWS time on it.
