### PR TITLE
Pin the PartiQL RETURNING MODIFIED list-index and batch empty-projection edges

### DIFF
--- a/tests/tier2/partiql/batchExecuteStatement.test.ts
+++ b/tests/tier2/partiql/batchExecuteStatement.test.ts
@@ -204,6 +204,35 @@ describe('BatchExecuteStatement — PartiQL', { tags: ['partiql', 'data-plane'] 
     expect(item!.data.S).toBe('new')
   })
 
+  it('omits Item when a member UPDATE produces an empty MODIFIED projection', async () => {
+    const pk = 'batch-ret-upd-modempty'
+    keysToCleanup.push({ pk: { S: pk } })
+    await ddb.send(new PutItemCommand({
+      TableName: hashTableDef.name,
+      Item: { pk: { S: pk }, data: { S: 'old' } },
+    }))
+
+    const result = await ddb.send(new BatchExecuteStatementCommand({
+      Statements: [
+        { Statement: `UPDATE "${hashTableDef.name}" REMOVE data WHERE pk = '${pk}' RETURNING MODIFIED NEW *` },
+      ],
+    }))
+
+    // ExecuteStatement expresses an empty MODIFIED projection as Items: [];
+    // the batch path's singular Item field cannot hold an empty row, so the
+    // field is omitted entirely (not Item: {}). TableName is still echoed.
+    expect(result.Responses).toBeDefined()
+    expect(result.Responses!.length).toBe(1)
+    expect(result.Responses![0].Item).toBeUndefined()
+    expect(result.Responses![0].TableName).toBe(hashTableDef.name)
+
+    // The member statement did apply: the attribute is gone.
+    const after = await ddb.send(new GetItemCommand({
+      TableName: hashTableDef.name, Key: { pk: { S: pk } }, ConsistentRead: true,
+    }))
+    expect(after.Item!.data).toBeUndefined()
+  })
+
   it('surfaces an invalid RETURNING variant on a member DELETE as a per-statement error', async () => {
     // The batch call itself succeeds (HTTP 200, no throw); the invalid variant
     // surfaces per-statement with Code 'ValidationError' (not the single-statement

--- a/tests/tier2/partiql/executeStatement.test.ts
+++ b/tests/tier2/partiql/executeStatement.test.ts
@@ -911,6 +911,55 @@ describe('ExecuteStatement — PartiQL', { tags: ['partiql', 'data-plane'] }, ()
     expect(item.data.S).toBe('new')
   })
 
+  it('UPDATE RETURNING MODIFIED NEW * on a list index returns only the changed element', async () => {
+    const pk = 'pq-ret-upd-lidx-new'
+    keysToCleanup.push({ pk: { S: pk } })
+    await ddb.send(new PutItemCommand({
+      TableName: hashTableDef.name,
+      Item: { pk: { S: pk }, tags: { L: [{ S: 'a' }, { S: 'b' }] } },
+    }))
+
+    const result = await ddb.send(new ExecuteStatementCommand({
+      Statement: `UPDATE "${hashTableDef.name}" SET tags[0] = 'x' WHERE pk = '${pk}' RETURNING MODIFIED NEW *`,
+    }))
+
+    // The list analogue of the nested-map changed-leaf rule: only the changed
+    // element comes back, in list shape, its index collapsed to 0. No key, no
+    // untouched sibling elements.
+    expect(result.Items).toBeDefined()
+    expect(result.Items!.length).toBe(1)
+    const item = result.Items![0]
+    expect(Object.keys(item)).toEqual(['tags'])
+    expect(item.tags.L!.length).toBe(1)
+    expect(item.tags.L![0].S).toBe('x')
+
+    // And the write is a genuine list-index SET: the untouched element survives.
+    const after = await ddb.send(new GetItemCommand({
+      TableName: hashTableDef.name, Key: { pk: { S: pk } }, ConsistentRead: true,
+    }))
+    expect(after.Item!.tags.L!.map(v => v.S)).toEqual(['x', 'b'])
+  })
+
+  it('UPDATE RETURNING MODIFIED OLD * on a list index returns only the prior element', async () => {
+    const pk = 'pq-ret-upd-lidx-old'
+    keysToCleanup.push({ pk: { S: pk } })
+    await ddb.send(new PutItemCommand({
+      TableName: hashTableDef.name,
+      Item: { pk: { S: pk }, tags: { L: [{ S: 'a' }, { S: 'b' }] } },
+    }))
+
+    const result = await ddb.send(new ExecuteStatementCommand({
+      Statement: `UPDATE "${hashTableDef.name}" SET tags[0] = 'x' WHERE pk = '${pk}' RETURNING MODIFIED OLD *`,
+    }))
+
+    expect(result.Items).toBeDefined()
+    expect(result.Items!.length).toBe(1)
+    const item = result.Items![0]
+    expect(Object.keys(item)).toEqual(['tags'])
+    expect(item.tags.L!.length).toBe(1)
+    expect(item.tags.L![0].S).toBe('a')
+  })
+
   it('UPDATE on a non-existent key fails ConditionalCheckFailed (PartiQL UPDATE is not an upsert)', async () => {
     const pk = 'pq-ret-upd-ghost'
     // Deliberately not seeded — the key must not exist.


### PR DESCRIPTION
## What this changes

Pins two more PartiQL `RETURNING MODIFIED` edges, captured against real AWS (eu-west-2, 2026-07-21) as a follow-up to the coverage landed for #102:

- A `BatchExecuteStatement` member whose MODIFIED projection is empty omits the singular `Item` field entirely - the batch shape of ExecuteStatement's `Items: []` - while still echoing `TableName`.
- A list-index `SET tags[0]` projects only the changed element, in list shape with the index collapsed to 0, and performs a genuine list-index write (the untouched element survives).

## Checklist

- [x] New or modified tests run against real AWS DynamoDB and pass (eu-west-2, 54/54 across the two files)
- [ ] New or modified tests run against at least one emulator target and behave as expected - not run this pass; the list-index pin encodes real-AWS behaviour a target that treats `tags[0]` as a literal key will sit red against, which is the point of the pin
- [x] Linked issue or a short note explaining the motivation
- [x] I agree my contribution is licensed under the project's terms (Apache License, Version 2.0)
