### PR TITLE
fix: make the legacy tag cover every test that sends a legacy parameter

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -83,11 +83,30 @@ describe('Query — GSI', { tags: ['query', 'data-plane', 'gsi'] }, () => {
 })
 ```
 
+A tag can also go on an individual test, and has to when only some of the tests
+in a describe exercise the capability. Legacy parameters are the usual case: a
+rejection test that sends `Expected` alongside `ConditionExpression` belongs
+next to its expression-parameter counterpart, so the file stays readable, but
+only that one test depends on legacy support.
+
+```ts
+describe('PutItem — validation', { tags: ['put-item', 'data-plane'] }, () => {
+  it('rejects mixing expression and non-expression parameters', { tags: ['legacy'] }, async () => {
+    // ...
+  })
+})
+```
+
+Tags add up rather than replace, so that test resolves to `put-item`,
+`data-plane` and `legacy`. Tagging the whole describe instead would drop every
+other case in it from a `--tags-filter='!legacy'` run.
+
 The vocabulary lives in `src/tags.ts` - add a tag there before using it, or
 `strictTags` rejects the run. The coverage guard (`npm run test:tooling`) fails
-if a top-level describe is left untagged, so feature filters like
-`--tags-filter='!partiql'` never silently miss a test. See "Filtering by
-feature" in the `README.md` for the full vocabulary.
+if a top-level describe is left untagged, and also if a test sends something a
+tag exists for without carrying it - a legacy request parameter, a PartiQL
+command. So feature filters like `--tags-filter='!partiql'` never silently miss
+a test. See "Filtering by feature" in the `README.md` for the full vocabulary.
 
 ### Tier 3 sub-directory choice
 

--- a/README.md
+++ b/README.md
@@ -163,7 +163,7 @@ The vocabulary lives in one place, `src/tags.ts`, and stays honest two ways: `st
 | `cloud-only` | No emulator implements it; needs real AWS infrastructure, another AWS service, or account/region context |
 | `gsi` | Exercises Global Secondary Indexes |
 | `lsi` | Exercises Local Secondary Indexes |
-| `legacy` | Deprecated request parameters (AttributeUpdates, QueryFilter, ScanFilter, Expected, AttributesToGet) |
+| `legacy` | Sends a deprecated request parameter (AttributeUpdates, QueryFilter, ScanFilter, Expected, AttributesToGet), wherever the test lives |
 | `slow` | Long-running against real AWS; the set `test:gating` excludes |
 | `negative-path` | Asserts only rejections: every case expects a validation error, conditional-check failure, or transaction cancellation |
 <!-- tags:end -->

--- a/results/tag-manifest.json
+++ b/results/tag-manifest.json
@@ -1,5 +1,5 @@
 {
-  "schema": 1,
+  "schema": 2,
   "describes": {
     "tests/tier1/batchGetItem/basic.test.ts": {
       "BatchGetItem — basic": [
@@ -1081,6 +1081,53 @@
         "data-plane",
         "negative-path"
       ]
+    }
+  },
+  "tests": {
+    "tests/tier1/getItem/projection.test.ts": {
+      "GetItem — projection matching nothing": {
+        "returns an empty Item when legacy AttributesToGet matches no attribute on a present item": [
+          "legacy"
+        ]
+      }
+    },
+    "tests/tier1/putItem/validation.test.ts": {
+      "PutItem — validation": {
+        "rejects mixing expression and non-expression parameters": [
+          "legacy"
+        ]
+      }
+    },
+    "tests/tier3/error-messages/batchGetItem.test.ts": {
+      "BatchGetItem — exact error messages": {
+        "AttributesToGet with ProjectionExpression in a KeysAndAttributes block: full conflict error": [
+          "legacy"
+        ],
+        "mixing ProjectionExpression on one table and AttributesToGet on another is rejected": [
+          "legacy"
+        ]
+      }
+    },
+    "tests/tier3/error-messages/deleteItem.test.ts": {
+      "DeleteItem — exact error messages": {
+        "mixing Expected with ConditionExpression: full conflict error": [
+          "legacy"
+        ]
+      }
+    },
+    "tests/tier3/error-messages/putItem.test.ts": {
+      "PutItem — exact error messages": {
+        "mixing expression and non-expression: full conflict error": [
+          "legacy"
+        ]
+      }
+    },
+    "tests/tier3/error-messages/updateItem.test.ts": {
+      "UpdateItem — exact error messages": {
+        "mixing UpdateExpression with AttributeUpdates": [
+          "legacy"
+        ]
+      }
     }
   }
 }

--- a/scripts/lib/tag-content.mjs
+++ b/scripts/lib/tag-content.mjs
@@ -1,0 +1,236 @@
+// Parse a test file into its describe/test blocks with the tags applied to
+// each, and check that a test exercising a tagged capability actually carries
+// that capability's tag.
+//
+// Why this exists: a `--tags-filter` is only honest if every test that belongs
+// to an axis is tagged. The coverage guard checks that a describe carries *some*
+// tag, which is the "is tagged" half. It cannot see the other half - whether a
+// test sending `AttributesToGet` carries `legacy` - and that gap is how seven
+// legacy tests sat inside a `!legacy` run for two months.
+//
+// Why static parsing rather than vitest's collection: collection resolves the
+// tags a test *has*, and says nothing about what the test *sends*. The check
+// needs both sides, and only the source has the second one.
+//
+// Kept free of any `src/` import so `scripts/tag-manifest.mjs` can consume it
+// under plain node (`npm run results:tags`); `src/tags.ts` is TypeScript and
+// would need a transform. The marker table's tag names are asserted against the
+// canonical vocabulary in this module's sibling test instead, which runs under
+// vitest and can import it.
+
+/** Opens a describe/it/test block. Covers `it.each(...)` and friends. */
+const BLOCK_OPEN = /^(\s*)(describe|it|test)(\.[A-Za-z]+)?\s*\(/
+
+/** The first string literal on the line, which is a block's title. */
+const TITLE = /\(\s*(['"`])(.*?)\1/
+
+/** An inline `{ tags: [...] }` options literal. */
+const TAGS = /\{\s*tags:\s*\[([^\]]*)\]\s*\}/
+
+/**
+ * Source markers that imply a capability, and the tag each one requires.
+ *
+ * The legacy parameters are matched in object-key position, anywhere on the
+ * line, so an inline `{ AttributesToGet: [pk] }` counts as much as a key on its
+ * own line. They also appear inside asserted message strings ("...Index Key
+ * lsi1sk Expected: S Actual: N", "Must specify the AttributesToGet or
+ * ProjectionExpression..."), which assert about a message rather than send the
+ * parameter. String contents are blanked before matching, so a quoted
+ * occurrence never reaches these patterns; that is what separates the two, not
+ * where the name sits on the line.
+ */
+export const CAPABILITY_MARKERS = [
+  {
+    tag: 'legacy',
+    what: 'a deprecated request parameter',
+    pattern:
+      /\b(AttributesToGet|AttributeUpdates|Expected|QueryFilter|ScanFilter|KeyConditions|ConditionalOperator)\s*:/,
+  },
+  {
+    tag: 'partiql',
+    what: 'a PartiQL command',
+    pattern: /\b(ExecuteStatementCommand|BatchExecuteStatementCommand|ExecuteTransactionCommand)\b/,
+  },
+]
+
+/**
+ * Blank the contents of string literals and comments, preserving line count and
+ * column offsets so line numbers and indentation still line up.
+ *
+ * Both consumers need this. Brace counting would be thrown off by a lone brace
+ * inside a message string, and marker matching would fire on a parameter name
+ * that only appears in an assertion.
+ */
+export function stripLiterals(src) {
+  const out = []
+  let state = 'code'
+  let quote = ''
+  for (let i = 0; i < src.length; i++) {
+    const c = src[i]
+    const next = src[i + 1]
+    if (state === 'code') {
+      if (c === '/' && next === '/') { state = 'line-comment'; out.push('  '); i++; continue }
+      if (c === '/' && next === '*') { state = 'block-comment'; out.push('  '); i++; continue }
+      if (c === "'" || c === '"' || c === '`') { state = 'string'; quote = c; out.push(c); continue }
+      out.push(c)
+      continue
+    }
+    if (state === 'line-comment') {
+      if (c === '\n') { state = 'code'; out.push('\n'); continue }
+      out.push(' ')
+      continue
+    }
+    if (state === 'block-comment') {
+      if (c === '*' && next === '/') { state = 'code'; out.push('  '); i++; continue }
+      out.push(c === '\n' ? '\n' : ' ')
+      continue
+    }
+    // state === 'string'
+    if (c === '\\') { out.push('  '); i++; continue }
+    if (c === quote) { state = 'code'; out.push(c); continue }
+    // An unterminated literal would run away; a newline inside a non-template
+    // quote ends it, matching how the parser would fail anyway.
+    if (c === '\n' && quote !== '`') { state = 'code'; out.push('\n'); continue }
+    out.push(c === '\n' ? '\n' : ' ')
+  }
+  return out.join('')
+}
+
+function netBraces(line) {
+  let n = 0
+  for (const c of line) {
+    if (c === '{') n++
+    else if (c === '}') n--
+  }
+  return n
+}
+
+function tagsOn(line) {
+  const m = line.match(TAGS)
+  if (!m) return []
+  return [...m[1].matchAll(/['"]([^'"]+)['"]/g)].map((x) => x[1])
+}
+
+/**
+ * Parse a test source into nested blocks.
+ *
+ * Each block is `{ kind, title, tags, start, end, children }` with 1-indexed
+ * line numbers. `kind` is 'describe' or 'test'. Tags are the ones applied
+ * directly to that block, not the resolved set - callers walk the chain.
+ */
+export function parseBlocks(src) {
+  const raw = src.split('\n')
+  const stripped = stripLiterals(src).split('\n')
+  const roots = []
+  const stack = []
+  let depth = 0
+
+  raw.forEach((line, i) => {
+    const open = line.match(BLOCK_OPEN)
+    const before = depth
+    depth += netBraces(stripped[i] ?? '')
+
+    if (open) {
+      const titleMatch = line.match(TITLE)
+      const block = {
+        kind: open[2] === 'describe' ? 'describe' : 'test',
+        title: titleMatch ? titleMatch[2] : line.trim().slice(0, 60),
+        tags: tagsOn(line),
+        start: i + 1,
+        end: null,
+        depthAtOpen: before,
+        children: [],
+      }
+      const parent = stack[stack.length - 1]
+      if (parent) parent.children.push(block)
+      else roots.push(block)
+      stack.push(block)
+      return
+    }
+
+    while (stack.length && depth <= stack[stack.length - 1].depthAtOpen) {
+      stack.pop().end = i + 1
+    }
+  })
+
+  // An unclosed block runs to the end of the file rather than staying null.
+  for (const b of stack) b.end = raw.length
+  return roots
+}
+
+/** Walk the block tree, yielding each block with its ancestor chain. */
+function* walk(blocks, chain = []) {
+  for (const b of blocks) {
+    yield { block: b, chain: [...chain, b] }
+    yield* walk(b.children, [...chain, b])
+  }
+}
+
+/** Every tag applied anywhere along a chain of nested blocks. */
+export function resolveTags(chain) {
+  return new Set(chain.flatMap((b) => b.tags))
+}
+
+/**
+ * The innermost block containing a line, and its ancestor chain.
+ *
+ * "Innermost" is the latest-opening block that still contains the line. A block
+ * opening and closing on one line is not closed until the following line, so its
+ * recorded end overlaps the next block's start; picking the latest opener is
+ * what keeps that overlap from misattributing a marker to the previous test.
+ */
+function innermostAt(roots, line) {
+  let found = null
+  for (const { block, chain } of walk(roots)) {
+    if (line < block.start || line > block.end) continue
+    if (!found || block.start > found.block.start) found = { block, chain }
+  }
+  return found
+}
+
+/**
+ * Capability markers that appear without the tag they imply.
+ *
+ * A marker inside a test needs the tag on that test or on any describe around
+ * it. A marker in shared setup - a `beforeAll`, or anything else between tests -
+ * makes every test in that describe depend on the capability, so it escalates
+ * to the describe. A marker at module scope (outside every describe) applies to
+ * the whole file, so every top-level describe must carry the tag; import lines
+ * are skipped, since naming a command in an import is not sending it.
+ *
+ * Returns one entry per offending line:
+ *   { line, tag, marker, scope, title }
+ */
+export function capabilityLeaks(src, { markers = CAPABILITY_MARKERS } = {}) {
+  const roots = parseBlocks(src)
+  const stripped = stripLiterals(src).split('\n')
+  const leaks = []
+
+  stripped.forEach((line, i) => {
+    if (/^\s*import\b/.test(line)) return
+    for (const marker of markers) {
+      const hit = line.match(marker.pattern)
+      if (!hit) continue
+      const found = { line: i + 1, tag: marker.tag, marker: hit[1] ?? hit[0].trim() }
+      const at = innermostAt(roots, i + 1)
+
+      if (!at) {
+        for (const d of roots.filter((r) => !r.tags.includes(marker.tag))) {
+          leaks.push({ ...found, scope: 'file', title: d.title })
+        }
+        continue
+      }
+
+      if (resolveTags(at.chain).has(marker.tag)) continue
+      leaks.push({ ...found, scope: at.block.kind, title: at.block.title })
+    }
+  })
+
+  return leaks
+}
+
+/** One line per leak, for a guard's failure message. */
+export function describeLeak(file, leak) {
+  const where = leak.scope === 'file' ? `describe « ${leak.title} »` : `« ${leak.title} »`
+  return `${file}:${leak.line} ${where} sends ${leak.marker} without the '${leak.tag}' tag`
+}

--- a/scripts/lib/tag-content.test.mjs
+++ b/scripts/lib/tag-content.test.mjs
@@ -1,0 +1,286 @@
+import { describe, it, expect } from 'vitest'
+import { TAG_NAMES } from '../../src/tags.js'
+import {
+  CAPABILITY_MARKERS,
+  capabilityLeaks,
+  parseBlocks,
+  resolveTags,
+  stripLiterals,
+} from './tag-content.mjs'
+
+const tags = (leaks) => leaks.map((l) => `${l.scope}:${l.title}:${l.tag}`)
+
+describe('stripLiterals', () => {
+  it('blanks string contents but keeps the quotes and the line count', () => {
+    const out = stripLiterals("const a = 'hello'\nconst b = 1\n")
+    expect(out).toBe("const a = '     '\nconst b = 1\n")
+  })
+
+  it('blanks braces inside strings so they cannot move the brace depth', () => {
+    const out = stripLiterals("expect(m).toContain('parameters: {Expected}')")
+    expect(out).not.toContain('{')
+    expect(out).not.toContain('}')
+  })
+
+  it('blanks line and block comments', () => {
+    expect(stripLiterals('const a = 1 // Expected: S\n')).not.toContain('Expected')
+    expect(stripLiterals('/* AttributesToGet: x */\n')).not.toContain('AttributesToGet')
+  })
+
+  it('does not treat an apostrophe inside a double-quoted string as a quote', () => {
+    const out = stripLiterals('const a = "don\'t"\nconst b = 2\n')
+    expect(out.split('\n')[1]).toBe('const b = 2')
+  })
+})
+
+describe('parseBlocks', () => {
+  it('records a describe, its tests, and the tags on each', () => {
+    const src = [
+      "describe('Outer', { tags: ['get-item', 'data-plane'] }, () => {",
+      "  it('plain', async () => {",
+      '    expect(1).toBe(1)',
+      '  })',
+      "  it('tagged', { tags: ['legacy'] }, async () => {",
+      '    expect(1).toBe(1)',
+      '  })',
+      '})',
+      '',
+    ].join('\n')
+    const [outer] = parseBlocks(src)
+    expect(outer.kind).toBe('describe')
+    expect(outer.title).toBe('Outer')
+    expect(outer.tags).toEqual(['get-item', 'data-plane'])
+    expect(outer.children.map((c) => [c.title, c.tags])).toEqual([
+      ['plain', []],
+      ['tagged', ['legacy']],
+    ])
+  })
+
+  it('nests a describe inside a describe', () => {
+    const src = [
+      "describe('Outer', { tags: ['scan'] }, () => {",
+      "  describe('Inner', { tags: ['legacy'] }, () => {",
+      "    it('deep', async () => {",
+      '      expect(1).toBe(1)',
+      '    })',
+      '  })',
+      '})',
+      '',
+    ].join('\n')
+    const [outer] = parseBlocks(src)
+    const inner = outer.children[0]
+    expect(inner.title).toBe('Inner')
+    expect(resolveTags([outer, inner, inner.children[0]])).toEqual(new Set(['scan', 'legacy']))
+  })
+
+  it('is not confused by a brace inside an asserted message', () => {
+    const src = [
+      "describe('Outer', { tags: ['put-item'] }, () => {",
+      "  it('one', async () => {",
+      "    expect(m).toContain('Non-expression parameters: {Expected}')",
+      '  })',
+      "  it('two', async () => {",
+      '    expect(1).toBe(1)',
+      '  })',
+      '})',
+      '',
+    ].join('\n')
+    const [outer] = parseBlocks(src)
+    expect(outer.children.map((c) => c.title)).toEqual(['one', 'two'])
+  })
+})
+
+describe('capabilityLeaks', () => {
+  it('reports a legacy parameter on an untagged test', () => {
+    const src = [
+      "describe('PutItem', { tags: ['put-item', 'data-plane'] }, () => {",
+      "  it('mixes them', async () => {",
+      '    await ddb.send(new PutItemCommand({',
+      '      TableName: t,',
+      '      Expected: { pk: { Exists: false } },',
+      '    }))',
+      '  })',
+      '})',
+      '',
+    ].join('\n')
+    expect(tags(capabilityLeaks(src))).toEqual(['test:mixes them:legacy'])
+  })
+
+  it('is clean when the tag is on the test', () => {
+    const src = [
+      "describe('PutItem', { tags: ['put-item', 'data-plane'] }, () => {",
+      "  it('mixes them', { tags: ['legacy'] }, async () => {",
+      '      Expected: { pk: { Exists: false } },',
+      '  })',
+      '})',
+      '',
+    ].join('\n')
+    expect(capabilityLeaks(src)).toEqual([])
+  })
+
+  it('is clean when the tag is inherited from the describe', () => {
+    const src = [
+      "describe('Legacy API', { tags: ['put-item', 'legacy', 'data-plane'] }, () => {",
+      "  it('uses Expected', async () => {",
+      '      Expected: { pk: { Exists: false } },',
+      '  })',
+      '})',
+      '',
+    ].join('\n')
+    expect(capabilityLeaks(src)).toEqual([])
+  })
+
+  it('escalates a marker in shared setup to the describe', () => {
+    const src = [
+      "describe('PutItem', { tags: ['put-item', 'data-plane'] }, () => {",
+      '  beforeAll(async () => {',
+      '    await ddb.send(new PutItemCommand({',
+      '      AttributesToGet: [x],',
+      '    }))',
+      '  })',
+      "  it('unrelated', async () => {",
+      '    expect(1).toBe(1)',
+      '  })',
+      '})',
+      '',
+    ].join('\n')
+    expect(tags(capabilityLeaks(src))).toEqual(['describe:PutItem:legacy'])
+  })
+
+  it('ignores a legacy parameter name inside an asserted message', () => {
+    const src = [
+      "describe('BatchWriteItem', { tags: ['batch', 'data-plane'] }, () => {",
+      "  it('type mismatch on an index key', async () => {",
+      '    expect(err.message).toContain(',
+      "      'One or more parameter values were invalid: Type mismatch for Index Key lsi1sk Expected: S Actual: N',",
+      '    )',
+      '  })',
+      '})',
+      '',
+    ].join('\n')
+    expect(capabilityLeaks(src)).toEqual([])
+  })
+
+  it('ignores AttributesToGet named in a Select rejection message', () => {
+    const src = [
+      "describe('Query', { tags: ['query', 'data-plane'] }, () => {",
+      "  it('SPECIFIC_ATTRIBUTES without a projection', async () => {",
+      '    expect(err.message).toContain(',
+      "      'Must specify the AttributesToGet or ProjectionExpression when choosing to get SPECIFIC_ATTRIBUTES',",
+      '    )',
+      '  })',
+      '})',
+      '',
+    ].join('\n')
+    expect(capabilityLeaks(src)).toEqual([])
+  })
+
+  it('catches a legacy parameter written inline rather than on its own line', () => {
+    const src = [
+      "describe('GetItem', { tags: ['get-item', 'data-plane'] }, () => {",
+      "  it('inline', async () => {",
+      '    await ddb.send(new GetItemCommand({ AttributesToGet: [pk] }))',
+      '  })',
+      '})',
+      '',
+    ].join('\n')
+    expect(tags(capabilityLeaks(src))).toEqual(['test:inline:legacy'])
+  })
+
+  it('does not match a longer identifier that ends with a parameter name', () => {
+    const src = [
+      "describe('GetItem', { tags: ['get-item', 'data-plane'] }, () => {",
+      "  it('unrelated', async () => {",
+      '    const myExpected: string = x',
+      '    expect(myExpected).toBe(x)',
+      '  })',
+      '})',
+      '',
+    ].join('\n')
+    expect(capabilityLeaks(src)).toEqual([])
+  })
+
+  it('attributes a marker to the right test when tests open and close on one line', () => {
+    // A one-line test is not closed until the following line, so its recorded
+    // range overlaps the next test's opening. The marker must still land on the
+    // test that sends it, not on the one before.
+    const src = [
+      "describe('GetItem', { tags: ['get-item', 'data-plane'] }, () => {",
+      "  it('first', async () => { expect(1).toBe(1) })",
+      "  it('second', async () => { await ddb.send(new GetItemCommand({ AttributesToGet: [pk] })) })",
+      "  it('third', async () => { expect(1).toBe(1) })",
+      '})',
+      '',
+    ].join('\n')
+    expect(tags(capabilityLeaks(src))).toEqual(['test:second:legacy'])
+  })
+
+  it('reports a PartiQL command in a describe not tagged partiql', () => {
+    const src = [
+      "describe('Statements', { tags: ['data-plane'] }, () => {",
+      "  it('runs one', async () => {",
+      '    await ddb.send(new ExecuteStatementCommand({ Statement: s }))',
+      '  })',
+      '})',
+      '',
+    ].join('\n')
+    expect(tags(capabilityLeaks(src))).toEqual(['test:runs one:partiql'])
+  })
+
+  it('does not count naming a command in an import as sending it', () => {
+    const src = [
+      "import { ExecuteStatementCommand } from '@aws-sdk/client-dynamodb'",
+      "describe('Something else', { tags: ['scan', 'data-plane'] }, () => {",
+      "  it('unrelated', async () => {",
+      '    expect(1).toBe(1)',
+      '  })',
+      '})',
+      '',
+    ].join('\n')
+    expect(capabilityLeaks(src)).toEqual([])
+  })
+
+  it('resolves tags from the whole enclosing chain, not just the top describe', () => {
+    const src = [
+      "describe('Outer', { tags: ['put-item', 'data-plane'] }, () => {",
+      "  describe('Inner', { tags: ['legacy'] }, () => {",
+      "    it('deep', async () => {",
+      '      Expected: { pk: { Exists: false } },',
+      '    })',
+      '  })',
+      '})',
+      '',
+    ].join('\n')
+    expect(capabilityLeaks(src)).toEqual([])
+  })
+
+  it('requires the tag on every top-level describe when the marker is at module scope', () => {
+    const src = [
+      'const legacyRead = { AttributesToGet: [pk] }',
+      "describe('Tagged', { tags: ['get-item', 'legacy', 'data-plane'] }, () => {",
+      "  it('a', async () => { expect(1).toBe(1) })",
+      '})',
+      "describe('Untagged', { tags: ['get-item', 'data-plane'] }, () => {",
+      "  it('b', async () => { expect(1).toBe(1) })",
+      '})',
+      '',
+    ].join('\n')
+    expect(tags(capabilityLeaks(src))).toEqual(['file:Untagged:legacy'])
+  })
+})
+
+describe('the marker table', () => {
+  // tag-content.mjs cannot import src/tags.ts, because scripts/tag-manifest.mjs
+  // consumes it under plain node. Asserting the table here is what keeps a
+  // typo'd tag name from silently checking nothing.
+  it('only requires tags that exist in the canonical vocabulary', () => {
+    const undeclared = CAPABILITY_MARKERS.map((m) => m.tag).filter((t) => !TAG_NAMES.has(t))
+    expect(undeclared, 'marker table references tags absent from src/tags.ts').toEqual([])
+  })
+
+  it('describes what each marker matches, for the failure message', () => {
+    for (const m of CAPABILITY_MARKERS) {
+      expect(m.what, `marker for '${m.tag}' has no description`).toBeTruthy()
+    }
+  })
+})

--- a/scripts/tag-coverage.test.mjs
+++ b/scripts/tag-coverage.test.mjs
@@ -3,19 +3,29 @@ import { readdirSync, readFileSync } from 'node:fs'
 import { join } from 'node:path'
 import { TAG_NAMES, PLANE_TAGS } from '../src/tags.js'
 import { buildManifest } from './tag-manifest.mjs'
+import { capabilityLeaks, describeLeak } from './lib/tag-content.mjs'
 
 // Guards that the feature/capability tags stay trustworthy as the suite grows.
 // A `--tags-filter` is only honest if every test that belongs to an axis is
 // actually tagged; an untagged file would silently slip through an exclusion.
 //
-// Why static parsing rather than booting vitest: every top-level describe
-// carries an inline `{ tags: [...] }` literal (no const indirection, no
-// per-test overrides), and tags inherit from a top-level describe to all of its
-// nested suites and tests. So validating every top-level describe — plus
-// forbidding stray top-level it()/test() that would escape a describe and carry
-// no tags — is equivalent to validating every test's resolved tags, with no AWS
-// and no test run. strictTags in vitest.config.ts is the run-time backstop that
-// rejects any undeclared tag whenever the suite actually executes.
+// Why static parsing rather than booting vitest: tags are inline `{ tags: [...] }`
+// literals (no const indirection), so the source is the whole truth, and reading
+// it needs no AWS and no test run. strictTags in vitest.config.ts is the
+// run-time backstop that rejects any undeclared tag whenever the suite executes.
+//
+// Two halves, and both are needed. Checking that every top-level describe is
+// tagged is the "is tagged" half: it catches a new file that forgets its tags.
+// It cannot catch a test that sends `AttributesToGet` inside a describe tagged
+// only `get-item`, because that describe is tagged perfectly well - and that gap
+// is how seven legacy tests sat inside a `!legacy` run. The "belongs to an axis"
+// half is scripts/lib/tag-content.mjs, which reads what a test sends and
+// requires the matching tag.
+//
+// Tags may also sit on an individual `it()`, which is how a capability is marked
+// when only some tests in a describe exercise it. Describe-level checks are
+// therefore no longer equivalent to checking every test's resolved tags, so do
+// not reintroduce that assumption.
 
 const TEST_DIR = 'tests'
 const PLANES = new Set(PLANE_TAGS)
@@ -80,6 +90,19 @@ describe('tag coverage guard', () => {
       if (src.split('\n').some((l) => /^(it|test)[.(]/.test(l))) offenders.push(file)
     }
     expect(offenders, `top-level tests outside any describe:\n${offenders.join('\n')}`).toEqual([])
+  })
+
+  it('every test that exercises a tagged capability carries that tag', () => {
+    const problems = []
+    for (const file of testFiles) {
+      for (const leak of capabilityLeaks(readFileSync(file, 'utf8'))) {
+        problems.push(describeLeak(file, leak))
+      }
+    }
+    expect(
+      problems,
+      `tests exercising a capability without its tag:\n${problems.join('\n')}`,
+    ).toEqual([])
   })
 
   it('the README tag table matches the declared vocabulary', () => {

--- a/scripts/tag-manifest.mjs
+++ b/scripts/tag-manifest.mjs
@@ -1,35 +1,37 @@
 // Generate the tag manifest: every test file's top-level describes mapped to
-// the tags applied to them, parsed straight from the test sources — the same
-// inline tags that strictTags and the coverage guard enforce, so this is a
-// faithful extraction of the single source of truth, not a second taxonomy.
+// the tags applied to them, plus the tags applied below that level, parsed
+// straight from the test sources — the same inline tags that strictTags and the
+// coverage guard enforce, so this is a faithful extraction of the single source
+// of truth, not a second taxonomy.
 //
 // Published to results/tag-manifest.json so paritysuite.org can group results
-// by capability (its results JSON carries file path + top-level describe title
-// per test, which is the manifest's join key) without re-deriving the tagging.
+// by capability. Its results JSON carries file path, top-level describe title
+// and test name per test, which is the manifest's join key.
+//
+// Schema 2 adds `tests`. A tag can sit on an individual `it()`, or on a nested
+// describe, and the describe-keyed map cannot express either: a test tagged
+// `legacy` inside a describe tagged only `get-item` would be grouped as though
+// it were not legacy at all. `tests` carries only what is added *below* the
+// top-level describe, so a consumer unions the two. `describes` is unchanged
+// from schema 1, so a reader predating this keeps working and simply misses the
+// finer-grained tags.
 //
 // Run: `npm run results:tags` (regenerates the committed manifest). The
 // coverage guard fails if the committed file drifts from the sources.
 
 import { readdirSync, readFileSync, writeFileSync } from 'node:fs'
 import { join } from 'node:path'
+import { parseBlocks, resolveTags } from './lib/tag-content.mjs'
 
 const TEST_DIR = 'tests'
 
-// Top-level (column-0) describes and their inline tags, parsed the same way as
-// scripts/tag-coverage.test.mjs (tags are inlined literals, no const indirection).
-function topLevelDescribes(src) {
-  const found = []
-  for (const line of src.split('\n')) {
-    if (!line.startsWith('describe(')) continue
-    const titleMatch = line.match(/^describe\((['"])(.*?)\1,/)
-    if (!titleMatch) continue
-    const tagsMatch = line.match(/\{\s*tags:\s*\[([^\]]*)\]\s*\}/)
-    const tags = tagsMatch
-      ? [...tagsMatch[1].matchAll(/['"]([^'"]+)['"]/g)].map((m) => m[1])
-      : []
-    found.push({ title: titleMatch[2], tags })
+/** Every test below a block, with the chain of blocks enclosing each one. */
+function* testsUnder(block, chain) {
+  for (const child of block.children) {
+    const next = [...chain, child]
+    if (child.kind === 'test') yield { test: child, chain: next }
+    else yield* testsUnder(child, next)
   }
-  return found
 }
 
 export function buildManifest(testDir = TEST_DIR) {
@@ -40,14 +42,27 @@ export function buildManifest(testDir = TEST_DIR) {
     .sort()
 
   const describes = {}
+  const tests = {}
   for (const file of files) {
+    const roots = parseBlocks(readFileSync(file, 'utf8')).filter((b) => b.kind === 'describe')
     const entry = {}
-    for (const { title, tags } of topLevelDescribes(readFileSync(file, 'utf8'))) {
-      entry[title] = tags
+    const perTest = {}
+    for (const root of roots) {
+      entry[root.title] = root.tags
+      const extras = {}
+      for (const { test, chain } of testsUnder(root, [root])) {
+        // Only what a test adds beyond its top-level describe. The describe's
+        // own tags already sit in `describes`, so repeating them per test would
+        // multiply the manifest by ~1000 for nothing.
+        const added = [...resolveTags(chain)].filter((t) => !root.tags.includes(t))
+        if (added.length) extras[test.title] = added
+      }
+      if (Object.keys(extras).length) perTest[root.title] = extras
     }
     describes[file] = entry
+    if (Object.keys(perTest).length) tests[file] = perTest
   }
-  return { schema: 1, describes }
+  return { schema: 2, describes, tests }
 }
 
 // CLI: write the committed manifest.
@@ -56,5 +71,11 @@ if (import.meta.url === `file://${process.argv[1]}`) {
   writeFileSync('results/tag-manifest.json', `${JSON.stringify(manifest, null, 2)}\n`)
   const fileCount = Object.keys(manifest.describes).length
   const describeCount = Object.values(manifest.describes).reduce((s, d) => s + Object.keys(d).length, 0)
-  console.log(`wrote results/tag-manifest.json: ${fileCount} files, ${describeCount} describes`)
+  const testCount = Object.values(manifest.tests).reduce(
+    (s, f) => s + Object.values(f).reduce((n, d) => n + Object.keys(d).length, 0),
+    0,
+  )
+  console.log(
+    `wrote results/tag-manifest.json: ${fileCount} files, ${describeCount} describes, ${testCount} individually tagged tests`,
+  )
 }

--- a/scripts/tag-manifest.test.mjs
+++ b/scripts/tag-manifest.test.mjs
@@ -1,0 +1,62 @@
+import { describe, it, expect } from 'vitest'
+import { buildManifest } from './tag-manifest.mjs'
+
+// The manifest is a published contract: paritysuite.org joins its results to it
+// by (file, top-level describe title, test name). These assertions cover the
+// shape that join depends on. Freshness of the committed copy is asserted in
+// scripts/tag-coverage.test.mjs.
+const manifest = buildManifest()
+
+describe('the tag manifest', () => {
+  it('declares schema 2', () => {
+    expect(manifest.schema).toBe(2)
+  })
+
+  it('maps every test file to its top-level describes', () => {
+    const files = Object.keys(manifest.describes)
+    expect(files.length).toBeGreaterThan(50)
+    expect(files.every((f) => f.startsWith('tests/') && f.endsWith('.test.ts'))).toBe(true)
+  })
+
+  it('gives every top-level describe a tag array', () => {
+    for (const [file, entry] of Object.entries(manifest.describes)) {
+      for (const [title, tags] of Object.entries(entry)) {
+        expect(Array.isArray(tags), `${file} « ${title} » is not an array`).toBe(true)
+        expect(tags.length, `${file} « ${title} » has no tags`).toBeGreaterThan(0)
+      }
+    }
+  })
+
+  it('records only what a test adds beyond its top-level describe', () => {
+    for (const [file, byDescribe] of Object.entries(manifest.tests)) {
+      for (const [describeTitle, byTest] of Object.entries(byDescribe)) {
+        const inherited = manifest.describes[file][describeTitle]
+        expect(inherited, `${file} « ${describeTitle} » is missing from describes`).toBeDefined()
+        for (const [testTitle, added] of Object.entries(byTest)) {
+          const overlap = added.filter((t) => inherited.includes(t))
+          expect(overlap, `${file} « ${testTitle} » repeats inherited tags`).toEqual([])
+        }
+      }
+    }
+  })
+
+  it('omits files and describes with nothing tagged below the top level', () => {
+    for (const [file, byDescribe] of Object.entries(manifest.tests)) {
+      expect(Object.keys(byDescribe).length, `${file} has an empty tests entry`).toBeGreaterThan(0)
+      for (const [title, byTest] of Object.entries(byDescribe)) {
+        expect(Object.keys(byTest).length, `${file} « ${title} » is empty`).toBeGreaterThan(0)
+      }
+    }
+  })
+
+  it('carries the legacy tag on the individually tagged tests', () => {
+    const tagged = Object.entries(manifest.tests).flatMap(([file, byDescribe]) =>
+      Object.values(byDescribe).flatMap((byTest) =>
+        Object.entries(byTest).map(([title, tags]) => ({ file, title, tags })),
+      ),
+    )
+    expect(tagged.length).toBeGreaterThan(0)
+    expect(tagged.every((t) => t.tags.includes('legacy'))).toBe(true)
+    expect(tagged.map((t) => t.file)).toContain('tests/tier1/getItem/projection.test.ts')
+  })
+})

--- a/site/data/tag-manifest.json
+++ b/site/data/tag-manifest.json
@@ -1,5 +1,5 @@
 {
-  "schema": 1,
+  "schema": 2,
   "describes": {
     "tests/tier1/batchGetItem/basic.test.ts": {
       "BatchGetItem — basic": [
@@ -827,6 +827,13 @@
         "negative-path"
       ]
     },
+    "tests/tier3/error-messages/partiql.test.ts": {
+      "PartiQL — exact error messages": [
+        "partiql",
+        "data-plane",
+        "negative-path"
+      ]
+    },
     "tests/tier3/error-messages/putItem.test.ts": {
       "PutItem — exact error messages": [
         "put-item",
@@ -1074,6 +1081,53 @@
         "data-plane",
         "negative-path"
       ]
+    }
+  },
+  "tests": {
+    "tests/tier1/getItem/projection.test.ts": {
+      "GetItem — projection matching nothing": {
+        "returns an empty Item when legacy AttributesToGet matches no attribute on a present item": [
+          "legacy"
+        ]
+      }
+    },
+    "tests/tier1/putItem/validation.test.ts": {
+      "PutItem — validation": {
+        "rejects mixing expression and non-expression parameters": [
+          "legacy"
+        ]
+      }
+    },
+    "tests/tier3/error-messages/batchGetItem.test.ts": {
+      "BatchGetItem — exact error messages": {
+        "AttributesToGet with ProjectionExpression in a KeysAndAttributes block: full conflict error": [
+          "legacy"
+        ],
+        "mixing ProjectionExpression on one table and AttributesToGet on another is rejected": [
+          "legacy"
+        ]
+      }
+    },
+    "tests/tier3/error-messages/deleteItem.test.ts": {
+      "DeleteItem — exact error messages": {
+        "mixing Expected with ConditionExpression: full conflict error": [
+          "legacy"
+        ]
+      }
+    },
+    "tests/tier3/error-messages/putItem.test.ts": {
+      "PutItem — exact error messages": {
+        "mixing expression and non-expression: full conflict error": [
+          "legacy"
+        ]
+      }
+    },
+    "tests/tier3/error-messages/updateItem.test.ts": {
+      "UpdateItem — exact error messages": {
+        "mixing UpdateExpression with AttributeUpdates": [
+          "legacy"
+        ]
+      }
     }
   }
 }

--- a/site/lib/capabilities.test.mjs
+++ b/site/lib/capabilities.test.mjs
@@ -4,13 +4,24 @@ import assert from "node:assert/strict";
 import { capabilityTallies, CAPABILITIES, CAPABILITY_GROUPS } from "./scoring.mjs";
 import { renderCapabilities, renderCapabilityCards } from "./capabilities.mjs";
 
-// A tag manifest like the suite publishes: (file, top-level describe title) -> tags.
+// A tag manifest like the suite publishes: (file, top-level describe title) -> tags,
+// plus schema 2's `tests` map for tags applied below the describe.
 const manifest = {
+  schema: 2,
   describes: {
     "tests/tier2/partiql/executeStatement.test.ts": { "ExecuteStatement — PartiQL": ["partiql", "data-plane"] },
     "tests/tier1/query/gsi.test.ts": { "Query — GSI": ["query", "data-plane", "gsi"] },
+    "tests/tier1/getItem/projection.test.ts": { "GetItem — projection": ["get-item", "data-plane"] },
+  },
+  tests: {
+    "tests/tier1/getItem/projection.test.ts": {
+      "GetItem — projection": { "legacy AttributesToGet": ["legacy"] },
+    },
   },
 };
+
+// The same manifest as a reader on schema 1 would see it: no `tests` map.
+const schema1Manifest = { schema: 1, describes: manifest.describes };
 
 // Raw Vitest output: one file with an absolute (CI) path, one with a repo-relative
 // path, to prove the join normalises both to the "tests/..." tail.
@@ -28,6 +39,15 @@ const raw = {
       assertionResults: [
         { ancestorTitles: ["Query — GSI"], status: "passed" },
         { ancestorTitles: ["Query — GSI"], status: "skipped" },
+      ],
+    },
+    {
+      // One describe holding a legacy test and a sibling that is not legacy.
+      // Only the tagged one may reach the legacy column.
+      name: "tests/tier1/getItem/projection.test.ts",
+      assertionResults: [
+        { ancestorTitles: ["GetItem — projection"], title: "legacy AttributesToGet", status: "passed" },
+        { ancestorTitles: ["GetItem — projection"], title: "plain projection", status: "passed" },
       ],
     },
   ],
@@ -61,6 +81,46 @@ test("capabilityTallies counts only declared capability columns, ignoring other 
 test("capabilityTallies returns one entry per capability column, in order", () => {
   const caps = capabilityTallies(raw, manifest);
   assert.deepEqual(caps.map((c) => c.key), CAPABILITIES.map((c) => c.key));
+});
+
+test("capabilityTallies counts a per-test tag but not its untagged sibling", () => {
+  const caps = byKey(capabilityTallies(raw, manifest));
+  // Two tests in that describe, one tagged legacy. Only that one lands in the
+  // legacy column; the sibling is a plain projection test and must not.
+  assert.deepEqual([caps.legacy.passed, caps.legacy.total], [1, 1]);
+});
+
+test("capabilityTallies still tallies describe-level tags with per-test tags present", () => {
+  const caps = byKey(capabilityTallies(raw, manifest));
+  assert.deepEqual([caps.partiql.passed, caps.partiql.failed], [1, 1]);
+  assert.deepEqual([caps.gsi.passed, caps.gsi.skipped], [1, 1]);
+});
+
+test("capabilityTallies falls back to describe-level tags on a schema 1 manifest", () => {
+  const caps = byKey(capabilityTallies(raw, schema1Manifest));
+  // No `tests` map, so the legacy test is invisible as legacy - but nothing
+  // throws and every describe-level column tallies as before.
+  assert.equal(caps.legacy.total, 0);
+  assert.deepEqual([caps.partiql.passed, caps.partiql.failed], [1, 1]);
+  assert.deepEqual([caps.gsi.passed, caps.gsi.skipped], [1, 1]);
+});
+
+test("capabilityTallies counts a tag once when a test repeats one from its describe", () => {
+  const dupManifest = {
+    schema: 2,
+    describes: { "tests/tier1/query/gsi.test.ts": { "Query — GSI": ["query", "data-plane", "gsi"] } },
+    tests: { "tests/tier1/query/gsi.test.ts": { "Query — GSI": { "a gsi query": ["gsi"] } } },
+  };
+  const dupRaw = {
+    testResults: [
+      {
+        name: "tests/tier1/query/gsi.test.ts",
+        assertionResults: [{ ancestorTitles: ["Query — GSI"], title: "a gsi query", status: "passed" }],
+      },
+    ],
+  };
+  const caps = byKey(capabilityTallies(dupRaw, dupManifest));
+  assert.deepEqual([caps.gsi.passed, caps.gsi.total], [1, 1]);
 });
 
 test("capabilityTallies degrades to unsupported with no manifest, rather than crashing", () => {

--- a/site/lib/scoring.mjs
+++ b/site/lib/scoring.mjs
@@ -149,17 +149,32 @@ const testsKey = (file) => {
 };
 
 // Per-capability tally for one target's raw results, joined to the tag manifest:
-// for each test, look up its resolved tags by (file, top-level describe title),
-// then sum pass/fail/skip into every capability column that tag set includes.
-// State is derived the same way areaState does, so the glyphs match the matrix.
-// With no manifest (e.g. a fetch fallback) every capability reports n/a.
+// for each test, look up its resolved tags by (file, top-level describe title,
+// test name), then sum pass/fail/skip into every capability column that tag set
+// includes. State is derived the same way areaState does, so the glyphs match
+// the matrix. With no manifest (e.g. a fetch fallback) every capability reports
+// n/a.
+//
+// A tag can sit on an individual test rather than on its describe, which is how
+// a capability is marked when only some tests in a describe exercise it. Schema
+// 2 of the manifest carries those in `tests`, holding only what is added below
+// the describe, so the two maps are unioned here. The site fetches the manifest
+// live from the suite's main branch at build time, so it can be handed either
+// schema; a schema 1 manifest simply has no `tests` and the union is a no-op.
 export function capabilityTallies(raw, manifest) {
   const describes = manifest?.describes ?? {};
+  const perTest = manifest?.tests ?? {};
   const tally = Object.fromEntries(CAPABILITIES.map((c) => [c.key, { passed: 0, failed: 0, skipped: 0 }]));
   for (const tr of raw?.testResults ?? []) {
-    const byTitle = describes[testsKey(tr.name)] ?? {};
+    const key = testsKey(tr.name);
+    const byTitle = describes[key] ?? {};
+    const testsByTitle = perTest[key] ?? {};
     for (const ar of tr.assertionResults ?? []) {
-      const tags = byTitle[ar.ancestorTitles?.[0]] ?? [];
+      const describeTitle = ar.ancestorTitles?.[0];
+      const tags = [
+        ...(byTitle[describeTitle] ?? []),
+        ...(testsByTitle[describeTitle]?.[ar.title] ?? []),
+      ];
       for (const c of CAPABILITIES) {
         if (!tags.includes(c.key)) continue;
         const e = tally[c.key];

--- a/tests/tier1/getItem/projection.test.ts
+++ b/tests/tier1/getItem/projection.test.ts
@@ -202,7 +202,7 @@ describe('GetItem — projection matching nothing', { tags: ['get-item', 'data-p
     expect(Object.keys(result.Item!)).toHaveLength(0)
   })
 
-  it('returns an empty Item when legacy AttributesToGet matches no attribute on a present item', async () => {
+  it('returns an empty Item when legacy AttributesToGet matches no attribute on a present item', { tags: ['legacy'] }, async () => {
     const result = await ddb.send(
       new GetItemCommand({
         TableName: hashTableDef.name,

--- a/tests/tier1/putItem/validation.test.ts
+++ b/tests/tier1/putItem/validation.test.ts
@@ -166,7 +166,7 @@ describe('PutItem — validation', { tags: ['put-item', 'data-plane', 'negative-
     )
   })
 
-  it('rejects mixing expression and non-expression parameters', async () => {
+  it('rejects mixing expression and non-expression parameters', { tags: ['legacy'] }, async () => {
     await expectDynamoError(
       () => ddb.send(
         new PutItemCommand({

--- a/tests/tier3/error-messages/batchGetItem.test.ts
+++ b/tests/tier3/error-messages/batchGetItem.test.ts
@@ -90,7 +90,7 @@ describe('BatchGetItem — exact error messages', { tags: ['batch', 'data-plane'
   // A KeysAndAttributes block accepts both the legacy AttributesToGet and a modern
   // ProjectionExpression; supplying both is the expression/non-expression conflict,
   // rejected before any read.
-  it('AttributesToGet with ProjectionExpression in a KeysAndAttributes block: full conflict error', async () => {
+  it('AttributesToGet with ProjectionExpression in a KeysAndAttributes block: full conflict error', { tags: ['legacy'] }, async () => {
     try {
       await ddb.send(
         new BatchGetItemCommand({
@@ -134,7 +134,7 @@ describe('BatchGetItem — exact error messages', { tags: ['batch', 'data-plane'
     }
   })
 
-  it('mixing ProjectionExpression on one table and AttributesToGet on another is rejected', async () => {
+  it('mixing ProjectionExpression on one table and AttributesToGet on another is rejected', { tags: ['legacy'] }, async () => {
     // Each table's block is internally consistent, but real AWS rejects the
     // request as a whole for mixing expression and non-expression projection
     // across tables.

--- a/tests/tier3/error-messages/deleteItem.test.ts
+++ b/tests/tier3/error-messages/deleteItem.test.ts
@@ -51,7 +51,7 @@ describe('DeleteItem — exact error messages', { tags: ['delete-item', 'data-pl
   // Completes the expression/non-expression mutual-exclusion family for the item
   // writes (PutItem and UpdateItem already pin it). DeleteItem takes legacy Expected
   // and a modern ConditionExpression; supplying both is rejected up front.
-  it('mixing Expected with ConditionExpression: full conflict error', async () => {
+  it('mixing Expected with ConditionExpression: full conflict error', { tags: ['legacy'] }, async () => {
     try {
       await ddb.send(
         new DeleteItemCommand({

--- a/tests/tier3/error-messages/putItem.test.ts
+++ b/tests/tier3/error-messages/putItem.test.ts
@@ -274,7 +274,7 @@ describe('PutItem — exact error messages', { tags: ['put-item', 'data-plane'] 
     }
   })
 
-  it('mixing expression and non-expression: full conflict error', async () => {
+  it('mixing expression and non-expression: full conflict error', { tags: ['legacy'] }, async () => {
     try {
       await ddb.send(
         new PutItemCommand({

--- a/tests/tier3/error-messages/updateItem.test.ts
+++ b/tests/tier3/error-messages/updateItem.test.ts
@@ -129,7 +129,7 @@ describe('UpdateItem — exact error messages', { tags: ['update-item', 'data-pl
     }
   })
 
-  it('mixing UpdateExpression with AttributeUpdates', async () => {
+  it('mixing UpdateExpression with AttributeUpdates', { tags: ['legacy'] }, async () => {
     try {
       await ddb.send(
         new UpdateItemCommand({


### PR DESCRIPTION
## What this changes

The `legacy` tag was applied by directory, so it only covered `tests/tier3/legacy-api/`. Seven tests elsewhere send `AttributesToGet`, `AttributeUpdates` or `Expected` and stayed selected by `--tags-filter='!legacy'`, which is the filter an engine without legacy support uses to skip them. Reported in #26.

They are tagged per-test rather than on their describes. Those six describes hold 61 tests between them, so tagging at describe level would have dropped 54 unrelated cases from the same run. `!legacy` now selects 949 rather than 956.

The coverage guard could not have caught this: it checks that a describe carries a tag, not that the tag matches what the test does, so a legacy parameter could be added to any tagged describe without anything going red. Three of the seven arrived that way. `scripts/lib/tag-content.mjs` adds a static parse of the describe and test tree with the tags on each, plus a marker table mapping source patterns to the tag they require, wired for `legacy` and `partiql`. String contents are blanked before matching, so a parameter named in an asserted message is not mistaken for one being sent.

`gsi` and `lsi` have the same directory-assignment problem and are not fixed here. They need the shared tables provisioning on demand first, since they are created with indexes before any filter applies, and that is a separate change.

## Checklist

- ~~New or modified tests run against real AWS DynamoDB and pass~~ - no test behaviour changed. The seven tests send and assert exactly what they did before; only their collection-time tags moved.
- ~~New or modified tests run against at least one emulator target and behave as expected~~ - as above. Tag selection was verified through `vitest list` across the whole suite, and the tooling guards run locally.
- [x] Linked issue or a short note explaining the motivation
- [x] I agree my contribution is licensed under the project's terms (Apache License, Version 2.0)

## Tier and scope

Touches the results pipeline. `results/tag-manifest.json` moves to schema 2, which adds a `tests` map carrying tags applied below the top-level describe. `describes` is byte-identical, so a reader on schema 1 keeps working and simply misses the finer-grained tags.

The site consumer unions the two maps and tolerates either schema, since it fetches the published manifest at build time and can be handed a newer one than its own code. `site/data/tag-manifest.json`, the committed fallback, is regenerated with it.

No target's conformance percentage moves - tags never fed the score. The `legacy` capability column gains seven tests per target, which is the tagging being corrected rather than drift.
