### PR TITLE
Cover the PartiQL RETURNING clause

### DIFF
--- a/README.md
+++ b/README.md
@@ -401,9 +401,9 @@ All test data must be synthetic. Don't use real names, emails, addresses, or any
 | UpdateTable | basic (throughput, billing mode) | GSI lifecycle | |
 | TransactWriteItems | | basic, conditions (incl. parens, non-existent key branch), idempotency, cancellation | error messages |
 | TransactGetItems | | basic, validation | error messages |
-| ExecuteStatement | | INSERT, SELECT, UPDATE, DELETE, parameterised | |
-| BatchExecuteStatement | | batch, partial failure | |
-| ExecuteTransaction | | atomic, rollback | |
+| ExecuteStatement | | INSERT, SELECT, UPDATE, DELETE, parameterised, RETURNING | error messages (RETURNING) |
+| BatchExecuteStatement | | batch, partial failure, RETURNING honoured | |
+| ExecuteTransaction | | atomic, rollback, RETURNING rejected | error messages (RETURNING) |
 | UpdateTimeToLive | | enable, validation | |
 | DescribeTimeToLive | | describe | |
 | TagResource | | add, list, remove, validation | |

--- a/results/tag-manifest.json
+++ b/results/tag-manifest.json
@@ -827,6 +827,13 @@
         "negative-path"
       ]
     },
+    "tests/tier3/error-messages/partiql.test.ts": {
+      "PartiQL — exact error messages": [
+        "partiql",
+        "data-plane",
+        "negative-path"
+      ]
+    },
     "tests/tier3/error-messages/putItem.test.ts": {
       "PutItem — exact error messages": [
         "put-item",

--- a/tests/tier2/partiql/batchExecuteStatement.test.ts
+++ b/tests/tier2/partiql/batchExecuteStatement.test.ts
@@ -129,6 +129,37 @@ describe('BatchExecuteStatement — PartiQL', { tags: ['partiql', 'data-plane'] 
     expect(errors[0].Error!.Code).toBe('ResourceNotFound')
   })
 
+  it('honours a RETURNING clause on a member statement', async () => {
+    const pk = 'batch-ret-allold'
+    keysToCleanup.push({ pk: { S: pk } })
+    await ddb.send(new PutItemCommand({
+      TableName: hashTableDef.name,
+      Item: { pk: { S: pk }, data: { S: 'batchgone' } },
+    }))
+
+    const result = await ddb.send(new BatchExecuteStatementCommand({
+      Statements: [
+        { Statement: `DELETE FROM "${hashTableDef.name}" WHERE pk = '${pk}' RETURNING ALL OLD *` },
+      ],
+    }))
+
+    // Unlike ExecuteTransaction, BatchExecuteStatement honours RETURNING — the
+    // deleted item surfaces on Responses[i].Item. Characterised against real
+    // AWS (eu-west-2). See #102.
+    expect(result.Responses).toBeDefined()
+    expect(result.Responses!.length).toBe(1)
+    expect(result.Responses![0].Item).toBeDefined()
+    expect(result.Responses![0].Item!.pk.S).toBe(pk)
+    expect(result.Responses![0].Item!.data.S).toBe('batchgone')
+
+    const after = await ddb.send(new GetItemCommand({
+      TableName: hashTableDef.name,
+      Key: { pk: { S: pk } },
+      ConsistentRead: true,
+    }))
+    expect(after.Item).toBeUndefined()
+  })
+
   it('rejects an empty Statements array', async () => {
     await expectDynamoError(
       () => ddb.send(new BatchExecuteStatementCommand({

--- a/tests/tier2/partiql/batchExecuteStatement.test.ts
+++ b/tests/tier2/partiql/batchExecuteStatement.test.ts
@@ -160,6 +160,70 @@ describe('BatchExecuteStatement — PartiQL', { tags: ['partiql', 'data-plane'] 
     expect(after.Item).toBeUndefined()
   })
 
+  it('honours a RETURNING ALL NEW * clause on a member UPDATE', async () => {
+    const pk = 'batch-ret-upd-allnew'
+    keysToCleanup.push({ pk: { S: pk } })
+    await ddb.send(new PutItemCommand({
+      TableName: hashTableDef.name,
+      Item: { pk: { S: pk }, data: { S: 'old' } },
+    }))
+
+    const result = await ddb.send(new BatchExecuteStatementCommand({
+      Statements: [
+        { Statement: `UPDATE "${hashTableDef.name}" SET data = 'new' WHERE pk = '${pk}' RETURNING ALL NEW *` },
+      ],
+    }))
+
+    // An UPDATE member projects the same shape as the ExecuteStatement path,
+    // onto Responses[i].Item. ALL NEW * returns the full new item incl. the key.
+    expect(result.Responses).toBeDefined()
+    expect(result.Responses!.length).toBe(1)
+    expect(result.Responses![0].Item!.pk.S).toBe(pk)
+    expect(result.Responses![0].Item!.data.S).toBe('new')
+  })
+
+  it('honours a RETURNING MODIFIED NEW * clause on a member UPDATE (only the changed attr)', async () => {
+    const pk = 'batch-ret-upd-modnew'
+    keysToCleanup.push({ pk: { S: pk } })
+    await ddb.send(new PutItemCommand({
+      TableName: hashTableDef.name,
+      Item: { pk: { S: pk }, data: { S: 'old' } },
+    }))
+
+    const result = await ddb.send(new BatchExecuteStatementCommand({
+      Statements: [
+        { Statement: `UPDATE "${hashTableDef.name}" SET data = 'new' WHERE pk = '${pk}' RETURNING MODIFIED NEW *` },
+      ],
+    }))
+
+    expect(result.Responses).toBeDefined()
+    expect(result.Responses!.length).toBe(1)
+    const item = result.Responses![0].Item
+    expect(item).toBeDefined()
+    expect(Object.keys(item!)).toEqual(['data'])
+    expect(item!.data.S).toBe('new')
+  })
+
+  it('surfaces an invalid RETURNING variant on a member DELETE as a per-statement error', async () => {
+    // The batch call itself succeeds (HTTP 200, no throw); the invalid variant
+    // surfaces per-statement with Code 'ValidationError' (not the single-statement
+    // path's thrown 'ValidationException' name) and the same verbatim message.
+    const result = await ddb.send(new BatchExecuteStatementCommand({
+      Statements: [
+        { Statement: `DELETE FROM "${hashTableDef.name}" WHERE pk = 'batch-ret-badvariant' RETURNING MODIFIED OLD *` },
+      ],
+    }))
+
+    expect(result.Responses).toBeDefined()
+    expect(result.Responses!.length).toBe(1)
+    const err = result.Responses![0].Error
+    expect(err).toBeDefined()
+    expect(err!.Code).toBe('ValidationError')
+    expect(err!.Message).toBe(
+      'Invalid returning clause: RETURNING MODIFIED OLD *. Only RETURNING ALL OLD * is allowed in DELETE statements.',
+    )
+  })
+
   it('rejects an empty Statements array', async () => {
     await expectDynamoError(
       () => ddb.send(new BatchExecuteStatementCommand({

--- a/tests/tier2/partiql/executeStatement.test.ts
+++ b/tests/tier2/partiql/executeStatement.test.ts
@@ -911,6 +911,25 @@ describe('ExecuteStatement — PartiQL', { tags: ['partiql', 'data-plane'] }, ()
     expect(item.data.S).toBe('new')
   })
 
+  it('UPDATE on a non-existent key fails ConditionalCheckFailed (PartiQL UPDATE is not an upsert)', async () => {
+    const pk = 'pq-ret-upd-ghost'
+    // Deliberately not seeded — the key must not exist.
+
+    await expectDynamoError(
+      () => ddb.send(new ExecuteStatementCommand({
+        Statement: `UPDATE "${hashTableDef.name}" SET data = 'new' WHERE pk = '${pk}' RETURNING ALL OLD *`,
+      })),
+      'ConditionalCheckFailedException',
+      'The conditional request failed',
+    )
+
+    // Not an upsert — the rejected UPDATE did not create the item.
+    const after = await ddb.send(new GetItemCommand({
+      TableName: hashTableDef.name, Key: { pk: { S: pk } }, ConsistentRead: true,
+    }))
+    expect(after.Item).toBeUndefined()
+  })
+
   // ── Error tests ───────────────────────────────────────────────────────
 
   it('rejects a statement with syntax error', async () => {

--- a/tests/tier2/partiql/executeStatement.test.ts
+++ b/tests/tier2/partiql/executeStatement.test.ts
@@ -789,6 +789,128 @@ describe('ExecuteStatement — PartiQL', { tags: ['partiql', 'data-plane'] }, ()
     expect(after.Item!.data.S).toBe('new')
   })
 
+  // ── RETURNING clause: MODIFIED projection edges ───────────────────────
+  // MODIFIED returns Items: [] (no row) when the projection would be empty —
+  // a removed attribute under NEW, or a never-existed attribute under OLD —
+  // and returns only the changed leaf for a nested SET path (the untouched
+  // sibling and the key are excluded). Characterised against real AWS
+  // (eu-west-2). See #102.
+
+  it('UPDATE RETURNING MODIFIED NEW * over a nested path returns only the changed leaf', async () => {
+    const pk = 'pq-ret-upd-nested-new'
+    keysToCleanup.push({ pk: { S: pk } })
+    await ddb.send(new PutItemCommand({
+      TableName: hashTableDef.name,
+      Item: { pk: { S: pk }, profile: { M: { sub: { S: 'old' }, sib: { S: 'keep' } } } },
+    }))
+
+    const result = await ddb.send(new ExecuteStatementCommand({
+      Statement: `UPDATE "${hashTableDef.name}" SET profile.sub = 'new' WHERE pk = '${pk}' RETURNING MODIFIED NEW *`,
+    }))
+
+    expect(result.Items).toBeDefined()
+    expect(result.Items!.length).toBe(1)
+    const item = result.Items![0]
+    // Only the changed leaf comes back — no untouched sibling, no key.
+    expect(Object.keys(item)).toEqual(['profile'])
+    expect(Object.keys(item.profile.M!)).toEqual(['sub'])
+    expect(item.profile.M!.sub.S).toBe('new')
+  })
+
+  it('UPDATE RETURNING MODIFIED OLD * over a nested path returns only the changed leaf at its old value', async () => {
+    const pk = 'pq-ret-upd-nested-old'
+    keysToCleanup.push({ pk: { S: pk } })
+    await ddb.send(new PutItemCommand({
+      TableName: hashTableDef.name,
+      Item: { pk: { S: pk }, profile: { M: { sub: { S: 'old' }, sib: { S: 'keep' } } } },
+    }))
+
+    const result = await ddb.send(new ExecuteStatementCommand({
+      Statement: `UPDATE "${hashTableDef.name}" SET profile.sub = 'new' WHERE pk = '${pk}' RETURNING MODIFIED OLD *`,
+    }))
+
+    expect(result.Items).toBeDefined()
+    expect(result.Items!.length).toBe(1)
+    const item = result.Items![0]
+    expect(Object.keys(item)).toEqual(['profile'])
+    expect(Object.keys(item.profile.M!)).toEqual(['sub'])
+    expect(item.profile.M!.sub.S).toBe('old')
+  })
+
+  it('UPDATE REMOVE RETURNING MODIFIED OLD * returns the removed attribute at its old value', async () => {
+    const pk = 'pq-ret-rem-modold'
+    keysToCleanup.push({ pk: { S: pk } })
+    await ddb.send(new PutItemCommand({
+      TableName: hashTableDef.name,
+      Item: { pk: { S: pk }, data: { S: 'old' }, keep: { S: 'same' } },
+    }))
+
+    const result = await ddb.send(new ExecuteStatementCommand({
+      Statement: `UPDATE "${hashTableDef.name}" REMOVE data WHERE pk = '${pk}' RETURNING MODIFIED OLD *`,
+    }))
+
+    expect(result.Items).toBeDefined()
+    expect(result.Items!.length).toBe(1)
+    const item = result.Items![0]
+    expect(Object.keys(item)).toEqual(['data'])
+    expect(item.data.S).toBe('old')
+  })
+
+  it('UPDATE REMOVE RETURNING MODIFIED NEW * returns an empty Items list', async () => {
+    const pk = 'pq-ret-rem-modnew'
+    keysToCleanup.push({ pk: { S: pk } })
+    await ddb.send(new PutItemCommand({
+      TableName: hashTableDef.name,
+      Item: { pk: { S: pk }, data: { S: 'old' }, keep: { S: 'same' } },
+    }))
+
+    const result = await ddb.send(new ExecuteStatementCommand({
+      Statement: `UPDATE "${hashTableDef.name}" REMOVE data WHERE pk = '${pk}' RETURNING MODIFIED NEW *`,
+    }))
+
+    // The removed attribute has no new value to project, so AWS returns no row
+    // (Items: []) rather than a row holding an empty object.
+    expect(result.Items).toBeDefined()
+    expect(result.Items!.length).toBe(0)
+  })
+
+  it('UPDATE RETURNING MODIFIED OLD * on a newly-set attribute returns an empty Items list', async () => {
+    const pk = 'pq-ret-upd-noprior-old'
+    keysToCleanup.push({ pk: { S: pk } })
+    await ddb.send(new PutItemCommand({
+      TableName: hashTableDef.name,
+      Item: { pk: { S: pk }, keep: { S: 'same' } },
+    }))
+
+    const result = await ddb.send(new ExecuteStatementCommand({
+      Statement: `UPDATE "${hashTableDef.name}" SET data = 'new' WHERE pk = '${pk}' RETURNING MODIFIED OLD *`,
+    }))
+
+    // The changed attribute had no old value, so the MODIFIED OLD projection is
+    // empty and AWS returns no row (Items: []), not a row with an empty object.
+    expect(result.Items).toBeDefined()
+    expect(result.Items!.length).toBe(0)
+  })
+
+  it('UPDATE RETURNING MODIFIED NEW * on a newly-set attribute returns the new value', async () => {
+    const pk = 'pq-ret-upd-noprior-new'
+    keysToCleanup.push({ pk: { S: pk } })
+    await ddb.send(new PutItemCommand({
+      TableName: hashTableDef.name,
+      Item: { pk: { S: pk }, keep: { S: 'same' } },
+    }))
+
+    const result = await ddb.send(new ExecuteStatementCommand({
+      Statement: `UPDATE "${hashTableDef.name}" SET data = 'new' WHERE pk = '${pk}' RETURNING MODIFIED NEW *`,
+    }))
+
+    expect(result.Items).toBeDefined()
+    expect(result.Items!.length).toBe(1)
+    const item = result.Items![0]
+    expect(Object.keys(item)).toEqual(['data'])
+    expect(item.data.S).toBe('new')
+  })
+
   // ── Error tests ───────────────────────────────────────────────────────
 
   it('rejects a statement with syntax error', async () => {

--- a/tests/tier2/partiql/executeStatement.test.ts
+++ b/tests/tier2/partiql/executeStatement.test.ts
@@ -3,6 +3,7 @@ import {
   GetItemCommand,
   PutItemCommand,
   DeleteItemCommand,
+  DynamoDBServiceException,
 } from '@aws-sdk/client-dynamodb'
 import { ddb } from '../../../src/client.js'
 import { hashTableDef, compositeTableDef, cleanupItems, expectDynamoError } from '../../../src/helpers.js'
@@ -568,6 +569,224 @@ describe('ExecuteStatement — PartiQL', { tags: ['partiql', 'data-plane'] }, ()
       TableName: hashTableDef.name, Key: { pk: { S: pk } }, ConsistentRead: true,
     }))
     expect(after.Item).toBeUndefined()
+  })
+
+  // ── RETURNING clause ──────────────────────────────────────────────────
+  // DynamoDB PartiQL accepts only `RETURNING ALL OLD *` on DELETE, and all four
+  // variants (ALL/MODIFIED x OLD/NEW) on UPDATE. The returned attributes surface
+  // on `result.Items` (an array), not on `Attributes`. `ALL *` includes the key;
+  // `MODIFIED *` returns only the changed attribute and omits the key. Behaviour
+  // characterised against real AWS (eu-west-2). See #102.
+
+  it('DELETE RETURNING ALL OLD * returns the deleted item', async () => {
+    const pk = 'pq-ret-del-hit'
+    keysToCleanup.push({ pk: { S: pk } })
+    await ddb.send(new PutItemCommand({
+      TableName: hashTableDef.name,
+      Item: { pk: { S: pk }, data: { S: 'gone' }, n: { N: '7' } },
+    }))
+
+    const result = await ddb.send(new ExecuteStatementCommand({
+      Statement: `DELETE FROM "${hashTableDef.name}" WHERE pk = '${pk}' RETURNING ALL OLD *`,
+    }))
+
+    expect(result.Items).toBeDefined()
+    expect(result.Items!.length).toBe(1)
+    expect(result.Items![0].pk.S).toBe(pk)
+    expect(result.Items![0].data.S).toBe('gone')
+    expect(result.Items![0].n.N).toBe('7')
+
+    const after = await ddb.send(new GetItemCommand({
+      TableName: hashTableDef.name, Key: { pk: { S: pk } }, ConsistentRead: true,
+    }))
+    expect(after.Item).toBeUndefined()
+  })
+
+  it('DELETE RETURNING ALL OLD * on a missing item returns an empty Items list', async () => {
+    const pk = 'pq-ret-del-miss'
+    // Ensure the key does not exist.
+    await ddb.send(new DeleteItemCommand({
+      TableName: hashTableDef.name, Key: { pk: { S: pk } },
+    }))
+
+    const result = await ddb.send(new ExecuteStatementCommand({
+      Statement: `DELETE FROM "${hashTableDef.name}" WHERE pk = '${pk}' RETURNING ALL OLD *`,
+    }))
+
+    // AWS returns an empty array — a no-op success — not undefined. This differs
+    // from the classic DeleteItem ReturnValues path (Attributes: undefined).
+    expect(result.Items).toBeDefined()
+    expect(result.Items!.length).toBe(0)
+  })
+
+  it('DELETE rejects RETURNING MODIFIED OLD * (only ALL OLD * is valid on DELETE)', async () => {
+    const pk = 'pq-ret-del-modold'
+    keysToCleanup.push({ pk: { S: pk } })
+    await ddb.send(new PutItemCommand({
+      TableName: hashTableDef.name, Item: { pk: { S: pk }, data: { S: 'x' } },
+    }))
+
+    await expectDynamoError(
+      () => ddb.send(new ExecuteStatementCommand({
+        Statement: `DELETE FROM "${hashTableDef.name}" WHERE pk = '${pk}' RETURNING MODIFIED OLD *`,
+      })),
+      'ValidationException',
+      /Only RETURNING ALL OLD \* is allowed in DELETE statements/,
+    )
+
+    // The rejected statement must not have deleted the item.
+    const after = await ddb.send(new GetItemCommand({
+      TableName: hashTableDef.name, Key: { pk: { S: pk } }, ConsistentRead: true,
+    }))
+    expect(after.Item!.data.S).toBe('x')
+  })
+
+  it('DELETE rejects RETURNING MODIFIED NEW * (only ALL OLD * is valid on DELETE)', async () => {
+    const pk = 'pq-ret-del-modnew'
+    keysToCleanup.push({ pk: { S: pk } })
+    await ddb.send(new PutItemCommand({
+      TableName: hashTableDef.name, Item: { pk: { S: pk }, data: { S: 'x' } },
+    }))
+
+    await expectDynamoError(
+      () => ddb.send(new ExecuteStatementCommand({
+        Statement: `DELETE FROM "${hashTableDef.name}" WHERE pk = '${pk}' RETURNING MODIFIED NEW *`,
+      })),
+      'ValidationException',
+      /Only RETURNING ALL OLD \* is allowed in DELETE statements/,
+    )
+
+    // The rejected statement must not have deleted the item.
+    const after = await ddb.send(new GetItemCommand({
+      TableName: hashTableDef.name, Key: { pk: { S: pk } }, ConsistentRead: true,
+    }))
+    expect(after.Item!.data.S).toBe('x')
+  })
+
+  it('DELETE rejects RETURNING ALL NEW * with a 400, not a 500', async () => {
+    const pk = 'pq-ret-del-allnew'
+    keysToCleanup.push({ pk: { S: pk } })
+    await ddb.send(new PutItemCommand({
+      TableName: hashTableDef.name, Item: { pk: { S: pk }, data: { S: 'x' } },
+    }))
+
+    try {
+      await ddb.send(new ExecuteStatementCommand({
+        Statement: `DELETE FROM "${hashTableDef.name}" WHERE pk = '${pk}' RETURNING ALL NEW *`,
+      }))
+      expect.unreachable('should have thrown')
+    } catch (e) {
+      expect(e).toBeInstanceOf(DynamoDBServiceException)
+      const err = e as DynamoDBServiceException
+      expect(err.name).toBe('ValidationException')
+      expect(err.$metadata.httpStatusCode).toBe(400)
+    }
+
+    // The rejected statement must not have deleted the item.
+    const after = await ddb.send(new GetItemCommand({
+      TableName: hashTableDef.name, Key: { pk: { S: pk } }, ConsistentRead: true,
+    }))
+    expect(after.Item!.data.S).toBe('x')
+  })
+
+  it('UPDATE RETURNING ALL OLD * returns the full prior item', async () => {
+    const pk = 'pq-ret-upd-allold'
+    keysToCleanup.push({ pk: { S: pk } })
+    await ddb.send(new PutItemCommand({
+      TableName: hashTableDef.name,
+      Item: { pk: { S: pk }, data: { S: 'old' }, keep: { S: 'same' } },
+    }))
+
+    const result = await ddb.send(new ExecuteStatementCommand({
+      Statement: `UPDATE "${hashTableDef.name}" SET data = 'new' WHERE pk = '${pk}' RETURNING ALL OLD *`,
+    }))
+
+    expect(result.Items).toBeDefined()
+    expect(result.Items!.length).toBe(1)
+    const item = result.Items![0]
+    expect(item.pk.S).toBe(pk)
+    expect(item.data.S).toBe('old')   // pre-update value
+    expect(item.keep.S).toBe('same')  // untouched attribute present
+
+    const after = await ddb.send(new GetItemCommand({
+      TableName: hashTableDef.name, Key: { pk: { S: pk } }, ConsistentRead: true,
+    }))
+    expect(after.Item!.data.S).toBe('new')
+  })
+
+  it('UPDATE RETURNING MODIFIED OLD * returns only the changed attribute (old value, no key)', async () => {
+    const pk = 'pq-ret-upd-modold'
+    keysToCleanup.push({ pk: { S: pk } })
+    await ddb.send(new PutItemCommand({
+      TableName: hashTableDef.name,
+      Item: { pk: { S: pk }, data: { S: 'old' }, keep: { S: 'same' } },
+    }))
+
+    const result = await ddb.send(new ExecuteStatementCommand({
+      Statement: `UPDATE "${hashTableDef.name}" SET data = 'new' WHERE pk = '${pk}' RETURNING MODIFIED OLD *`,
+    }))
+
+    expect(result.Items).toBeDefined()
+    expect(result.Items!.length).toBe(1)
+    const item = result.Items![0]
+    expect(item.data.S).toBe('old')
+    // MODIFIED returns only the changed attribute — no key, no untouched attrs.
+    expect(Object.keys(item)).toEqual(['data'])
+
+    // The payload echoes the OLD value, so confirm the write actually applied.
+    const after = await ddb.send(new GetItemCommand({
+      TableName: hashTableDef.name, Key: { pk: { S: pk } }, ConsistentRead: true,
+    }))
+    expect(after.Item!.data.S).toBe('new')
+  })
+
+  it('UPDATE RETURNING ALL NEW * returns the full new item', async () => {
+    const pk = 'pq-ret-upd-allnew'
+    keysToCleanup.push({ pk: { S: pk } })
+    await ddb.send(new PutItemCommand({
+      TableName: hashTableDef.name,
+      Item: { pk: { S: pk }, data: { S: 'old' }, keep: { S: 'same' } },
+    }))
+
+    const result = await ddb.send(new ExecuteStatementCommand({
+      Statement: `UPDATE "${hashTableDef.name}" SET data = 'new' WHERE pk = '${pk}' RETURNING ALL NEW *`,
+    }))
+
+    expect(result.Items).toBeDefined()
+    expect(result.Items!.length).toBe(1)
+    const item = result.Items![0]
+    expect(item.pk.S).toBe(pk)
+    expect(item.data.S).toBe('new')   // post-update value
+    expect(item.keep.S).toBe('same')  // untouched attribute present
+
+    const after = await ddb.send(new GetItemCommand({
+      TableName: hashTableDef.name, Key: { pk: { S: pk } }, ConsistentRead: true,
+    }))
+    expect(after.Item!.data.S).toBe('new')
+  })
+
+  it('UPDATE RETURNING MODIFIED NEW * returns only the changed attribute (new value, no key)', async () => {
+    const pk = 'pq-ret-upd-modnew'
+    keysToCleanup.push({ pk: { S: pk } })
+    await ddb.send(new PutItemCommand({
+      TableName: hashTableDef.name,
+      Item: { pk: { S: pk }, data: { S: 'old' }, keep: { S: 'same' } },
+    }))
+
+    const result = await ddb.send(new ExecuteStatementCommand({
+      Statement: `UPDATE "${hashTableDef.name}" SET data = 'new' WHERE pk = '${pk}' RETURNING MODIFIED NEW *`,
+    }))
+
+    expect(result.Items).toBeDefined()
+    expect(result.Items!.length).toBe(1)
+    const item = result.Items![0]
+    expect(item.data.S).toBe('new')
+    expect(Object.keys(item)).toEqual(['data'])
+
+    const after = await ddb.send(new GetItemCommand({
+      TableName: hashTableDef.name, Key: { pk: { S: pk } }, ConsistentRead: true,
+    }))
+    expect(after.Item!.data.S).toBe('new')
   })
 
   // ── Error tests ───────────────────────────────────────────────────────

--- a/tests/tier2/partiql/executeTransaction.test.ts
+++ b/tests/tier2/partiql/executeTransaction.test.ts
@@ -184,6 +184,37 @@ describe('ExecuteTransaction — PartiQL', { tags: ['partiql', 'data-plane'] }, 
     expect(replayEntry?.WriteCapacityUnits).toBeUndefined()
   })
 
+  it('rejects a RETURNING clause inside a transaction statement', async () => {
+    const pk = 'txn-ret-reject'
+    keysToCleanup.push({ pk: { S: pk } })
+    await ddb.send(new PutItemCommand({
+      TableName: hashTableDef.name,
+      Item: { pk: { S: pk }, data: { S: 'txnold' } },
+    }))
+
+    // ExecuteTransaction rejects RETURNING up front with a top-level
+    // ValidationException (not a TransactionCanceledException), so no statement
+    // in the transaction applies. Characterised against real AWS (eu-west-2).
+    // See #102.
+    await expectDynamoError(
+      () => ddb.send(new ExecuteTransactionCommand({
+        TransactStatements: [
+          { Statement: `UPDATE "${hashTableDef.name}" SET data = 'txnnew' WHERE pk = '${pk}' RETURNING ALL NEW *` },
+        ],
+      })),
+      'ValidationException',
+      /RETURNING clause is not supported in ExecuteTransaction/,
+    )
+
+    // The write did not apply — the item is unchanged.
+    const after = await ddb.send(new GetItemCommand({
+      TableName: hashTableDef.name,
+      Key: { pk: { S: pk } },
+      ConsistentRead: true,
+    }))
+    expect(after.Item!.data.S).toBe('txnold')
+  })
+
   it('rejects empty TransactStatements', async () => {
     await expectDynamoError(
       () => ddb.send(new ExecuteTransactionCommand({

--- a/tests/tier3/error-messages/partiql.test.ts
+++ b/tests/tier3/error-messages/partiql.test.ts
@@ -1,0 +1,92 @@
+import {
+  ExecuteStatementCommand,
+  ExecuteTransactionCommand,
+  DynamoDBServiceException,
+} from '@aws-sdk/client-dynamodb'
+import { ddb } from '../../../src/client.js'
+import { hashTableDef } from '../../../src/helpers.js'
+
+// Exact AWS strings for the PartiQL RETURNING rejections, pinned against real
+// AWS (eu-west-2). Tier 2 (tests/tier2/partiql/) asserts the error shape; this
+// file pins the verbatim messages. Only DELETE's invalid RETURNING variants and
+// ExecuteTransaction reject the clause — BatchExecuteStatement honours it, so it
+// has no rejection string to pin. See #102.
+describe('PartiQL — exact error messages', { tags: ['partiql', 'data-plane', 'negative-path'] }, () => {
+  let supported = true
+
+  beforeAll(async () => {
+    try {
+      await ddb.send(new ExecuteStatementCommand({
+        Statement: `SELECT * FROM "${hashTableDef.name}" WHERE pk = 'partiql-canary'`,
+      }))
+    } catch (e: unknown) {
+      if (e instanceof Error && (e.name === 'UnknownOperationException' || e.name === 'UnrecognizedClientException')) {
+        supported = false
+      }
+    }
+  })
+
+  beforeEach(({ skip }) => { if (!supported) skip() })
+
+  it('DELETE RETURNING MODIFIED OLD * — exact message', async () => {
+    try {
+      await ddb.send(new ExecuteStatementCommand({
+        Statement: `DELETE FROM "${hashTableDef.name}" WHERE pk = 'x' RETURNING MODIFIED OLD *`,
+      }))
+      expect.unreachable('should have thrown')
+    } catch (err) {
+      expect(err).toBeInstanceOf(DynamoDBServiceException)
+      expect((err as DynamoDBServiceException).name).toBe('ValidationException')
+      expect((err as DynamoDBServiceException).message).toBe(
+        'Invalid returning clause: RETURNING MODIFIED OLD *. Only RETURNING ALL OLD * is allowed in DELETE statements.',
+      )
+    }
+  })
+
+  it('DELETE RETURNING ALL NEW * — exact message', async () => {
+    try {
+      await ddb.send(new ExecuteStatementCommand({
+        Statement: `DELETE FROM "${hashTableDef.name}" WHERE pk = 'x' RETURNING ALL NEW *`,
+      }))
+      expect.unreachable('should have thrown')
+    } catch (err) {
+      expect(err).toBeInstanceOf(DynamoDBServiceException)
+      expect((err as DynamoDBServiceException).name).toBe('ValidationException')
+      expect((err as DynamoDBServiceException).message).toBe(
+        'Invalid returning clause: RETURNING ALL NEW *. Only RETURNING ALL OLD * is allowed in DELETE statements.',
+      )
+    }
+  })
+
+  it('DELETE RETURNING MODIFIED NEW * — exact message', async () => {
+    try {
+      await ddb.send(new ExecuteStatementCommand({
+        Statement: `DELETE FROM "${hashTableDef.name}" WHERE pk = 'x' RETURNING MODIFIED NEW *`,
+      }))
+      expect.unreachable('should have thrown')
+    } catch (err) {
+      expect(err).toBeInstanceOf(DynamoDBServiceException)
+      expect((err as DynamoDBServiceException).name).toBe('ValidationException')
+      expect((err as DynamoDBServiceException).message).toBe(
+        'Invalid returning clause: RETURNING MODIFIED NEW *. Only RETURNING ALL OLD * is allowed in DELETE statements.',
+      )
+    }
+  })
+
+  it('ExecuteTransaction with a RETURNING member — exact message', async () => {
+    try {
+      await ddb.send(new ExecuteTransactionCommand({
+        TransactStatements: [
+          { Statement: `UPDATE "${hashTableDef.name}" SET data = 'v' WHERE pk = 'x' RETURNING ALL NEW *` },
+        ],
+      }))
+      expect.unreachable('should have thrown')
+    } catch (err) {
+      expect(err).toBeInstanceOf(DynamoDBServiceException)
+      expect((err as DynamoDBServiceException).name).toBe('ValidationException')
+      expect((err as DynamoDBServiceException).message).toBe(
+        'Validation failed in TransactStatements[0]: RETURNING clause is not supported in ExecuteTransaction.',
+      )
+    }
+  })
+})


### PR DESCRIPTION
## What this changes

Adds conformance coverage for the PartiQL `RETURNING` clause (#102), which no tier exercised, plus the UPDATE-side edges around it. Every case was captured against real AWS in eu-west-2 first, then pinned:

- `DELETE ... RETURNING ALL OLD *` returns the deleted item on a hit and an empty `Items` list (not `undefined`) on a miss; the three other DELETE variants are rejected, since only `ALL OLD *` is valid there.
- UPDATE's four variants: `ALL *` returns the full item including the key, `MODIFIED *` returns only the changed attribute and omits the key, across OLD and NEW.
- `MODIFIED` edges: over a nested `SET path.leaf` it returns only the changed leaf, not the whole attribute; and when the projection would be empty (a removed attribute under `NEW`, or a never-existed attribute under `OLD`) AWS returns `Items: []`, not a row holding an empty object.
- `BatchExecuteStatement` honours the clause on `Responses[].Item`, and surfaces an invalid DELETE variant as a per-statement `Error` (`Code: ValidationError`), not a throw. `ExecuteTransaction` rejects the clause with a top-level `ValidationException`.
- PartiQL `UPDATE` on a non-existent key raises `ConditionalCheckFailedException` - it is not an upsert.

tier2 asserts the response shapes; a new `tests/tier3/error-messages/partiql.test.ts` pins the four exact rejection strings. README coverage matrix updated.

## Checklist

- [x] New or modified tests run against real AWS DynamoDB and pass
- ~~New or modified tests run against at least one emulator target and behave as expected~~ - N/A: the PartiQL suite self-skips on targets without PartiQL support, so there is no emulator behaviour to assert here.
- [x] Linked issue or a short note explaining the motivation (#102)
- [x] I agree my contribution is licensed under the project's terms (Apache License, Version 2.0)

## Tier and scope

Touches tier2 (`partiql/`) and adds a tier3 error-messages file; both run in the existing gating lane. The new tier3 describe means `results/tag-manifest.json` is regenerated (`npm run results:tags`), included in the diff. No results-table or target-config changes; those regenerate in CI as usual.
