### PR TITLE
Move the gating run to Sunday 04:00 UTC

### DIFF
--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -2,7 +2,7 @@ name: Conformance Tests
 
 on:
   schedule:
-    - cron: '0 6 * * 1' # 6am UTC every Monday
+    - cron: '0 4 * * 0' # 4am UTC every Sunday, when AWS is quieter
   push:
     branches: [main]
   pull_request:
@@ -104,8 +104,8 @@ jobs:
             --baseline captures/2026-07-13-empty-set-member.json \
             --region eu-west-2 --out "$RUNNER_TEMP/drift.json"
 
-      # File or update a single deduped issue so a red Monday is actionable, not a
-      # silent X. The drift verdict (if computed above) labels it aws-drift-confirmed
+      # File or update a single deduped issue so a red scheduled run is actionable,
+      # not a silent X. The drift verdict (if computed above) labels it aws-drift-confirmed
       # or likely-flake and fills the body's triage slot.
       - name: Report a deterministic failure as an issue
         if: failure() && github.event_name == 'schedule'

--- a/.github/workflows/sweep.yml
+++ b/.github/workflows/sweep.yml
@@ -11,7 +11,7 @@ name: Ground Truth Sweep
 # file landing there would fabricate phantom targets and redden the PR gate.
 on:
   schedule:
-    - cron: '0 3 * * 6' # sweep: 3am UTC Saturday, clear of Monday's gating run
+    - cron: '0 3 * * 6' # sweep: 3am UTC Saturday, clear of Sunday's gating run
     - cron: '30 5 * * *' # cleanup: daily, catching tables a dead run stranded
   workflow_dispatch:
     inputs:

--- a/scripts/cleanup-orphans.mjs
+++ b/scripts/cleanup-orphans.mjs
@@ -10,11 +10,13 @@
  * the job. Per region, so one unreachable region never blocks the others.
  *
  * The one thing it must never do is delete tables out from under a run still
- * in flight, so selection is age-based: every live run holds OIDC credentials
- * capped at two hours (role-duration-seconds: 7200 in the workflows), so no
- * legitimate `_conformance_` table can be older than its run's two-hour
- * ceiling. The three-hour default adds slack on top of that hard bound; do
- * not lower it below the credential ceiling.
+ * in flight, so selection is age-based: a live run cannot outlive the OIDC
+ * credentials it holds, so no legitimate `_conformance_` table can be older
+ * than its run's credential ceiling. That ceiling is the largest
+ * role-duration-seconds across the workflows - six hours, set by the GSI
+ * lifecycle lane, whose backfills need it. The seven-hour default adds slack
+ * on top of that hard bound; do not lower it below the credential ceiling,
+ * and raise it whenever a lane raises role-duration-seconds past six hours.
  *
  * Tables without the `_conformance_` prefix are never touched, in any region,
  * under any condition - the same contract the IAM role enforces.
@@ -35,7 +37,7 @@ import { COMMERCIAL_REGIONS } from '../src/regions.ts'
 
 const TABLE_PREFIX = '_conformance_'
 
-export const DEFAULT_MAX_AGE_HOURS = 3
+export const DEFAULT_MAX_AGE_HOURS = 7
 
 /**
  * Pure selection: the table names safe to delete. A table qualifies only when

--- a/scripts/cleanup-orphans.test.mjs
+++ b/scripts/cleanup-orphans.test.mjs
@@ -18,9 +18,11 @@ function table(name, ageHours) {
 
 describe('selectOrphans', () => {
   it('selects stray _conformance_ tables older than the threshold', () => {
+    // Ages are relative to the threshold so this tracks the credential ceiling
+    // rather than pinning a number the workflows can move out from under it.
     const tables = [
-      table('_conformance_users_170000_1', 26),
-      table('_conformance_orders_170000_2', 4),
+      table('_conformance_users_170000_1', DEFAULT_MAX_AGE_HOURS + 23),
+      table('_conformance_orders_170000_2', DEFAULT_MAX_AGE_HOURS + 1),
     ]
     expect(selectOrphans(tables, { now: NOW, maxAgeMs })).toEqual([
       '_conformance_orders_170000_2',
@@ -29,9 +31,9 @@ describe('selectOrphans', () => {
   })
 
   it('never selects a table young enough to belong to a run still in flight', () => {
-    // A live run's tables cannot outlive its two-hour credential ceiling, so
-    // anything under the three-hour default might still be in use.
-    const tables = [table('_conformance_live_170000_3', 1.5)]
+    // A live run's tables cannot outlive its six-hour credential ceiling, so
+    // anything under the seven-hour default might still be in use.
+    const tables = [table('_conformance_live_170000_3', DEFAULT_MAX_AGE_HOURS - 1)]
     expect(selectOrphans(tables, { now: NOW, maxAgeMs })).toEqual([])
   })
 

--- a/scripts/report-failure.mjs
+++ b/scripts/report-failure.mjs
@@ -11,7 +11,7 @@
  *
  * The scheduled-run workflow calls this on a deterministic ground-truth failure
  * (after retries) and threads the output onto a single deduped issue, so a red
- * Monday is actionable rather than a silent X.
+ * scheduled run is actionable rather than a silent X.
  *
  * The report is classified (scripts/lib/classify.mjs) before anything is
  * listed, because a raw `status: "failed"` cannot tell a real behavioural


### PR DESCRIPTION
## What this changes

Moves the gating conformance run from Monday 06:00 UTC to Sunday 04:00 UTC, when
AWS is quieter. The Saturday sweep is untouched and still sits clear of it.

The second commit fixes something that move surfaced. `cleanup-orphans.mjs`
deletes stray `_conformance_` tables past a fixed age, and that gate was three
hours on the reasoning that a live run cannot outlive its two-hour OIDC
credentials. The GSI lifecycle lane holds six-hour credentials, because a full
green run there was measured at close to three hours on a slow backfill night,
so a long GSI run can hold live tables well past a three-hour gate and have them
deleted from under it mid-backfill.

The gate is now seven hours, an hour clear of the longest
`role-duration-seconds` in the workflows. The test fixtures now derive their
ages from the constant rather than hardcoding numbers, so they follow it if a
lane raises its credentials again.

Neither the old schedule nor the new one actually lands the daily cleanup inside
a GSI run, so this is a latent hole rather than a live breakage, but the
reasoning the gate rests on stopped being true when the GSI lane landed.

## Checklist

- ~~New or modified tests run against real AWS DynamoDB and pass~~ - no
  conformance tests change here; this is CI scheduling and a cleanup script
- ~~New or modified tests run against at least one emulator target and behave as
  expected~~ - as above
- [x] Linked issue or a short note explaining the motivation
- [x] I agree my contribution is licensed under the project's terms
  (Apache License, Version 2.0)
