### PR TITLE
test(partiql): pin RETURNING MODIFIED shapes over list indices

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ broadened, and targets brought into the run. Newest first.
 
 ## 2026-07-21 (2.1.0)
 
-Grew to 979 tests, up 25, all characterised against real DynamoDB across the
+Grew to 995 tests, up 41, all characterised against real DynamoDB across the
 per-region ground truth 2.0.0 put in place. New coverage is PartiQL's
 RETURNING clause; the GSI lifecycle also joins the ground truth, and the
 sweep's drift classifier gains a converged case.
@@ -21,6 +21,18 @@ sweep's drift classifier gains a converged case.
   non-upsert paths round it out: INSERT on an existing item, and UPDATE or
   DELETE behind a false predicate, fail ConditionalCheckFailed and leave the
   item untouched.
+- PartiQL RETURNING over list indices (#102): the MODIFIED projection shapes
+  for a list-index `SET` or `REMOVE`, pinned against real AWS. The projection
+  reads the literal index against the resulting list (`MODIFIED NEW *`) or the
+  prior list (`MODIFIED OLD *`): an in-range index returns its element, an
+  out-of-range one returns nothing, and multiple changed indices pack into a
+  dense list in ascending index order. So a non-zero index collapses to one
+  element, an append projects only when the index lands inside the new list,
+  and removing the last index yields nothing under NEW while a middle REMOVE
+  returns the shifted element. Setting an index on an absent attribute is
+  rejected, not auto-created. In BatchExecuteStatement a member that fails to
+  parse surfaces per-statement with the short `Code: ValidationError`, the same
+  Code as an execution failure, and does not fail the batch.
 - GSI lifecycle in the ground truth (#100): the 14 UpdateTable GSI lifecycle
   tests are now observed by the weekly sweep and recorded as per-region ground
   truth. They are the one slice the gating run drops for runtime, so they were

--- a/README.md
+++ b/README.md
@@ -310,7 +310,7 @@ tests/
     describeTable/          # basic
     listTables/             # basic
     updateTable/            # basic
-  tier2/                    # ~180 tests
+  tier2/                    # ~196 tests
     transactions/           # transactWrite, transactGet
     partiql/                # executeStatement, batchExecuteStatement, executeTransaction
     ttl/                    # basic

--- a/tests/tier2/partiql/batchExecuteStatement.test.ts
+++ b/tests/tier2/partiql/batchExecuteStatement.test.ts
@@ -253,6 +253,42 @@ describe('BatchExecuteStatement — PartiQL', { tags: ['partiql', 'data-plane'] 
     )
   })
 
+  it('surfaces a malformed member statement as a per-statement ValidationError without failing the batch', async () => {
+    const pk = 'batch-parse-ok'
+    keysToCleanup.push({ pk: { S: pk } })
+    await ddb.send(new PutItemCommand({
+      TableName: hashTableDef.name,
+      Item: { pk: { S: pk }, data: { S: 'valid' } },
+    }))
+
+    // A member that fails to parse (SLECT) surfaces per-statement with the short
+    // Code 'ValidationError' — the same Code as an execution error, not the
+    // single-statement path's thrown 'ValidationException'. The batch call itself
+    // returns 200 and a valid sibling member still executes. Characterised against
+    // real AWS (eu-west-2). See #102.
+    const result = await ddb.send(new BatchExecuteStatementCommand({
+      Statements: [
+        { Statement: `SLECT * FROM "${hashTableDef.name}" WHERE pk = '${pk}'` },
+        { Statement: `SELECT * FROM "${hashTableDef.name}" WHERE pk = '${pk}'` },
+      ],
+    }))
+
+    expect(result.Responses).toBeDefined()
+    expect(result.Responses!.length).toBe(2)
+
+    const err = result.Responses![0].Error
+    expect(err).toBeDefined()
+    expect(err!.Code).toBe('ValidationError')
+    expect(err!.Message).toBe(
+      "Statement wasn't well formed, can't be processed: Expected data manipulation",
+    )
+
+    // The valid sibling still executed — a malformed member does not poison the batch.
+    expect(result.Responses![1].Error).toBeUndefined()
+    expect(result.Responses![1].Item).toBeDefined()
+    expect(result.Responses![1].Item!.data.S).toBe('valid')
+  })
+
   it('rejects an empty Statements array', async () => {
     await expectDynamoError(
       () => ddb.send(new BatchExecuteStatementCommand({

--- a/tests/tier2/partiql/executeStatement.test.ts
+++ b/tests/tier2/partiql/executeStatement.test.ts
@@ -960,6 +960,368 @@ describe('ExecuteStatement — PartiQL', { tags: ['partiql', 'data-plane'] }, ()
     expect(item.tags.L![0].S).toBe('a')
   })
 
+  // ── RETURNING clause: MODIFIED over list-index edges ──────────────────
+  // Extends the single-index-0 case above. MODIFIED projects each path named
+  // in the statement against the relevant item (new item for NEW, old item for
+  // OLD): a path that still resolves contributes its element, one that no longer
+  // resolves contributes nothing, and contributed list elements come back as a
+  // dense list in ascending index order (positions are not preserved). So a
+  // non-zero index collapses to a single element, multiple indices pack densely,
+  // an out-of-range append projects nothing, and a REMOVE shifts rather than
+  // clears the index. Characterised against real AWS (eu-west-2). See #102.
+
+  it('UPDATE RETURNING MODIFIED NEW * on a non-zero list index returns only the changed element', async () => {
+    const pk = 'pq-ret-upd-lidx-nz-new'
+    keysToCleanup.push({ pk: { S: pk } })
+    await ddb.send(new PutItemCommand({
+      TableName: hashTableDef.name,
+      Item: { pk: { S: pk }, tags: { L: [{ S: 'a' }, { S: 'b' }, { S: 'c' }] } },
+    }))
+
+    const result = await ddb.send(new ExecuteStatementCommand({
+      Statement: `UPDATE "${hashTableDef.name}" SET tags[2] = 'y' WHERE pk = '${pk}' RETURNING MODIFIED NEW *`,
+    }))
+
+    // The changed element comes back as a single-element list whatever its source
+    // index — index 2 collapses to projection index 0, the same as index 0 did.
+    expect(result.Items).toBeDefined()
+    expect(result.Items!.length).toBe(1)
+    const item = result.Items![0]
+    expect(Object.keys(item)).toEqual(['tags'])
+    expect(item.tags.L!.map(v => v.S)).toEqual(['y'])
+
+    const after = await ddb.send(new GetItemCommand({
+      TableName: hashTableDef.name, Key: { pk: { S: pk } }, ConsistentRead: true,
+    }))
+    expect(after.Item!.tags.L!.map(v => v.S)).toEqual(['a', 'b', 'y'])
+  })
+
+  it('UPDATE RETURNING MODIFIED OLD * on a non-zero list index returns the prior element', async () => {
+    const pk = 'pq-ret-upd-lidx-nz-old'
+    keysToCleanup.push({ pk: { S: pk } })
+    await ddb.send(new PutItemCommand({
+      TableName: hashTableDef.name,
+      Item: { pk: { S: pk }, tags: { L: [{ S: 'a' }, { S: 'b' }, { S: 'c' }] } },
+    }))
+
+    const result = await ddb.send(new ExecuteStatementCommand({
+      Statement: `UPDATE "${hashTableDef.name}" SET tags[2] = 'y' WHERE pk = '${pk}' RETURNING MODIFIED OLD *`,
+    }))
+
+    expect(result.Items).toBeDefined()
+    expect(result.Items!.length).toBe(1)
+    const item = result.Items![0]
+    expect(Object.keys(item)).toEqual(['tags'])
+    expect(item.tags.L!.map(v => v.S)).toEqual(['c'])
+  })
+
+  it('UPDATE RETURNING MODIFIED NEW * over multiple list indices returns a dense pack of the changed elements', async () => {
+    const pk = 'pq-ret-upd-lidx-multi-new'
+    keysToCleanup.push({ pk: { S: pk } })
+    await ddb.send(new PutItemCommand({
+      TableName: hashTableDef.name,
+      Item: { pk: { S: pk }, tags: { L: [{ S: 'a' }, { S: 'b' }, { S: 'c' }] } },
+    }))
+
+    const result = await ddb.send(new ExecuteStatementCommand({
+      Statement: `UPDATE "${hashTableDef.name}" SET tags[0] = 'x', tags[2] = 'y' WHERE pk = '${pk}' RETURNING MODIFIED NEW *`,
+    }))
+
+    // Both changed elements come back, packed into a dense list in ascending
+    // index order. The untouched element at index 1 is dropped and 'y' sits at
+    // projection index 1, not 2 — this is not a positional or sparse projection.
+    expect(result.Items).toBeDefined()
+    expect(result.Items!.length).toBe(1)
+    const item = result.Items![0]
+    expect(Object.keys(item)).toEqual(['tags'])
+    expect(item.tags.L!.map(v => v.S)).toEqual(['x', 'y'])
+
+    const after = await ddb.send(new GetItemCommand({
+      TableName: hashTableDef.name, Key: { pk: { S: pk } }, ConsistentRead: true,
+    }))
+    expect(after.Item!.tags.L!.map(v => v.S)).toEqual(['x', 'b', 'y'])
+  })
+
+  it('UPDATE RETURNING MODIFIED OLD * over multiple list indices returns the prior elements densely', async () => {
+    const pk = 'pq-ret-upd-lidx-multi-old'
+    keysToCleanup.push({ pk: { S: pk } })
+    await ddb.send(new PutItemCommand({
+      TableName: hashTableDef.name,
+      Item: { pk: { S: pk }, tags: { L: [{ S: 'a' }, { S: 'b' }, { S: 'c' }] } },
+    }))
+
+    const result = await ddb.send(new ExecuteStatementCommand({
+      Statement: `UPDATE "${hashTableDef.name}" SET tags[0] = 'x', tags[2] = 'y' WHERE pk = '${pk}' RETURNING MODIFIED OLD *`,
+    }))
+
+    expect(result.Items).toBeDefined()
+    expect(result.Items!.length).toBe(1)
+    const item = result.Items![0]
+    expect(Object.keys(item)).toEqual(['tags'])
+    expect(item.tags.L!.map(v => v.S)).toEqual(['a', 'c'])
+  })
+
+  it('UPDATE RETURNING MODIFIED NEW * packs changed indices in ascending index order, not statement order', async () => {
+    const pk = 'pq-ret-upd-lidx-order'
+    keysToCleanup.push({ pk: { S: pk } })
+    await ddb.send(new PutItemCommand({
+      TableName: hashTableDef.name,
+      Item: { pk: { S: pk }, tags: { L: [{ S: 'a' }, { S: 'b' }, { S: 'c' }] } },
+    }))
+
+    // The statement lists the higher index first, but the projection still comes
+    // back in ascending index order ('x' from index 0 before 'y' from index 2),
+    // so the dense pack is ordered by index, not by the order of the SET clauses.
+    const result = await ddb.send(new ExecuteStatementCommand({
+      Statement: `UPDATE "${hashTableDef.name}" SET tags[2] = 'y', tags[0] = 'x' WHERE pk = '${pk}' RETURNING MODIFIED NEW *`,
+    }))
+
+    expect(result.Items).toBeDefined()
+    expect(result.Items!.length).toBe(1)
+    const item = result.Items![0]
+    expect(Object.keys(item)).toEqual(['tags'])
+    expect(item.tags.L!.map(v => v.S)).toEqual(['x', 'y'])
+
+    const after = await ddb.send(new GetItemCommand({
+      TableName: hashTableDef.name, Key: { pk: { S: pk } }, ConsistentRead: true,
+    }))
+    expect(after.Item!.tags.L!.map(v => v.S)).toEqual(['x', 'b', 'y'])
+  })
+
+  it('UPDATE RETURNING MODIFIED OLD * packs changed indices in ascending index order, not statement order', async () => {
+    const pk = 'pq-ret-upd-lidx-order-old'
+    keysToCleanup.push({ pk: { S: pk } })
+    await ddb.send(new PutItemCommand({
+      TableName: hashTableDef.name,
+      Item: { pk: { S: pk }, tags: { L: [{ S: 'a' }, { S: 'b' }, { S: 'c' }] } },
+    }))
+
+    // OLD sorts by index too: the statement lists tags[2] before tags[0], but the
+    // prior values come back ['a','c'] (index 0 then index 2), not ['c','a'].
+    const result = await ddb.send(new ExecuteStatementCommand({
+      Statement: `UPDATE "${hashTableDef.name}" SET tags[2] = 'y', tags[0] = 'x' WHERE pk = '${pk}' RETURNING MODIFIED OLD *`,
+    }))
+
+    expect(result.Items).toBeDefined()
+    expect(result.Items!.length).toBe(1)
+    const item = result.Items![0]
+    expect(Object.keys(item)).toEqual(['tags'])
+    expect(item.tags.L!.map(v => v.S)).toEqual(['a', 'c'])
+  })
+
+  it('UPDATE RETURNING MODIFIED NEW * on an out-of-range list index (append) returns an empty Items list', async () => {
+    const pk = 'pq-ret-upd-lidx-append-new'
+    keysToCleanup.push({ pk: { S: pk } })
+    await ddb.send(new PutItemCommand({
+      TableName: hashTableDef.name,
+      Item: { pk: { S: pk }, tags: { L: [{ S: 'a' }, { S: 'b' }] } },
+    }))
+
+    const result = await ddb.send(new ExecuteStatementCommand({
+      Statement: `UPDATE "${hashTableDef.name}" SET tags[5] = 'c' WHERE pk = '${pk}' RETURNING MODIFIED NEW *`,
+    }))
+
+    // The write appends at the end (the index is clamped to the length), but the
+    // projection resolves the literal path tags[5] against the new 3-element list,
+    // where it is out of range — so nothing is projected and AWS returns no row.
+    expect(result.Items).toBeDefined()
+    expect(result.Items!.length).toBe(0)
+
+    // The append still applied.
+    const after = await ddb.send(new GetItemCommand({
+      TableName: hashTableDef.name, Key: { pk: { S: pk } }, ConsistentRead: true,
+    }))
+    expect(after.Item!.tags.L!.map(v => v.S)).toEqual(['a', 'b', 'c'])
+  })
+
+  it('UPDATE RETURNING MODIFIED OLD * on an out-of-range list index (append) returns an empty Items list', async () => {
+    const pk = 'pq-ret-upd-lidx-append-old'
+    keysToCleanup.push({ pk: { S: pk } })
+    await ddb.send(new PutItemCommand({
+      TableName: hashTableDef.name,
+      Item: { pk: { S: pk }, tags: { L: [{ S: 'a' }, { S: 'b' }] } },
+    }))
+
+    const result = await ddb.send(new ExecuteStatementCommand({
+      Statement: `UPDATE "${hashTableDef.name}" SET tags[5] = 'c' WHERE pk = '${pk}' RETURNING MODIFIED OLD *`,
+    }))
+
+    // tags[5] is out of range on the old 2-element list too, so the OLD
+    // projection is also empty.
+    expect(result.Items).toBeDefined()
+    expect(result.Items!.length).toBe(0)
+  })
+
+  it('UPDATE RETURNING MODIFIED NEW * appending at exactly the list length returns the appended element', async () => {
+    const pk = 'pq-ret-upd-lidx-applen-new'
+    keysToCleanup.push({ pk: { S: pk } })
+    await ddb.send(new PutItemCommand({
+      TableName: hashTableDef.name,
+      Item: { pk: { S: pk }, tags: { L: [{ S: 'a' }, { S: 'b' }] } },
+    }))
+
+    const result = await ddb.send(new ExecuteStatementCommand({
+      Statement: `UPDATE "${hashTableDef.name}" SET tags[2] = 'c' WHERE pk = '${pk}' RETURNING MODIFIED NEW *`,
+    }))
+
+    // Same append as the tags[5] case (stored ['a','b','c']), but here the literal
+    // index equals the old length, so tags[2] DOES resolve on the new 3-element
+    // list and the projection returns the appended element rather than Items: [].
+    expect(result.Items).toBeDefined()
+    expect(result.Items!.length).toBe(1)
+    const item = result.Items![0]
+    expect(Object.keys(item)).toEqual(['tags'])
+    expect(item.tags.L!.map(v => v.S)).toEqual(['c'])
+
+    const after = await ddb.send(new GetItemCommand({
+      TableName: hashTableDef.name, Key: { pk: { S: pk } }, ConsistentRead: true,
+    }))
+    expect(after.Item!.tags.L!.map(v => v.S)).toEqual(['a', 'b', 'c'])
+  })
+
+  it('UPDATE RETURNING MODIFIED OLD * appending at exactly the list length returns an empty Items list', async () => {
+    const pk = 'pq-ret-upd-lidx-applen-old'
+    keysToCleanup.push({ pk: { S: pk } })
+    await ddb.send(new PutItemCommand({
+      TableName: hashTableDef.name,
+      Item: { pk: { S: pk }, tags: { L: [{ S: 'a' }, { S: 'b' }] } },
+    }))
+
+    const result = await ddb.send(new ExecuteStatementCommand({
+      Statement: `UPDATE "${hashTableDef.name}" SET tags[2] = 'c' WHERE pk = '${pk}' RETURNING MODIFIED OLD *`,
+    }))
+
+    // tags[2] is out of range on the OLD 2-element list, so the OLD projection is
+    // empty even though the NEW projection returns the appended element.
+    expect(result.Items).toBeDefined()
+    expect(result.Items!.length).toBe(0)
+  })
+
+  it('UPDATE REMOVE RETURNING MODIFIED OLD * on a list index returns the removed element at its old value', async () => {
+    const pk = 'pq-ret-rem-lidx-old'
+    keysToCleanup.push({ pk: { S: pk } })
+    await ddb.send(new PutItemCommand({
+      TableName: hashTableDef.name,
+      Item: { pk: { S: pk }, tags: { L: [{ S: 'a' }, { S: 'b' }, { S: 'c' }] } },
+    }))
+
+    const result = await ddb.send(new ExecuteStatementCommand({
+      Statement: `UPDATE "${hashTableDef.name}" REMOVE tags[1] WHERE pk = '${pk}' RETURNING MODIFIED OLD *`,
+    }))
+
+    expect(result.Items).toBeDefined()
+    expect(result.Items!.length).toBe(1)
+    const item = result.Items![0]
+    expect(Object.keys(item)).toEqual(['tags'])
+    expect(item.tags.L!.map(v => v.S)).toEqual(['b'])
+
+    const after = await ddb.send(new GetItemCommand({
+      TableName: hashTableDef.name, Key: { pk: { S: pk } }, ConsistentRead: true,
+    }))
+    expect(after.Item!.tags.L!.map(v => v.S)).toEqual(['a', 'c'])
+  })
+
+  it('UPDATE REMOVE RETURNING MODIFIED NEW * on a list index returns the shifted element, not an empty list', async () => {
+    const pk = 'pq-ret-rem-lidx-new'
+    keysToCleanup.push({ pk: { S: pk } })
+    await ddb.send(new PutItemCommand({
+      TableName: hashTableDef.name,
+      Item: { pk: { S: pk }, tags: { L: [{ S: 'a' }, { S: 'b' }, { S: 'c' }] } },
+    }))
+
+    const result = await ddb.send(new ExecuteStatementCommand({
+      Statement: `UPDATE "${hashTableDef.name}" REMOVE tags[1] WHERE pk = '${pk}' RETURNING MODIFIED NEW *`,
+    }))
+
+    // Removing a list index shifts the tail down rather than deleting a key, so
+    // the path tags[1] still resolves on the new list ['a','c'] and points at 'c'.
+    // This is why the map-REMOVE rule (removed attribute -> Items: []) does not
+    // carry to list indices: the index is not gone, it now holds the shifted tail.
+    expect(result.Items).toBeDefined()
+    expect(result.Items!.length).toBe(1)
+    const item = result.Items![0]
+    expect(Object.keys(item)).toEqual(['tags'])
+    expect(item.tags.L!.map(v => v.S)).toEqual(['c'])
+
+    const after = await ddb.send(new GetItemCommand({
+      TableName: hashTableDef.name, Key: { pk: { S: pk } }, ConsistentRead: true,
+    }))
+    expect(after.Item!.tags.L!.map(v => v.S)).toEqual(['a', 'c'])
+  })
+
+  it('UPDATE REMOVE RETURNING MODIFIED NEW * on the last list index returns an empty Items list', async () => {
+    const pk = 'pq-ret-rem-lidx-last-new'
+    keysToCleanup.push({ pk: { S: pk } })
+    await ddb.send(new PutItemCommand({
+      TableName: hashTableDef.name,
+      Item: { pk: { S: pk }, tags: { L: [{ S: 'a' }, { S: 'b' }, { S: 'c' }] } },
+    }))
+
+    const result = await ddb.send(new ExecuteStatementCommand({
+      Statement: `UPDATE "${hashTableDef.name}" REMOVE tags[2] WHERE pk = '${pk}' RETURNING MODIFIED NEW *`,
+    }))
+
+    // Removing the LAST index leaves no tail to shift up, so tags[2] no longer
+    // resolves on the new 2-element list and the NEW projection is empty — unlike
+    // a middle-index REMOVE, where the shifted element keeps the path resolvable.
+    expect(result.Items).toBeDefined()
+    expect(result.Items!.length).toBe(0)
+
+    const after = await ddb.send(new GetItemCommand({
+      TableName: hashTableDef.name, Key: { pk: { S: pk } }, ConsistentRead: true,
+    }))
+    expect(after.Item!.tags.L!.map(v => v.S)).toEqual(['a', 'b'])
+  })
+
+  it('UPDATE REMOVE RETURNING MODIFIED OLD * on the last list index returns the removed element', async () => {
+    const pk = 'pq-ret-rem-lidx-last-old'
+    keysToCleanup.push({ pk: { S: pk } })
+    await ddb.send(new PutItemCommand({
+      TableName: hashTableDef.name,
+      Item: { pk: { S: pk }, tags: { L: [{ S: 'a' }, { S: 'b' }, { S: 'c' }] } },
+    }))
+
+    const result = await ddb.send(new ExecuteStatementCommand({
+      Statement: `UPDATE "${hashTableDef.name}" REMOVE tags[2] WHERE pk = '${pk}' RETURNING MODIFIED OLD *`,
+    }))
+
+    // tags[2] is in range on the OLD list, so the OLD projection still returns the
+    // removed element.
+    expect(result.Items).toBeDefined()
+    expect(result.Items!.length).toBe(1)
+    const item = result.Items![0]
+    expect(Object.keys(item)).toEqual(['tags'])
+    expect(item.tags.L!.map(v => v.S)).toEqual(['c'])
+  })
+
+  it('UPDATE SET on a list index of an absent attribute is rejected, not auto-created', async () => {
+    const pk = 'pq-ret-upd-lidx-absent'
+    keysToCleanup.push({ pk: { S: pk } })
+    await ddb.send(new PutItemCommand({
+      TableName: hashTableDef.name,
+      Item: { pk: { S: pk }, marker: { S: 'present' } },
+    }))
+
+    // A write-path gap, not RETURNING-specific: DynamoDB does not auto-create a
+    // parent for a nested write, so setting an index on an attribute that does
+    // not exist is rejected the same as a map key on a missing parent. It does
+    // not create the list. Characterised against real AWS (eu-west-2).
+    await expectDynamoError(
+      () => ddb.send(new ExecuteStatementCommand({
+        Statement: `UPDATE "${hashTableDef.name}" SET newlist[0] = 'x' WHERE pk = '${pk}'`,
+      })),
+      'ValidationException',
+      'The document path provided in the update expression is invalid for update',
+    )
+
+    // The rejected statement created nothing.
+    const after = await ddb.send(new GetItemCommand({
+      TableName: hashTableDef.name, Key: { pk: { S: pk } }, ConsistentRead: true,
+    }))
+    expect(after.Item!.newlist).toBeUndefined()
+    expect(after.Item!.marker.S).toBe('present')
+  })
+
   it('UPDATE on a non-existent key fails ConditionalCheckFailed (PartiQL UPDATE is not an upsert)', async () => {
     const pk = 'pq-ret-upd-ghost'
     // Deliberately not seeded — the key must not exist.


### PR DESCRIPTION
## What this changes

Adds tier-2 tests characterising the PartiQL `RETURNING MODIFIED` projection for list-index `SET`/`REMOVE` against real DynamoDB: it reads the literal index against the new list (`NEW`) or prior list (`OLD`), returning the element when the index is in range and nothing when it is not, with multiple changed indices packed in ascending index order. Covers a non-zero index, multiple indices, append both at and past the list length, `REMOVE` of a middle and of the last index, `SET` on an absent attribute (rejected), and a batch member that fails to parse. Refs #102.

## Checklist

- [x] New or modified tests run against real AWS DynamoDB and pass
- ~~New or modified tests run against at least one emulator target and behave as expected~~ - emulator targets are scored by the weekly sweep, not run per-PR
- [x] Linked issue or a short note explaining the motivation (#102)
- [x] I agree my contribution is licensed under the project's terms (Apache License, Version 2.0)
