### PR TITLE
fix: make the index exclusions create no indexed table

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -112,6 +112,16 @@ If a test is flaky against real DynamoDB (for example GSI
 propagation), use the existing wait/retry helpers rather than adding
 sleeps.
 
+A new test file must call `declareTables(...)` at module scope for
+every shared table def it uses. Shared tables are created on demand,
+so an undeclared table is simply never created for a run narrow enough
+that no other file asked for it, and the test fails with
+`ResourceNotFoundException` rather than a real answer. `npm run
+test:tooling` checks the declaration against what the file references.
+Reach for `compositeIndexedTableDef` when a test needs a secondary
+index; `compositeTableDef` has none, and any file using the indexed one
+carries both the `gsi` and `lsi` tags.
+
 ## Citing a suite finding elsewhere
 
 When a finding from this suite is referenced in another project's

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -70,6 +70,29 @@ is a maintainer task and does not block your PR.
   grouped by the definition of each tier in the `README.md`.
 - Prefer the existing wait/retry helpers over `setTimeout` sleeps.
 
+### Declare the tables your file uses
+
+Shared tables are created on demand, so a file has to say which ones it needs.
+Call `declareTables` once at module scope, naming every shared def the file
+goes on to use:
+
+```ts
+import { compositeTableDef, declareTables, hashTableDef } from '../../../src/helpers.js'
+
+declareTables(hashTableDef, compositeTableDef)
+```
+
+Setup creates the tables the running file declared and nothing else, which is
+what lets `--tags-filter='!gsi and !lsi'` produce a run that never creates a
+table with a secondary index. Leave a table out and the file passes a full run,
+because some other file will have created it, then fails on a narrower run with
+`ResourceNotFoundException`. `npm run test:tooling` checks the declaration
+against what the file actually references, in both directions.
+
+Use `compositeIndexedTableDef` rather than `compositeTableDef` if you need a
+secondary index; the plain composite table has none. Any file declaring it
+needs both `gsi` and `lsi` tags, since it carries both kinds.
+
 ### Tag your test
 
 Every top-level `describe` takes a `tags` array as its second argument: the

--- a/README.md
+++ b/README.md
@@ -117,6 +117,9 @@ DYNAMODB_ENDPOINT=http://localhost:8000 npx vitest run --tags-filter='data-plane
 # Drop the operations no emulator implements
 DYNAMODB_ENDPOINT=http://localhost:8000 npx vitest run --tags-filter='!cloud-only'
 
+# Skip secondary indexes entirely, and create no table that has one
+DYNAMODB_ENDPOINT=http://localhost:8000 npx vitest run --tags-filter='!gsi and !lsi'
+
 # Compose them, and with tiers: transactions only, excluding cloud-only async
 DYNAMODB_ENDPOINT=http://localhost:8000 npx vitest run tests/tier2 --tags-filter='transactions and !cloud-only'
 ```
@@ -124,6 +127,14 @@ DYNAMODB_ENDPOINT=http://localhost:8000 npx vitest run tests/tier2 --tags-filter
 The grammar takes `and` / `&&`, `not` / `!`, `or`, parentheses, and `prefix/*` wildcards, and it composes with the tier scripts and directory paths.
 
 The vocabulary lives in one place, `src/tags.ts`, and stays honest two ways: `strictTags` rejects an undeclared tag the moment the suite runs, and a coverage guard (`npm run test:tooling`) fails if any test is left untagged. So an exclusion like `!partiql` can't silently miss a test that someone forgot to tag.
+
+### What excluding an index buys you
+
+Most exclusions only change which tests run. The index ones also change what gets built, which matters if your engine can't build it.
+
+Tables are created on demand: a test file declares the shared tables it needs, and a run creates what its selected files asked for and nothing else. Exclude `gsi` and `lsi` and no table carrying a secondary index is ever created, so an engine with no index support can complete the run instead of dying in setup.
+
+The shared indexed table carries both kinds together, so any test using it is tagged `gsi` and `lsi` both, and excluding either axis drops it. That costs some precision when you select rather than exclude: `--tags-filter='gsi'` picks up tests that only exercise an LSI, because they share a table. If a target ever supports one index kind and not the other, splitting the table into separate variants is the way to fix that, at the cost of seeding both.
 
 <!-- tags:start -->
 **Operation tags** - one per test, matching the operation it exercises.
@@ -161,8 +172,8 @@ The vocabulary lives in one place, `src/tags.ts`, and stays honest two ways: `st
 | `data-plane` | Reads or writes items |
 | `control-plane` | Manages tables, indexes, or table-level features |
 | `cloud-only` | No emulator implements it; needs real AWS infrastructure, another AWS service, or account/region context |
-| `gsi` | Exercises Global Secondary Indexes |
-| `lsi` | Exercises Local Secondary Indexes |
+| `gsi` | Depends on a Global Secondary Index, whether it queries one, asserts on an index key, or creates a table carrying one |
+| `lsi` | Depends on a Local Secondary Index, on the same terms |
 | `legacy` | Sends a deprecated request parameter (AttributeUpdates, QueryFilter, ScanFilter, Expected, AttributesToGet), wherever the test lives |
 | `slow` | Long-running against real AWS; the set `test:gating` excludes |
 | `negative-path` | Asserts only rejections: every case expects a validation error, conditional-check failure, or transaction cancellation |
@@ -376,7 +387,7 @@ tests/
 
 - `src/client.ts` - DynamoDB and Streams client, configured from the `DYNAMODB_ENDPOINT` env var
 - `src/helpers.ts` - table lifecycle, assertion helpers (`expectDynamoError`, `cleanupItems`, `waitForGsiConsistency`)
-- `src/setup.ts` - global beforeAll/afterAll that creates 5 shared tables
+- `src/setup.ts` - per-file beforeAll that creates the shared tables the running file declared
 - `src/types.ts` - `TestTableDef` and `KeyDef` types
 
 ## The site

--- a/results/tag-manifest.json
+++ b/results/tag-manifest.json
@@ -42,6 +42,14 @@
         "data-plane"
       ]
     },
+    "tests/tier1/batchWriteItem/indexKeyValidation.test.ts": {
+      "BatchWriteItem — index key validation": [
+        "batch",
+        "data-plane",
+        "negative-path",
+        "lsi"
+      ]
+    },
     "tests/tier1/batchWriteItem/validation.test.ts": {
       "BatchWriteItem — validation": [
         "batch",
@@ -142,6 +150,14 @@
         "describe-table",
         "control-plane",
         "negative-path"
+      ]
+    },
+    "tests/tier1/describeTable/indexes.test.ts": {
+      "DescribeTable — secondary indexes": [
+        "describe-table",
+        "control-plane",
+        "gsi",
+        "lsi"
       ]
     },
     "tests/tier1/getItem/basic.test.ts": {
@@ -249,10 +265,19 @@
         "data-plane"
       ]
     },
+    "tests/tier1/putItem/indexKeyValidation.test.ts": {
+      "PutItem — index key validation": [
+        "put-item",
+        "data-plane",
+        "negative-path",
+        "lsi"
+      ]
+    },
     "tests/tier1/putItem/itemCollectionMetrics.test.ts": {
       "ReturnItemCollectionMetrics": [
         "put-item",
-        "data-plane"
+        "data-plane",
+        "lsi"
       ]
     },
     "tests/tier1/putItem/numberFormat.test.ts": {
@@ -332,6 +357,12 @@
         "query",
         "data-plane",
         "gsi"
+      ],
+      "Query — GSI ExclusiveStartKey validation": [
+        "query",
+        "data-plane",
+        "gsi",
+        "negative-path"
       ]
     },
     "tests/tier1/query/gsiHashOnlyPagination.test.ts": {
@@ -386,10 +417,6 @@
         "query",
         "data-plane"
       ],
-      "Query — Select modes on indexes": [
-        "query",
-        "data-plane"
-      ],
       "Query — Select SPECIFIC_ATTRIBUTES": [
         "query",
         "data-plane"
@@ -398,6 +425,14 @@
         "query",
         "data-plane",
         "negative-path"
+      ]
+    },
+    "tests/tier1/query/selectOnIndexes.test.ts": {
+      "Query — Select modes on indexes": [
+        "query",
+        "data-plane",
+        "gsi",
+        "lsi"
       ]
     },
     "tests/tier1/query/validation.test.ts": {
@@ -463,6 +498,11 @@
     },
     "tests/tier1/scan/gsi.test.ts": {
       "Scan — GSI": [
+        "scan",
+        "data-plane",
+        "gsi"
+      ],
+      "Scan — GSI FilterExpression parens": [
         "scan",
         "data-plane",
         "gsi"
@@ -740,6 +780,14 @@
         "data-plane"
       ]
     },
+    "tests/tier2/transactions/transactWriteIndexKeys.test.ts": {
+      "TransactWriteItems — index key validation": [
+        "transactions",
+        "data-plane",
+        "negative-path",
+        "lsi"
+      ]
+    },
     "tests/tier2/ttl/basic.test.ts": {
       "TTL — basic": [
         "ttl",
@@ -827,6 +875,40 @@
         "negative-path"
       ]
     },
+    "tests/tier3/error-messages/indexKeyValues.test.ts": {
+      "BatchWriteItem — index key error messages": [
+        "batch",
+        "data-plane",
+        "negative-path",
+        "gsi"
+      ],
+      "PutItem — index key error messages": [
+        "put-item",
+        "data-plane",
+        "negative-path",
+        "gsi"
+      ],
+      "UpdateItem — index key error messages": [
+        "update-item",
+        "data-plane",
+        "negative-path",
+        "gsi"
+      ]
+    },
+    "tests/tier3/error-messages/indexReads.test.ts": {
+      "Query — index error messages": [
+        "query",
+        "data-plane",
+        "negative-path",
+        "gsi"
+      ],
+      "Scan — index error messages": [
+        "scan",
+        "data-plane",
+        "negative-path",
+        "gsi"
+      ]
+    },
     "tests/tier3/error-messages/partiql.test.ts": {
       "PartiQL — exact error messages": [
         "partiql",
@@ -869,6 +951,14 @@
         "transactions",
         "data-plane",
         "negative-path"
+      ]
+    },
+    "tests/tier3/error-messages/transactIndexKeys.test.ts": {
+      "TransactWriteItems — index key error messages": [
+        "transactions",
+        "data-plane",
+        "negative-path",
+        "gsi"
       ]
     },
     "tests/tier3/error-messages/transactWriteItems.test.ts": {

--- a/results/tag-manifest.json
+++ b/results/tag-manifest.json
@@ -97,7 +97,8 @@
       "CreateTable — index and stream spec validation": [
         "create-table",
         "control-plane",
-        "negative-path"
+        "negative-path",
+        "gsi"
       ]
     },
     "tests/tier1/deleteItem/basic.test.ts": {
@@ -1200,6 +1201,13 @@
     }
   },
   "tests": {
+    "tests/tier1/createTable/basic.test.ts": {
+      "CreateTable — validation": {
+        "rejects a GSI INCLUDE projection without NonKeyAttributes": [
+          "gsi"
+        ]
+      }
+    },
     "tests/tier1/getItem/projection.test.ts": {
       "GetItem — projection matching nothing": {
         "returns an empty Item when legacy AttributesToGet matches no attribute on a present item": [
@@ -1221,6 +1229,22 @@
         ],
         "mixing ProjectionExpression on one table and AttributesToGet on another is rejected": [
           "legacy"
+        ]
+      }
+    },
+    "tests/tier3/error-messages/createTable.test.ts": {
+      "CreateTable — exact error messages": {
+        "LSI without range key on base table": [
+          "lsi"
+        ],
+        "duplicate index names": [
+          "gsi"
+        ],
+        "GSI INCLUDE projection without NonKeyAttributes: full missing-attributes message": [
+          "gsi"
+        ],
+        "LSI INCLUDE projection without NonKeyAttributes: full missing-attributes message": [
+          "lsi"
         ]
       }
     },

--- a/results/tag-manifest.json
+++ b/results/tag-manifest.json
@@ -47,6 +47,7 @@
         "batch",
         "data-plane",
         "negative-path",
+        "gsi",
         "lsi"
       ]
     },
@@ -270,6 +271,7 @@
         "put-item",
         "data-plane",
         "negative-path",
+        "gsi",
         "lsi"
       ]
     },
@@ -277,6 +279,7 @@
       "ReturnItemCollectionMetrics": [
         "put-item",
         "data-plane",
+        "gsi",
         "lsi"
       ]
     },
@@ -351,18 +354,21 @@
       "Query — GSI": [
         "query",
         "data-plane",
-        "gsi"
+        "gsi",
+        "lsi"
       ],
       "Query — GSI pagination across tied sort keys": [
         "query",
         "data-plane",
-        "gsi"
+        "gsi",
+        "lsi"
       ],
       "Query — GSI ExclusiveStartKey validation": [
         "query",
         "data-plane",
+        "negative-path",
         "gsi",
-        "negative-path"
+        "lsi"
       ]
     },
     "tests/tier1/query/gsiHashOnlyPagination.test.ts": {
@@ -370,6 +376,14 @@
         "query",
         "data-plane",
         "gsi"
+      ]
+    },
+    "tests/tier1/query/indexConsumedCapacity.test.ts": {
+      "ConsumedCapacity — INDEXES on a secondary-index Query": [
+        "query",
+        "data-plane",
+        "gsi",
+        "lsi"
       ]
     },
     "tests/tier1/query/keyConditionParens.test.ts": {
@@ -388,11 +402,13 @@
       "Query — LSI": [
         "query",
         "data-plane",
+        "gsi",
         "lsi"
       ],
       "Query — LSI pagination across tied sort keys": [
         "query",
         "data-plane",
+        "gsi",
         "lsi"
       ]
     },
@@ -500,12 +516,14 @@
       "Scan — GSI": [
         "scan",
         "data-plane",
-        "gsi"
+        "gsi",
+        "lsi"
       ],
       "Scan — GSI FilterExpression parens": [
         "scan",
         "data-plane",
-        "gsi"
+        "gsi",
+        "lsi"
       ]
     },
     "tests/tier1/scan/gsiPagination.test.ts": {
@@ -524,6 +542,7 @@
       "Scan — LSI": [
         "scan",
         "data-plane",
+        "gsi",
         "lsi"
       ]
     },
@@ -785,6 +804,7 @@
         "transactions",
         "data-plane",
         "negative-path",
+        "gsi",
         "lsi"
       ]
     },
@@ -880,19 +900,22 @@
         "batch",
         "data-plane",
         "negative-path",
-        "gsi"
+        "gsi",
+        "lsi"
       ],
       "PutItem — index key error messages": [
         "put-item",
         "data-plane",
         "negative-path",
-        "gsi"
+        "gsi",
+        "lsi"
       ],
       "UpdateItem — index key error messages": [
         "update-item",
         "data-plane",
         "negative-path",
-        "gsi"
+        "gsi",
+        "lsi"
       ]
     },
     "tests/tier3/error-messages/indexReads.test.ts": {
@@ -900,13 +923,15 @@
         "query",
         "data-plane",
         "negative-path",
-        "gsi"
+        "gsi",
+        "lsi"
       ],
       "Scan — index error messages": [
         "scan",
         "data-plane",
         "negative-path",
-        "gsi"
+        "gsi",
+        "lsi"
       ]
     },
     "tests/tier3/error-messages/partiql.test.ts": {
@@ -958,7 +983,8 @@
         "transactions",
         "data-plane",
         "negative-path",
-        "gsi"
+        "gsi",
+        "lsi"
       ]
     },
     "tests/tier3/error-messages/transactWriteItems.test.ts": {

--- a/scripts/lib/tag-content.mjs
+++ b/scripts/lib/tag-content.mjs
@@ -51,6 +51,17 @@ export const CAPABILITY_MARKERS = [
     what: 'a PartiQL command',
     pattern: /\b(ExecuteStatementCommand|BatchExecuteStatementCommand|ExecuteTransactionCommand)\b/,
   },
+  {
+    // The category filenames miss entirely: a test that never names an index
+    // but writes an index-key attribute, and is only rejected because that
+    // attribute is an index key. Either axis satisfies it - the shared indexed
+    // table carries both, so which one a case is filed under is a coin toss,
+    // and demanding a specific one would just encode that arbitrariness.
+    tag: 'gsi',
+    anyOf: ['gsi', 'lsi'],
+    what: 'a secondary index key attribute',
+    pattern: /\b(lsi1sk|lsi2sk|bidx)\s*:/,
+  },
 ]
 
 /**
@@ -211,17 +222,23 @@ export function capabilityLeaks(src, { markers = CAPABILITY_MARKERS } = {}) {
     for (const marker of markers) {
       const hit = line.match(marker.pattern)
       if (!hit) continue
-      const found = { line: i + 1, tag: marker.tag, marker: hit[1] ?? hit[0].trim() }
+      const accepted = marker.anyOf ?? [marker.tag]
+      const found = {
+        line: i + 1,
+        tag: accepted.join(' or '),
+        marker: hit[1] ?? hit[0].trim(),
+      }
       const at = innermostAt(roots, i + 1)
 
       if (!at) {
-        for (const d of roots.filter((r) => !r.tags.includes(marker.tag))) {
+        for (const d of roots.filter((r) => !accepted.some((t) => r.tags.includes(t)))) {
           leaks.push({ ...found, scope: 'file', title: d.title })
         }
         continue
       }
 
-      if (resolveTags(at.chain).has(marker.tag)) continue
+      const resolved = resolveTags(at.chain)
+      if (accepted.some((t) => resolved.has(t))) continue
       leaks.push({ ...found, scope: at.block.kind, title: at.block.title })
     }
   })

--- a/scripts/lib/tag-content.mjs
+++ b/scripts/lib/tag-content.mjs
@@ -62,6 +62,21 @@ export const CAPABILITY_MARKERS = [
     what: 'a secondary index key attribute',
     pattern: /\b(lsi1sk|lsi2sk|bidx)\s*:/,
   },
+  {
+    // Building a table that carries an index. This is the case an exclusion has
+    // to catch, because the table is created before any assertion runs.
+    //
+    // Deliberately not `IndexName`: naming an index is not depending on one.
+    // tests/tier3/validation-ordering/index.test.ts queries a name that exists
+    // nowhere, on an index-free table, and an engine without index support
+    // should still reject it - tagging it would drop a test that run can
+    // legitimately execute. Same for GlobalSecondaryIndexUpdates, which is a
+    // delete as often as an add.
+    tag: 'gsi',
+    anyOf: ['gsi', 'lsi'],
+    what: 'a table carrying a secondary index',
+    pattern: /\b(GlobalSecondaryIndexes|LocalSecondaryIndexes)\s*:/,
+  },
 ]
 
 /**

--- a/scripts/lib/tag-content.test.mjs
+++ b/scripts/lib/tag-content.test.mjs
@@ -254,6 +254,42 @@ describe('capabilityLeaks', () => {
     expect(capabilityLeaks(src)).toEqual([])
   })
 
+  it('reports an index-key attribute written by an untagged test', () => {
+    const src = [
+      "describe('PutItem', { tags: ['put-item', 'data-plane'] }, () => {",
+      "  it('rejects a wrong-typed index key', async () => {",
+      '    await ddb.send(new PutItemCommand({ Item: { pk: p, lsi1sk: { N: :v } } }))',
+      '  })',
+      '})',
+      '',
+    ].join('\n')
+    expect(tags(capabilityLeaks(src))).toEqual(['test:rejects a wrong-typed index key:gsi or lsi'])
+  })
+
+  it('accepts either index axis for an index-key attribute', () => {
+    const withLsi = [
+      "describe('PutItem', { tags: ['put-item', 'data-plane', 'lsi'] }, () => {",
+      "  it('a', async () => { await ddb.send(new PutItemCommand({ Item: { lsi1sk: v } })) })",
+      '})',
+      '',
+    ].join('\n')
+    const withGsi = withLsi.replace("'lsi'", "'gsi'")
+    expect(capabilityLeaks(withLsi)).toEqual([])
+    expect(capabilityLeaks(withGsi)).toEqual([])
+  })
+
+  it('does not treat an index-key name inside an asserted message as a dependency', () => {
+    const src = [
+      "describe('Scan', { tags: ['scan', 'data-plane'] }, () => {",
+      "  it('reports the message', async () => {",
+      "    expect(err.message).toBe('Type mismatch for Index Key lsi1sk: Expected S')",
+      '  })',
+      '})',
+      '',
+    ].join('\n')
+    expect(capabilityLeaks(src)).toEqual([])
+  })
+
   it('requires the tag on every top-level describe when the marker is at module scope', () => {
     const src = [
       'const legacyRead = { AttributesToGet: [pk] }',

--- a/scripts/table-declarations.test.mjs
+++ b/scripts/table-declarations.test.mjs
@@ -1,0 +1,163 @@
+import { describe, it, expect } from 'vitest'
+import { readdirSync, readFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { stripLiterals } from './lib/tag-content.mjs'
+
+// Guards that every test file declares the shared tables it uses.
+//
+// Provisioning is demand-driven: src/setup.ts creates the tables the running
+// file declared via `declareTables(...)`, and nothing else. A file that uses a
+// shared def without declaring it still passes a full run, because some other
+// selected file will have declared the same table - and then fails with
+// ResourceNotFoundException on the narrower run that does not, which is scored
+// as a behavioural disagreement rather than the scaffolding error it is.
+//
+// The reverse direction matters for the index axes. A file declaring a table it
+// no longer uses keeps creating it, so an exclusion that should have skipped
+// that table silently still provisions it.
+//
+// Static parsing rather than a runtime check, for the same reason the tag guard
+// is static: the declaration is the whole truth, reading it needs no AWS, and
+// the failure it prevents only reproduces under a filtered run.
+
+const TEST_DIR = 'tests'
+const HELPERS = 'src/helpers.ts'
+
+/** The shared table defs exported from src/helpers.ts. */
+function sharedDefNames() {
+  const src = readFileSync(HELPERS, 'utf8')
+  return new Set(
+    [...src.matchAll(/^export const (\w+TableDef)\s*:/gm)].map((m) => m[1]),
+  )
+}
+
+/** The defs named in a file's `declareTables(...)` call. */
+function declaredIn(stripped) {
+  const call = stripped.match(/declareTables\(([^)]*)\)/)
+  if (!call) return null
+  return new Set(
+    call[1]
+      .split(',')
+      .map((s) => s.trim())
+      .filter(Boolean),
+  )
+}
+
+/** Shared defs a file actually references, ignoring the declaration itself. */
+function usedIn(stripped, shared) {
+  const withoutDeclaration = stripped.replace(/declareTables\([^)]*\)/, '')
+  const used = new Set()
+  for (const name of shared) {
+    if (new RegExp(`\\b${name}\\b`).test(withoutDeclaration)) used.add(name)
+  }
+  return used
+}
+
+const testFiles = readdirSync(TEST_DIR, { recursive: true })
+  .map((f) => f.toString())
+  .filter((f) => f.endsWith('.test.ts'))
+  .map((f) => join(TEST_DIR, f))
+
+describe('the single-fork invariant the registry rests on', () => {
+  // The creation memo and the sweep guard are module state, so they are only
+  // shared across files while the suite runs as one non-isolated worker.
+  // Raising either setting makes the memo reset per file: every file would
+  // re-sweep and delete tables still in use. It fails silently, so assert it.
+  const config = readFileSync('vitest.config.ts', 'utf8')
+
+  it('runs a single worker', () => {
+    expect(config).toMatch(/^\s*maxWorkers:\s*1\s*,/m)
+  })
+
+  it('does not isolate modules between files', () => {
+    expect(config).toMatch(/^\s*isolate:\s*false\s*,/m)
+  })
+})
+
+describe('shared table declaration guard', () => {
+  const shared = sharedDefNames()
+
+  it('finds the shared table defs', () => {
+    expect(shared.size).toBeGreaterThan(3)
+    expect(shared).toContain('compositeTableDef')
+  })
+
+  it('discovers the test suite', () => {
+    expect(testFiles.length).toBeGreaterThan(50)
+  })
+
+  it('every file declares the shared tables it uses', () => {
+    const problems = []
+    for (const file of testFiles) {
+      const stripped = stripLiterals(readFileSync(file, 'utf8'))
+      const used = usedIn(stripped, shared)
+      if (used.size === 0) continue
+
+      const declared = declaredIn(stripped)
+      if (declared === null) {
+        problems.push(
+          `${file}: uses ${[...used].join(', ')} but never calls declareTables()`,
+        )
+        continue
+      }
+      const missing = [...used].filter((n) => !declared.has(n))
+      if (missing.length) {
+        problems.push(`${file}: uses ${missing.join(', ')} without declaring it`)
+      }
+    }
+    expect(
+      problems,
+      `shared tables used without being declared:\n${problems.join('\n')}`,
+    ).toEqual([])
+  })
+
+  it('no file declares a shared table it does not use', () => {
+    const problems = []
+    for (const file of testFiles) {
+      const stripped = stripLiterals(readFileSync(file, 'utf8'))
+      const declared = declaredIn(stripped)
+      if (!declared || declared.size === 0) continue
+
+      const used = usedIn(stripped, shared)
+      const unused = [...declared].filter((n) => shared.has(n) && !used.has(n))
+      if (unused.length) {
+        problems.push(`${file}: declares ${unused.join(', ')} but never uses it`)
+      }
+    }
+    expect(
+      problems,
+      `shared tables declared but unused (they would still be created):\n${problems.join('\n')}`,
+    ).toEqual([])
+  })
+
+  it('a file declaring the index-bearing composite table carries both index tags', () => {
+    // compositeIndexedTableDef carries LSIs and GSIs together, so a run
+    // excluding either axis must exclude the whole file - otherwise the
+    // excluded index kind is created anyway and an engine lacking it fails in
+    // setup, which is the failure the exclusion exists to prevent.
+    const problems = []
+    for (const file of testFiles) {
+      const src = readFileSync(file, 'utf8')
+      const stripped = stripLiterals(src)
+      const declared = declaredIn(stripped)
+      if (!declared?.has('compositeIndexedTableDef')) continue
+
+      for (const line of src.split('\n')) {
+        if (!line.startsWith('describe(')) continue
+        const tags = line.match(/\{\s*tags:\s*\[([^\]]*)\]\s*\}/)
+        const names = tags
+          ? [...tags[1].matchAll(/['"]([^'"]+)['"]/g)].map((m) => m[1])
+          : []
+        const missing = ['gsi', 'lsi'].filter((t) => !names.includes(t))
+        if (missing.length) {
+          const title = line.match(/^describe\((['"])(.*?)\1/)?.[2] ?? line.slice(0, 60)
+          problems.push(`${file} « ${title} »: missing ${missing.join(', ')}`)
+        }
+      }
+    }
+    expect(
+      problems,
+      `describes using the index-bearing table without both index tags:\n${problems.join('\n')}`,
+    ).toEqual([])
+  })
+})

--- a/scripts/tag-manifest.mjs
+++ b/scripts/tag-manifest.mjs
@@ -68,7 +68,11 @@ export function buildManifest(testDir = TEST_DIR) {
 // CLI: write the committed manifest.
 if (import.meta.url === `file://${process.argv[1]}`) {
   const manifest = buildManifest()
-  writeFileSync('results/tag-manifest.json', `${JSON.stringify(manifest, null, 2)}\n`)
+  const json = `${JSON.stringify(manifest, null, 2)}\n`
+  // The site reads its own copy as a build-time fallback, so write both here.
+  // Keeping them in step by hand is what let them drift nine files apart.
+  writeFileSync('results/tag-manifest.json', json)
+  writeFileSync('site/data/tag-manifest.json', json)
   const fileCount = Object.keys(manifest.describes).length
   const describeCount = Object.values(manifest.describes).reduce((s, d) => s + Object.keys(d).length, 0)
   const testCount = Object.values(manifest.tests).reduce(

--- a/scripts/tag-manifest.test.mjs
+++ b/scripts/tag-manifest.test.mjs
@@ -49,14 +49,18 @@ describe('the tag manifest', () => {
     }
   })
 
-  it('carries the legacy tag on the individually tagged tests', () => {
+  it('carries the per-test tags, which are the axes a describe would over-exclude', () => {
     const tagged = Object.entries(manifest.tests).flatMap(([file, byDescribe]) =>
       Object.values(byDescribe).flatMap((byTest) =>
         Object.entries(byTest).map(([title, tags]) => ({ file, title, tags })),
       ),
     )
     expect(tagged.length).toBeGreaterThan(0)
-    expect(tagged.every((t) => t.tags.includes('legacy'))).toBe(true)
+    // Every per-test tag names one of the axes that gets applied per test
+    // rather than per describe: a deprecated parameter, or an index dependency
+    // sitting among cases that have nothing to do with indexes.
+    expect(tagged.every((t) => t.tags.some((x) => ['legacy', 'gsi', 'lsi'].includes(x)))).toBe(true)
     expect(tagged.map((t) => t.file)).toContain('tests/tier1/getItem/projection.test.ts')
+    expect(tagged.map((t) => t.file)).toContain('tests/tier3/error-messages/createTable.test.ts')
   })
 })

--- a/site/data/tag-manifest.json
+++ b/site/data/tag-manifest.json
@@ -42,6 +42,15 @@
         "data-plane"
       ]
     },
+    "tests/tier1/batchWriteItem/indexKeyValidation.test.ts": {
+      "BatchWriteItem — index key validation": [
+        "batch",
+        "data-plane",
+        "negative-path",
+        "gsi",
+        "lsi"
+      ]
+    },
     "tests/tier1/batchWriteItem/validation.test.ts": {
       "BatchWriteItem — validation": [
         "batch",
@@ -88,7 +97,8 @@
       "CreateTable — index and stream spec validation": [
         "create-table",
         "control-plane",
-        "negative-path"
+        "negative-path",
+        "gsi"
       ]
     },
     "tests/tier1/deleteItem/basic.test.ts": {
@@ -142,6 +152,14 @@
         "describe-table",
         "control-plane",
         "negative-path"
+      ]
+    },
+    "tests/tier1/describeTable/indexes.test.ts": {
+      "DescribeTable — secondary indexes": [
+        "describe-table",
+        "control-plane",
+        "gsi",
+        "lsi"
       ]
     },
     "tests/tier1/getItem/basic.test.ts": {
@@ -249,10 +267,21 @@
         "data-plane"
       ]
     },
+    "tests/tier1/putItem/indexKeyValidation.test.ts": {
+      "PutItem — index key validation": [
+        "put-item",
+        "data-plane",
+        "negative-path",
+        "gsi",
+        "lsi"
+      ]
+    },
     "tests/tier1/putItem/itemCollectionMetrics.test.ts": {
       "ReturnItemCollectionMetrics": [
         "put-item",
-        "data-plane"
+        "data-plane",
+        "gsi",
+        "lsi"
       ]
     },
     "tests/tier1/putItem/numberFormat.test.ts": {
@@ -326,12 +355,21 @@
       "Query — GSI": [
         "query",
         "data-plane",
-        "gsi"
+        "gsi",
+        "lsi"
       ],
       "Query — GSI pagination across tied sort keys": [
         "query",
         "data-plane",
-        "gsi"
+        "gsi",
+        "lsi"
+      ],
+      "Query — GSI ExclusiveStartKey validation": [
+        "query",
+        "data-plane",
+        "negative-path",
+        "gsi",
+        "lsi"
       ]
     },
     "tests/tier1/query/gsiHashOnlyPagination.test.ts": {
@@ -339,6 +377,14 @@
         "query",
         "data-plane",
         "gsi"
+      ]
+    },
+    "tests/tier1/query/indexConsumedCapacity.test.ts": {
+      "ConsumedCapacity — INDEXES on a secondary-index Query": [
+        "query",
+        "data-plane",
+        "gsi",
+        "lsi"
       ]
     },
     "tests/tier1/query/keyConditionParens.test.ts": {
@@ -357,11 +403,13 @@
       "Query — LSI": [
         "query",
         "data-plane",
+        "gsi",
         "lsi"
       ],
       "Query — LSI pagination across tied sort keys": [
         "query",
         "data-plane",
+        "gsi",
         "lsi"
       ]
     },
@@ -386,10 +434,6 @@
         "query",
         "data-plane"
       ],
-      "Query — Select modes on indexes": [
-        "query",
-        "data-plane"
-      ],
       "Query — Select SPECIFIC_ATTRIBUTES": [
         "query",
         "data-plane"
@@ -398,6 +442,14 @@
         "query",
         "data-plane",
         "negative-path"
+      ]
+    },
+    "tests/tier1/query/selectOnIndexes.test.ts": {
+      "Query — Select modes on indexes": [
+        "query",
+        "data-plane",
+        "gsi",
+        "lsi"
       ]
     },
     "tests/tier1/query/validation.test.ts": {
@@ -465,7 +517,14 @@
       "Scan — GSI": [
         "scan",
         "data-plane",
-        "gsi"
+        "gsi",
+        "lsi"
+      ],
+      "Scan — GSI FilterExpression parens": [
+        "scan",
+        "data-plane",
+        "gsi",
+        "lsi"
       ]
     },
     "tests/tier1/scan/gsiPagination.test.ts": {
@@ -484,6 +543,7 @@
       "Scan — LSI": [
         "scan",
         "data-plane",
+        "gsi",
         "lsi"
       ]
     },
@@ -740,6 +800,15 @@
         "data-plane"
       ]
     },
+    "tests/tier2/transactions/transactWriteIndexKeys.test.ts": {
+      "TransactWriteItems — index key validation": [
+        "transactions",
+        "data-plane",
+        "negative-path",
+        "gsi",
+        "lsi"
+      ]
+    },
     "tests/tier2/ttl/basic.test.ts": {
       "TTL — basic": [
         "ttl",
@@ -827,6 +896,45 @@
         "negative-path"
       ]
     },
+    "tests/tier3/error-messages/indexKeyValues.test.ts": {
+      "BatchWriteItem — index key error messages": [
+        "batch",
+        "data-plane",
+        "negative-path",
+        "gsi",
+        "lsi"
+      ],
+      "PutItem — index key error messages": [
+        "put-item",
+        "data-plane",
+        "negative-path",
+        "gsi",
+        "lsi"
+      ],
+      "UpdateItem — index key error messages": [
+        "update-item",
+        "data-plane",
+        "negative-path",
+        "gsi",
+        "lsi"
+      ]
+    },
+    "tests/tier3/error-messages/indexReads.test.ts": {
+      "Query — index error messages": [
+        "query",
+        "data-plane",
+        "negative-path",
+        "gsi",
+        "lsi"
+      ],
+      "Scan — index error messages": [
+        "scan",
+        "data-plane",
+        "negative-path",
+        "gsi",
+        "lsi"
+      ]
+    },
     "tests/tier3/error-messages/partiql.test.ts": {
       "PartiQL — exact error messages": [
         "partiql",
@@ -869,6 +977,15 @@
         "transactions",
         "data-plane",
         "negative-path"
+      ]
+    },
+    "tests/tier3/error-messages/transactIndexKeys.test.ts": {
+      "TransactWriteItems — index key error messages": [
+        "transactions",
+        "data-plane",
+        "negative-path",
+        "gsi",
+        "lsi"
       ]
     },
     "tests/tier3/error-messages/transactWriteItems.test.ts": {
@@ -1084,6 +1201,13 @@
     }
   },
   "tests": {
+    "tests/tier1/createTable/basic.test.ts": {
+      "CreateTable — validation": {
+        "rejects a GSI INCLUDE projection without NonKeyAttributes": [
+          "gsi"
+        ]
+      }
+    },
     "tests/tier1/getItem/projection.test.ts": {
       "GetItem — projection matching nothing": {
         "returns an empty Item when legacy AttributesToGet matches no attribute on a present item": [
@@ -1105,6 +1229,22 @@
         ],
         "mixing ProjectionExpression on one table and AttributesToGet on another is rejected": [
           "legacy"
+        ]
+      }
+    },
+    "tests/tier3/error-messages/createTable.test.ts": {
+      "CreateTable — exact error messages": {
+        "LSI without range key on base table": [
+          "lsi"
+        ],
+        "duplicate index names": [
+          "gsi"
+        ],
+        "GSI INCLUDE projection without NonKeyAttributes: full missing-attributes message": [
+          "gsi"
+        ],
+        "LSI INCLUDE projection without NonKeyAttributes: full missing-attributes message": [
+          "lsi"
         ]
       }
     },

--- a/src/helpers.test.ts
+++ b/src/helpers.test.ts
@@ -1,0 +1,219 @@
+import { describe, it, expect } from 'vitest'
+import { createTableRegistry } from './helpers.js'
+import type { TestTableDef } from './types.js'
+
+// The declaration registry behind demand-driven provisioning.
+//
+// These assertions run against a synthetic creator rather than real AWS,
+// because what needs proving is the bookkeeping: how many times a table is
+// created, and how many times the leftover sweep runs. Both are properties the
+// suite cannot observe about itself - a second create surfaces as
+// ResourceInUseException and a second sweep silently deletes tables the run is
+// still using, ~80 files after the code that caused it.
+
+const def = (name: string): TestTableDef => ({
+  name,
+  hashKey: { name: 'pk', type: 'S' },
+})
+
+/** A creator that records what it was asked to create. */
+function recordingCreator() {
+  const calls: string[] = []
+  return {
+    calls,
+    create: async (d: TestTableDef) => {
+      calls.push(d.name)
+    },
+  }
+}
+
+describe('createTableRegistry — declarations', () => {
+  it('collects the defs a file declares', () => {
+    const r = createTableRegistry()
+    r.declare(def('a'), def('b'))
+    expect(r.declaredDefs().map((d) => d.name)).toEqual(['a', 'b'])
+  })
+
+  it('deduplicates a def declared by several files', () => {
+    const r = createTableRegistry()
+    const shared = def('shared')
+    r.declare(shared)
+    r.declare(shared)
+    r.declare(shared)
+    expect(r.declaredDefs()).toHaveLength(1)
+  })
+
+  it('starts empty, so a run that selects nothing creates nothing', () => {
+    expect(createTableRegistry().declaredDefs()).toEqual([])
+  })
+})
+
+describe('createTableRegistry — provisioning', () => {
+  it('creates each declared table exactly once across repeated provisions', async () => {
+    const r = createTableRegistry()
+    const { calls, create } = recordingCreator()
+    r.declare(def('a'), def('b'))
+
+    // The shared beforeAll runs per test file; forty files declaring the same
+    // def must still create it once.
+    await r.provision(create)
+    await r.provision(create)
+    await r.provision(create)
+
+    expect(calls).toEqual(['a', 'b'])
+  })
+
+  it('creates only what a later file newly declared', async () => {
+    const r = createTableRegistry()
+    const { calls, create } = recordingCreator()
+
+    r.declare(def('first'))
+    await r.provision(create)
+    r.declare(def('first'), def('second'))
+    await r.provision(create)
+
+    expect(calls).toEqual(['first', 'second'])
+  })
+
+  it('creates only the declared subset, not every table in the suite', async () => {
+    const r = createTableRegistry()
+    const { calls, create } = recordingCreator()
+    r.declare(def('only-this-one'))
+    await r.provision(create)
+    expect(calls).toEqual(['only-this-one'])
+  })
+
+  it('does not create concurrently for a def already in flight', async () => {
+    const r = createTableRegistry()
+    const { calls, create } = recordingCreator()
+    r.declare(def('a'))
+
+    await Promise.all([r.provision(create), r.provision(create), r.provision(create)])
+
+    expect(calls).toEqual(['a'])
+  })
+
+  it('propagates a creation failure so setup can record it at run level', async () => {
+    const r = createTableRegistry()
+    r.declare(def('a'))
+    await expect(
+      r.provision(async () => {
+        throw new Error('CreateTable exploded')
+      }),
+    ).rejects.toThrow('CreateTable exploded')
+  })
+
+  it('retries a failed creation on the next attempt rather than replaying the rejection', async () => {
+    const r = createTableRegistry()
+    r.declare(def('a'))
+    let attempts = 0
+    const flaky = async () => {
+      attempts++
+      if (attempts === 1) throw new Error('transient')
+    }
+
+    await expect(r.provision(flaky)).rejects.toThrow('transient')
+    await expect(r.provision(flaky)).resolves.toBeUndefined()
+    expect(attempts).toBe(2)
+  })
+
+  it('does not retry a table that already succeeded when a sibling failed', async () => {
+    const r = createTableRegistry()
+    r.declare(def('good'), def('bad'))
+    const seen: string[] = []
+    const create = async (d: TestTableDef) => {
+      seen.push(d.name)
+      if (d.name === 'bad' && seen.filter((n) => n === 'bad').length === 1) {
+        throw new Error('transient')
+      }
+    }
+
+    await expect(r.provision(create)).rejects.toThrow('transient')
+    await r.provision(create)
+
+    expect(seen).toEqual(['good', 'bad', 'bad'])
+  })
+})
+
+describe('createTableRegistry — the leftover sweep', () => {
+  it('sweeps once however many files call it', async () => {
+    const r = createTableRegistry()
+    let sweeps = 0
+    const sweep = async () => {
+      sweeps++
+    }
+
+    await r.sweepOnce(sweep)
+    await r.sweepOnce(sweep)
+    await r.sweepOnce(sweep)
+
+    expect(sweeps).toBe(1)
+  })
+
+  it('does not sweep again once tables have been provisioned', async () => {
+    // The regression this guards: a sweep sharing provisioning's guard would
+    // run again mid-run and delete the shared tables in use.
+    const r = createTableRegistry()
+    const { create } = recordingCreator()
+    let sweeps = 0
+    const sweep = async () => {
+      sweeps++
+    }
+
+    r.declare(def('a'))
+    await r.sweepOnce(sweep)
+    await r.provision(create)
+    r.declare(def('b'))
+    await r.sweepOnce(sweep)
+    await r.provision(create)
+
+    expect(sweeps).toBe(1)
+  })
+
+  it('sweeps once under concurrent callers', async () => {
+    const r = createTableRegistry()
+    let sweeps = 0
+    const sweep = async () => {
+      sweeps++
+    }
+
+    await Promise.all([r.sweepOnce(sweep), r.sweepOnce(sweep), r.sweepOnce(sweep)])
+
+    expect(sweeps).toBe(1)
+  })
+
+  it('retries a failed sweep, so a transient fault does not skip cleanup for the run', async () => {
+    const r = createTableRegistry()
+    let attempts = 0
+    const flaky = async () => {
+      attempts++
+      if (attempts === 1) throw new Error('ListTables exploded')
+    }
+
+    await expect(r.sweepOnce(flaky)).rejects.toThrow('ListTables exploded')
+    await r.sweepOnce(flaky)
+    await r.sweepOnce(flaky)
+
+    expect(attempts).toBe(2)
+  })
+
+  it('keeps its guard independent of the provisioning memo', async () => {
+    const r = createTableRegistry()
+    const { calls, create } = recordingCreator()
+    let sweeps = 0
+
+    r.declare(def('a'))
+    await expect(
+      r.sweepOnce(async () => {
+        sweeps++
+        throw new Error('transient')
+      }),
+    ).rejects.toThrow('transient')
+    await r.provision(create)
+    await r.sweepOnce(async () => {
+      sweeps++
+    })
+
+    expect({ sweeps, calls }).toEqual({ sweeps: 2, calls: ['a'] })
+  })
+})

--- a/src/helpers.test.ts
+++ b/src/helpers.test.ts
@@ -2,14 +2,10 @@ import { describe, it, expect } from 'vitest'
 import { createTableRegistry } from './helpers.js'
 import type { TestTableDef } from './types.js'
 
-// The declaration registry behind demand-driven provisioning.
-//
-// These assertions run against a synthetic creator rather than real AWS,
-// because what needs proving is the bookkeeping: how many times a table is
-// created, and how many times the leftover sweep runs. Both are properties the
-// suite cannot observe about itself - a second create surfaces as
-// ResourceInUseException and a second sweep silently deletes tables the run is
-// still using, ~80 files after the code that caused it.
+// The declaration registry behind demand-driven provisioning. Asserted against
+// a synthetic creator: what needs proving is how many times a table is created
+// and how many times the sweep runs, neither of which the suite can observe
+// about itself.
 
 const def = (name: string): TestTableDef => ({
   name,
@@ -151,8 +147,7 @@ describe('createTableRegistry — the leftover sweep', () => {
   })
 
   it('does not sweep again once tables have been provisioned', async () => {
-    // The regression this guards: a sweep sharing provisioning's guard would
-    // run again mid-run and delete the shared tables in use.
+    // A sweep sharing provisioning's guard would delete tables still in use.
     const r = createTableRegistry()
     const { create } = recordingCreator()
     let sweeps = 0

--- a/src/helpers.test.ts
+++ b/src/helpers.test.ts
@@ -12,6 +12,10 @@ const def = (name: string): TestTableDef => ({
   hashKey: { name: 'pk', type: 'S' },
 })
 
+// Declarations are keyed by the file that made them, which under vitest is this
+// test file.
+const thisFile = expect.getState().testPath ?? 'unknown'
+
 /** A creator that records what it was asked to create. */
 function recordingCreator() {
   const calls: string[] = []
@@ -28,6 +32,13 @@ describe('createTableRegistry — declarations', () => {
     const r = createTableRegistry()
     r.declare(def('a'), def('b'))
     expect(r.declaredDefs().map((d) => d.name)).toEqual(['a', 'b'])
+  })
+
+  it('attributes declarations to the declaring file', () => {
+    const r = createTableRegistry()
+    r.declare(def('a'))
+    expect(r.declaredBy(thisFile).map((d) => d.name)).toEqual(['a'])
+    expect(r.declaredBy('some/other/file.test.ts')).toEqual([])
   })
 
   it('deduplicates a def declared by several files', () => {
@@ -77,6 +88,26 @@ describe('createTableRegistry — provisioning', () => {
     r.declare(def('only-this-one'))
     await r.provision(create)
     expect(calls).toEqual(['only-this-one'])
+  })
+
+  it('creates nothing for a file that declared nothing', async () => {
+    // The property that makes an excluded axis honest. `--tags-filter` skips
+    // tests but still imports the file, so an excluded file's declaration is
+    // registered; only its hook never runs. Provisioning the whole registry
+    // would create its tables on behalf of whichever file runs next.
+    const r = createTableRegistry()
+    const { calls, create } = recordingCreator()
+    r.declare(def('declared-by-an-excluded-file'))
+    await r.provision(create, 'a/file/that/declared/nothing.test.ts')
+    expect(calls).toEqual([])
+  })
+
+  it('creates only the requesting file\'s tables, not another file\'s', async () => {
+    const r = createTableRegistry()
+    const { calls, create } = recordingCreator()
+    r.declare(def('ours'))
+    await r.provision(create, thisFile)
+    expect(calls).toEqual(['ours'])
   })
 
   it('does not create concurrently for a def already in flight', async () => {
@@ -190,6 +221,30 @@ describe('createTableRegistry — the leftover sweep', () => {
     await r.sweepOnce(flaky)
 
     expect(attempts).toBe(2)
+  })
+
+  it('sweeps before any table is created, on every file', async () => {
+    // src/setup.ts awaits the sweep then provisions. This pins the ordering
+    // that sequence exists to guarantee: nothing may be created before the
+    // one sweep has finished, or the sweep deletes it again.
+    const r = createTableRegistry()
+    const order: string[] = []
+    const sweep = async () => {
+      await Promise.resolve()
+      order.push('sweep')
+    }
+    const create = async (d: TestTableDef) => {
+      order.push(`create:${d.name}`)
+    }
+
+    r.declare(def('a'))
+    await r.sweepOnce(sweep)
+    await r.provision(create)
+    r.declare(def('b'))
+    await r.sweepOnce(sweep)
+    await r.provision(create)
+
+    expect(order).toEqual(['sweep', 'create:a', 'create:b'])
   })
 
   it('keeps its guard independent of the provisioning memo', async () => {

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -283,6 +283,119 @@ async function disableDeletionProtection(tableName: string): Promise<void> {
   }
 }
 
+// ── Demand-driven provisioning ────────────────────────────────────────
+//
+// A test file declares the shared tables it needs at module scope, and
+// src/setup.ts creates whatever the files vitest actually selected asked for.
+// A run that excludes an axis therefore never creates the tables only that axis
+// needed, which is what lets an exclusion like `--tags-filter="!gsi and !lsi"`
+// mean something to an engine that cannot create the excluded thing at all.
+// Provisioning used to run over a fixed list before any filter had been
+// applied, so the run died in setup no matter what it had selected.
+//
+// Module scope rather than a per-file hook, for two reasons. Imports are
+// evaluated before any hook runs, so a file's declaration is always registered
+// by the time the shared beforeAll executes, and provisioning stays a single
+// ordered step instead of scattering across a hundred files' own hooks. And a
+// module-scope call is statically visible, so a guard can fail a file that uses
+// a table def it never declared; the same mistake under a per-file hook would
+// surface only as a missing-table error, and only on the run that happened to
+// select that file.
+//
+// Nothing here reads the tag filter. Deselected files are never imported, so
+// their declarations never register and their tables are never created. That
+// falls out of vitest's collection for free, and keeps provisioning from
+// growing its own copy of the CLI's filter semantics.
+
+interface TableRegistry {
+  declare: (...defs: TestTableDef[]) => void
+  declaredDefs: () => TestTableDef[]
+  provision: (create?: (def: TestTableDef) => Promise<void>) => Promise<void>
+  sweepOnce: (sweep?: () => Promise<void>) => Promise<void>
+}
+
+/**
+ * An isolated declaration set, creation memo, and sweep guard.
+ *
+ * Exported as a factory so the memoisation and retry behaviour can be asserted
+ * against synthetic creators, rather than by counting calls to real AWS.
+ */
+export function createTableRegistry(): TableRegistry {
+  const declared = new Map<string, TestTableDef>()
+  const inFlight = new Map<string, Promise<void>>()
+  let swept: Promise<void> | null = null
+
+  return {
+    declare(...defs: TestTableDef[]): void {
+      for (const def of defs) declared.set(def.name, def)
+    },
+
+    declaredDefs(): TestTableDef[] {
+      return [...declared.values()]
+    },
+
+    async provision(create = createTable): Promise<void> {
+      await Promise.all(
+        [...declared.values()].map((def) => {
+          const existing = inFlight.get(def.name)
+          if (existing) return existing
+          // A rejected attempt drops out of the memo so the next file retries
+          // it rather than replaying the same rejection for the rest of the
+          // run. This is the old flag-set-only-after-success behaviour, held
+          // per table instead of per run.
+          const attempt = create(def).catch((e: unknown) => {
+            inFlight.delete(def.name)
+            throw e
+          })
+          inFlight.set(def.name, attempt)
+          return attempt
+        }),
+      )
+    },
+
+    // Guarded separately from provisioning, and that separation is the whole
+    // point. Provisioning now runs on every test file, creating whatever that
+    // file newly declared; a sweep sharing the same guard would run again after
+    // tables existed and delete the ones earlier files are still using.
+    sweepOnce(sweep = cleanupAllTables): Promise<void> {
+      if (!swept) {
+        swept = sweep().catch((e: unknown) => {
+          swept = null
+          throw e
+        })
+      }
+      return swept
+    },
+  }
+}
+
+// The suite-wide registry. Module state is shared across every test file
+// because the suite runs as a single non-isolated fork (`maxWorkers: 1`,
+// `isolate: false` in vitest.config.ts) - the same property that already lets
+// the table defs below compute their unique names once and be addressed by
+// every file. It breaks silently if anyone ever parallelises the suite.
+const registry = createTableRegistry()
+
+/**
+ * Declare the shared tables a test file needs. Call once at module scope,
+ * naming every shared def the file goes on to use.
+ */
+export const declareTables = registry.declare
+
+/** Every shared table declared by the files collected so far. */
+export const declaredTableDefs = registry.declaredDefs
+
+/**
+ * Create every declared table that no earlier file has created yet.
+ *
+ * Safe to call from a beforeAll that runs per test file: tables already created
+ * are memoised by name, so a def declared by forty files is created once.
+ */
+export const provisionDeclaredTables = registry.provision
+
+/** Sweep leftover tables exactly once per run, before anything is created. */
+export const cleanupAllTablesOnce = registry.sweepOnce
+
 /** Delete all tables created by the conformance suite */
 export async function cleanupAllTables(): Promise<void> {
   const allNames: string[] = []

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -165,10 +165,23 @@ export async function waitUntilActive(
   )
 }
 
-/** Create a table from a TestTableDef and wait for it to become ACTIVE */
+/**
+ * Create a table from a TestTableDef and wait for it to become ACTIVE.
+ *
+ * Idempotent on the create itself. An attempt whose CreateTable succeeded but
+ * whose activation wait timed out leaves the table behind, and table names are
+ * fixed for the run - so the retry must adopt the existing table rather than
+ * collide with it. Without this, one slow activation turns every later file's
+ * provisioning into ResourceInUseException, which is a real answer rather than
+ * an indeterminate one and would publish a run of false disagreements.
+ */
 export async function createTable(def: TestTableDef): Promise<void> {
   const input = buildCreateInput(def)
-  await ddb.send(new CreateTableCommand(input))
+  try {
+    await ddb.send(new CreateTableCommand(input))
+  } catch (e: unknown) {
+    if (!(e instanceof ResourceInUseException)) throw e
+  }
   await waitUntilActive(def.name)
 }
 
@@ -285,41 +298,80 @@ async function disableDeletionProtection(tableName: string): Promise<void> {
 
 // ── Demand-driven provisioning ────────────────────────────────────────
 //
-// A test file declares the shared tables it needs at module scope; setup
-// creates only what the selected files declared, so an excluded axis never
-// creates its tables. Deselected files are never imported, so nothing here
-// needs to read the tag filter.
+// A test file declares the shared tables it needs at module scope, and setup
+// creates only the tables declared by the file whose hook is running.
 //
-// Module scope rather than a per-file hook because a static declaration can be
-// checked by a guard; a missing declaration would otherwise surface only as a
-// runtime missing-table error on the run that selected that file.
+// Scoping to the declaring file is load-bearing, not tidiness. `--tags-filter`
+// skips tests; it does not deselect files, so vitest still imports an excluded
+// file and its declaration still registers. Its setup hook does not run,
+// though, so keying declarations by file is what stops an excluded axis
+// creating its tables - provisioning the whole registry would create them on
+// behalf of the next file that runs.
+//
+// Module scope rather than inside a hook because a static declaration can be
+// checked by scripts/table-declarations.test.mjs; a missing declaration would
+// otherwise surface only as a runtime missing-table error, and only on a run
+// narrow enough that no other file declared the same table.
 
 interface TableRegistry {
-  declare: (...defs: TestTableDef[]) => void
-  declaredDefs: () => TestTableDef[]
-  provision: (create?: (def: TestTableDef) => Promise<void>) => Promise<void>
-  sweepOnce: (sweep?: () => Promise<void>) => Promise<void>
+  // `this: void` so unbinding these onto module-level consts below stays safe:
+  // a future edit reaching for `this` fails to compile rather than at runtime.
+  declare: (this: void, ...defs: TestTableDef[]) => void
+  declaredDefs: (this: void) => TestTableDef[]
+  declaredBy: (this: void, file: string) => TestTableDef[]
+  provision: (
+    this: void,
+    create?: (def: TestTableDef) => Promise<void>,
+    file?: string,
+  ) => Promise<void>
+  sweepOnce: (this: void, sweep?: () => Promise<void>) => Promise<void>
+}
+
+/**
+ * The file vitest is currently importing or running, used to scope
+ * declarations. Available at module-import time as well as inside hooks.
+ */
+function currentTestFile(): string {
+  return expect.getState().testPath ?? 'unknown'
 }
 
 /** A declaration set, creation memo and sweep guard. A factory so the
  * memoisation and retry behaviour can be tested without real AWS. */
 export function createTableRegistry(): TableRegistry {
   const declared = new Map<string, TestTableDef>()
+  const declaringFiles = new Map<string, Set<string>>()
   const inFlight = new Map<string, Promise<void>>()
   let swept: Promise<void> | null = null
 
   return {
     declare(...defs: TestTableDef[]): void {
-      for (const def of defs) declared.set(def.name, def)
+      const file = currentTestFile()
+      for (const def of defs) {
+        declared.set(def.name, def)
+        const files = declaringFiles.get(file) ?? new Set<string>()
+        files.add(def.name)
+        declaringFiles.set(file, files)
+      }
     },
 
     declaredDefs(): TestTableDef[] {
       return [...declared.values()]
     },
 
-    async provision(create = createTable): Promise<void> {
+    declaredBy(file: string): TestTableDef[] {
+      const names = declaringFiles.get(file) ?? new Set<string>()
+      return [...names].flatMap((n) => {
+        const def = declared.get(n)
+        return def ? [def] : []
+      })
+    },
+
+    async provision(create = createTable, file = currentTestFile()): Promise<void> {
+      const names = declaringFiles.get(file) ?? new Set<string>()
       await Promise.all(
-        [...declared.values()].map((def) => {
+        [...names].map((name) => {
+          const def = declared.get(name)
+          if (!def) return Promise.resolve()
           const existing = inFlight.get(def.name)
           if (existing) return existing
           // Drop a rejected attempt from the memo so the next file retries it
@@ -359,7 +411,10 @@ export const declareTables = registry.declare
 /** Every shared table declared by the files collected so far. */
 export const declaredTableDefs = registry.declaredDefs
 
-/** Create every declared table not already created. Safe to call per file. */
+/** The shared tables one test file declared. */
+export const tablesDeclaredBy = registry.declaredBy
+
+/** Create the current file's declared tables. Safe to call per file. */
 export const provisionDeclaredTables = registry.provision
 
 /** Sweep leftover tables exactly once per run, before anything is created. */
@@ -536,9 +591,8 @@ export const compositeTableDef: TestTableDef = {
 // `lsi1sk` exactly. One indexed variant carries both kinds, so excluding both
 // axes together is the guarantee and excluding one is not; see README.
 export const compositeIndexedTableDef: TestTableDef = {
+  ...compositeTableDef,
   name: uniqueTableName('compositeIdx'),
-  hashKey: { name: 'pk', type: 'S' },
-  rangeKey: { name: 'sk', type: 'S' },
   lsis: [
     {
       indexName: 'lsi1',

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -285,27 +285,14 @@ async function disableDeletionProtection(tableName: string): Promise<void> {
 
 // ── Demand-driven provisioning ────────────────────────────────────────
 //
-// A test file declares the shared tables it needs at module scope, and
-// src/setup.ts creates whatever the files vitest actually selected asked for.
-// A run that excludes an axis therefore never creates the tables only that axis
-// needed, which is what lets an exclusion like `--tags-filter="!gsi and !lsi"`
-// mean something to an engine that cannot create the excluded thing at all.
-// Provisioning used to run over a fixed list before any filter had been
-// applied, so the run died in setup no matter what it had selected.
+// A test file declares the shared tables it needs at module scope; setup
+// creates only what the selected files declared, so an excluded axis never
+// creates its tables. Deselected files are never imported, so nothing here
+// needs to read the tag filter.
 //
-// Module scope rather than a per-file hook, for two reasons. Imports are
-// evaluated before any hook runs, so a file's declaration is always registered
-// by the time the shared beforeAll executes, and provisioning stays a single
-// ordered step instead of scattering across a hundred files' own hooks. And a
-// module-scope call is statically visible, so a guard can fail a file that uses
-// a table def it never declared; the same mistake under a per-file hook would
-// surface only as a missing-table error, and only on the run that happened to
-// select that file.
-//
-// Nothing here reads the tag filter. Deselected files are never imported, so
-// their declarations never register and their tables are never created. That
-// falls out of vitest's collection for free, and keeps provisioning from
-// growing its own copy of the CLI's filter semantics.
+// Module scope rather than a per-file hook because a static declaration can be
+// checked by a guard; a missing declaration would otherwise surface only as a
+// runtime missing-table error on the run that selected that file.
 
 interface TableRegistry {
   declare: (...defs: TestTableDef[]) => void
@@ -314,12 +301,8 @@ interface TableRegistry {
   sweepOnce: (sweep?: () => Promise<void>) => Promise<void>
 }
 
-/**
- * An isolated declaration set, creation memo, and sweep guard.
- *
- * Exported as a factory so the memoisation and retry behaviour can be asserted
- * against synthetic creators, rather than by counting calls to real AWS.
- */
+/** A declaration set, creation memo and sweep guard. A factory so the
+ * memoisation and retry behaviour can be tested without real AWS. */
 export function createTableRegistry(): TableRegistry {
   const declared = new Map<string, TestTableDef>()
   const inFlight = new Map<string, Promise<void>>()
@@ -339,10 +322,8 @@ export function createTableRegistry(): TableRegistry {
         [...declared.values()].map((def) => {
           const existing = inFlight.get(def.name)
           if (existing) return existing
-          // A rejected attempt drops out of the memo so the next file retries
-          // it rather than replaying the same rejection for the rest of the
-          // run. This is the old flag-set-only-after-success behaviour, held
-          // per table instead of per run.
+          // Drop a rejected attempt from the memo so the next file retries it
+          // instead of replaying the rejection.
           const attempt = create(def).catch((e: unknown) => {
             inFlight.delete(def.name)
             throw e
@@ -353,10 +334,8 @@ export function createTableRegistry(): TableRegistry {
       )
     },
 
-    // Guarded separately from provisioning, and that separation is the whole
-    // point. Provisioning now runs on every test file, creating whatever that
-    // file newly declared; a sweep sharing the same guard would run again after
-    // tables existed and delete the ones earlier files are still using.
+    // Guarded separately from provisioning: provisioning runs per file, and a
+    // sweep sharing that guard would delete tables earlier files are using.
     sweepOnce(sweep = cleanupAllTables): Promise<void> {
       if (!swept) {
         swept = sweep().catch((e: unknown) => {
@@ -369,28 +348,18 @@ export function createTableRegistry(): TableRegistry {
   }
 }
 
-// The suite-wide registry. Module state is shared across every test file
-// because the suite runs as a single non-isolated fork (`maxWorkers: 1`,
-// `isolate: false` in vitest.config.ts) - the same property that already lets
-// the table defs below compute their unique names once and be addressed by
-// every file. It breaks silently if anyone ever parallelises the suite.
+// Shared across every test file only because the suite runs as a single
+// non-isolated fork (maxWorkers: 1, isolate: false in vitest.config.ts), the
+// same property the table defs below rely on for their names.
 const registry = createTableRegistry()
 
-/**
- * Declare the shared tables a test file needs. Call once at module scope,
- * naming every shared def the file goes on to use.
- */
+/** Declare the shared tables a file uses. Call once at module scope. */
 export const declareTables = registry.declare
 
 /** Every shared table declared by the files collected so far. */
 export const declaredTableDefs = registry.declaredDefs
 
-/**
- * Create every declared table that no earlier file has created yet.
- *
- * Safe to call from a beforeAll that runs per test file: tables already created
- * are memoised by name, so a def declared by forty files is created once.
- */
+/** Create every declared table not already created. Safe to call per file. */
 export const provisionDeclaredTables = registry.provision
 
 /** Sweep leftover tables exactly once per run, before anything is created. */
@@ -554,8 +523,20 @@ export const gsiBTableDef: TestTableDef = {
   billingMode: 'PAY_PER_REQUEST',
 }
 
+// The generic composite-key table. No secondary index, so a run excluding both
+// index axes creates nothing an index-free engine would reject.
 export const compositeTableDef: TestTableDef = {
   name: uniqueTableName('composite'),
+  hashKey: { name: 'pk', type: 'S' },
+  rangeKey: { name: 'sk', type: 'S' },
+}
+
+// The same key schema carrying the secondary indexes. Index names, projections
+// and key attributes are unchanged - tests pin messages naming `gsi1` and
+// `lsi1sk` exactly. One indexed variant carries both kinds, so excluding both
+// axes together is the guarantee and excluding one is not; see README.
+export const compositeIndexedTableDef: TestTableDef = {
+  name: uniqueTableName('compositeIdx'),
   hashKey: { name: 'pk', type: 'S' },
   rangeKey: { name: 'sk', type: 'S' },
   lsis: [

--- a/src/setup.ts
+++ b/src/setup.ts
@@ -7,17 +7,13 @@ import {
 } from './indeterminate-sink.js'
 import { clearObservedMarker } from './observation-sink.js'
 
-// Provision the shared tables the selected test files asked for.
+// Provision the shared tables the selected test files declared.
 //
-// vitest 4 runs setupFiles' beforeAll for every test file (vitest 3's singleFork
-// ran it once), and each file's declarations only register when that file is
-// imported, so this hook has to run per file to create what the newest file
-// added. Both steps are idempotent across those runs, and each is guarded in
-// src/helpers.ts for a different reason: tables are memoised by name, so a def
-// forty files declare is created once rather than deleted and recreated ~100
-// times a run; the sweep is memoised separately so it stays one pass at run
-// start and never deletes tables a later file is still using. Final teardown
-// runs once in src/global-teardown.ts.
+// vitest 4 runs this beforeAll per test file, and a file's declarations only
+// register once it is imported, so the hook must run per file to create what
+// the newest one added. Both steps are guarded in src/helpers.ts: tables are
+// memoised by name, the sweep separately so it stays one pass at run start.
+// Final teardown runs once in src/global-teardown.ts.
 beforeAll(async () => {
   try {
     await cleanupAllTablesOnce()

--- a/src/setup.ts
+++ b/src/setup.ts
@@ -1,14 +1,4 @@
-import {
-  createTable,
-  cleanupAllTables,
-  hashTableDef,
-  hashNTableDef,
-  hashBTableDef,
-  gsiBTableDef,
-  compositeTableDef,
-  compositeNTableDef,
-  compositeBTableDef,
-} from './helpers.js'
+import { cleanupAllTablesOnce, provisionDeclaredTables } from './helpers.js'
 import { indeterminateFrom } from './indeterminate.js'
 import {
   clearIndeterminateMarker,
@@ -17,29 +7,21 @@ import {
 } from './indeterminate-sink.js'
 import { clearObservedMarker } from './observation-sink.js'
 
-// Provision the shared tables once per run.
+// Provision the shared tables the selected test files asked for.
 //
 // vitest 4 runs setupFiles' beforeAll for every test file (vitest 3's singleFork
-// ran it once), so without this guard the suite deletes and recreates the
-// shared tables ~once per file - ~100 times a run. That is slow, and on real AWS
-// the churn of just-created tables surfaces as InternalServerException on the
-// data operations that hit them. The single fork (maxWorkers: 1) means every
-// file shares one process, so a process.env flag set after the first successful
-// provision is seen by every later file. Final teardown runs once in
-// src/global-teardown.ts.
+// ran it once), and each file's declarations only register when that file is
+// imported, so this hook has to run per file to create what the newest file
+// added. Both steps are idempotent across those runs, and each is guarded in
+// src/helpers.ts for a different reason: tables are memoised by name, so a def
+// forty files declare is created once rather than deleted and recreated ~100
+// times a run; the sweep is memoised separately so it stays one pass at run
+// start and never deletes tables a later file is still using. Final teardown
+// runs once in src/global-teardown.ts.
 beforeAll(async () => {
-  if (process.env.CONFORMANCE_PROVISIONED === '1') return
   try {
-    await cleanupAllTables()
-    await Promise.all([
-      createTable(hashTableDef),
-      createTable(hashNTableDef),
-      createTable(hashBTableDef),
-      createTable(gsiBTableDef),
-      createTable(compositeTableDef),
-      createTable(compositeNTableDef),
-      createTable(compositeBTableDef),
-    ])
+    await cleanupAllTablesOnce()
+    await provisionDeclaredTables()
   } catch (e: unknown) {
     // Vitest does not retry beforeAll, so a provisioning failure takes out the
     // whole run and no test ever executes to annotate itself. When the failure
@@ -56,8 +38,6 @@ beforeAll(async () => {
     }
     throw e
   }
-  // Set only after success, so a failed first attempt is retried by the next file.
-  process.env.CONFORMANCE_PROVISIONED = '1'
 }, 180_000)
 
 // Clear both task.meta markers at the start of every attempt. task.meta lives

--- a/src/setup.ts
+++ b/src/setup.ts
@@ -7,13 +7,13 @@ import {
 } from './indeterminate-sink.js'
 import { clearObservedMarker } from './observation-sink.js'
 
-// Provision the shared tables the selected test files declared.
+// Provision the tables this test file declared.
 //
-// vitest 4 runs this beforeAll per test file, and a file's declarations only
-// register once it is imported, so the hook must run per file to create what
-// the newest one added. Both steps are guarded in src/helpers.ts: tables are
-// memoised by name, the sweep separately so it stays one pass at run start.
-// Final teardown runs once in src/global-teardown.ts.
+// vitest 4 runs this beforeAll per test file, and it does not run at all for a
+// file whose tests were all filtered out - which is what keeps an excluded
+// axis from creating its tables. Both steps are guarded in src/helpers.ts:
+// tables are memoised by name, the sweep separately so it stays one pass at
+// run start. Final teardown runs once in src/global-teardown.ts.
 beforeAll(async () => {
   try {
     await cleanupAllTablesOnce()

--- a/tests/tier1/batchGetItem/basic.test.ts
+++ b/tests/tier1/batchGetItem/basic.test.ts
@@ -3,7 +3,9 @@ import {
   PutItemCommand,
 } from '@aws-sdk/client-dynamodb'
 import { ddb } from '../../../src/client.js'
-import { hashTableDef, compositeTableDef, cleanupItems } from '../../../src/helpers.js'
+import { declareTables, hashTableDef, compositeTableDef, cleanupItems } from '../../../src/helpers.js'
+
+declareTables(hashTableDef, compositeTableDef)
 
 describe('BatchGetItem — basic', { tags: ['batch', 'data-plane'] }, () => {
   const items = Array.from({ length: 5 }, (_, i) => ({

--- a/tests/tier1/batchGetItem/projection.test.ts
+++ b/tests/tier1/batchGetItem/projection.test.ts
@@ -1,6 +1,8 @@
 import { PutItemCommand, BatchGetItemCommand } from '@aws-sdk/client-dynamodb'
 import { ddb } from '../../../src/client.js'
-import { hashTableDef, cleanupItems } from '../../../src/helpers.js'
+import { declareTables, hashTableDef, cleanupItems } from '../../../src/helpers.js'
+
+declareTables(hashTableDef)
 
 describe('BatchGetItem — legal shared-prefix projections', { tags: ['batch', 'data-plane'] }, () => {
   // Projection paths that share a prefix without one being a prefix of the

--- a/tests/tier1/batchGetItem/validation.test.ts
+++ b/tests/tier1/batchGetItem/validation.test.ts
@@ -1,6 +1,8 @@
 import { BatchGetItemCommand } from '@aws-sdk/client-dynamodb'
 import { ddb } from '../../../src/client.js'
-import { hashTableDef, expectDynamoError } from '../../../src/helpers.js'
+import { declareTables, hashTableDef, expectDynamoError } from '../../../src/helpers.js'
+
+declareTables(hashTableDef)
 
 describe('BatchGetItem — validation', { tags: ['batch', 'data-plane', 'negative-path'] }, () => {
   it('rejects more than 100 keys', async () => {

--- a/tests/tier1/batchWriteItem/basic.test.ts
+++ b/tests/tier1/batchWriteItem/basic.test.ts
@@ -4,7 +4,9 @@ import {
   PutItemCommand,
 } from '@aws-sdk/client-dynamodb'
 import { ddb } from '../../../src/client.js'
-import { hashTableDef, compositeTableDef, cleanupItems } from '../../../src/helpers.js'
+import { declareTables, hashTableDef, compositeTableDef, cleanupItems } from '../../../src/helpers.js'
+
+declareTables(hashTableDef, compositeTableDef)
 
 describe('BatchWriteItem — basic', { tags: ['batch', 'data-plane'] }, () => {
   afterAll(async () => {

--- a/tests/tier1/batchWriteItem/indexKeyValidation.test.ts
+++ b/tests/tier1/batchWriteItem/indexKeyValidation.test.ts
@@ -8,7 +8,7 @@ import {
 
 declareTables(compositeIndexedTableDef)
 
-describe('BatchWriteItem — index key validation', { tags: ['batch', 'data-plane', 'negative-path', 'lsi'] }, () => {
+describe('BatchWriteItem — index key validation', { tags: ['batch', 'data-plane', 'negative-path', 'gsi', 'lsi'] }, () => {
   // An index key value whose type is wrong, is non-scalar, or is an empty
   // string is rejected. BatchWriteItem validates the item up front, so every
   // variant is a top-level ValidationException for the whole request - there is

--- a/tests/tier1/batchWriteItem/indexKeyValidation.test.ts
+++ b/tests/tier1/batchWriteItem/indexKeyValidation.test.ts
@@ -1,0 +1,76 @@
+import { BatchWriteItemCommand } from '@aws-sdk/client-dynamodb'
+import { ddb } from '../../../src/client.js'
+import {
+  compositeIndexedTableDef,
+  expectDynamoError,
+  declareTables,
+} from '../../../src/helpers.js'
+
+declareTables(compositeIndexedTableDef)
+
+describe('BatchWriteItem — index key validation', { tags: ['batch', 'data-plane', 'negative-path', 'lsi'] }, () => {
+  // An index key value whose type is wrong, is non-scalar, or is an empty
+  // string is rejected. BatchWriteItem validates the item up front, so every
+  // variant is a top-level ValidationException for the whole request - there is
+  // no cancellation path here, unlike TransactWriteItems. Exact strings are
+  // pinned in tests/tier3/error-messages/batchWriteItem.test.ts.
+  it('rejects a wrong-typed index key value', async () => {
+    await expectDynamoError(
+      () => ddb.send(
+        new BatchWriteItemCommand({
+          RequestItems: {
+            [compositeIndexedTableDef.name]: [
+              {
+                PutRequest: {
+                  Item: { pk: { S: 'bw-idx-type' }, sk: { S: 'a' }, lsi1sk: { N: '5' } },
+                },
+              },
+            ],
+          },
+        }),
+      ),
+      'ValidationException',
+      /Type mismatch for Index Key/,
+    )
+  })
+
+  it('rejects a non-scalar index key value', async () => {
+    await expectDynamoError(
+      () => ddb.send(
+        new BatchWriteItemCommand({
+          RequestItems: {
+            [compositeIndexedTableDef.name]: [
+              {
+                PutRequest: {
+                  Item: { pk: { S: 'bw-idx-nonscalar' }, sk: { S: 'b' }, lsi1sk: { L: [{ S: 'x' }] } },
+                },
+              },
+            ],
+          },
+        }),
+      ),
+      'ValidationException',
+      /Type mismatch for Index Key/,
+    )
+  })
+
+  it('rejects an empty-string index key value', async () => {
+    await expectDynamoError(
+      () => ddb.send(
+        new BatchWriteItemCommand({
+          RequestItems: {
+            [compositeIndexedTableDef.name]: [
+              {
+                PutRequest: {
+                  Item: { pk: { S: 'bw-idx-empty' }, sk: { S: 'c' }, lsi1sk: { S: '' } },
+                },
+              },
+            ],
+          },
+        }),
+      ),
+      'ValidationException',
+      /secondary index key/i,
+    )
+  })
+})

--- a/tests/tier1/batchWriteItem/validation.test.ts
+++ b/tests/tier1/batchWriteItem/validation.test.ts
@@ -4,7 +4,10 @@ import {
   hashTableDef,
   compositeTableDef,
   expectDynamoError,
+  declareTables,
 } from '../../../src/helpers.js'
+
+declareTables(hashTableDef, compositeTableDef)
 
 describe('BatchWriteItem — validation', { tags: ['batch', 'data-plane', 'negative-path'] }, () => {
   it('rejects more than 25 items', async () => {

--- a/tests/tier1/batchWriteItem/validation.test.ts
+++ b/tests/tier1/batchWriteItem/validation.test.ts
@@ -2,12 +2,11 @@ import { BatchWriteItemCommand } from '@aws-sdk/client-dynamodb'
 import { ddb } from '../../../src/client.js'
 import {
   hashTableDef,
-  compositeTableDef,
   expectDynamoError,
   declareTables,
 } from '../../../src/helpers.js'
 
-declareTables(hashTableDef, compositeTableDef)
+declareTables(hashTableDef)
 
 describe('BatchWriteItem — validation', { tags: ['batch', 'data-plane', 'negative-path'] }, () => {
   it('rejects more than 25 items', async () => {
@@ -90,11 +89,11 @@ describe('BatchWriteItem — validation', { tags: ['batch', 'data-plane', 'negat
     }
   })
 
-  // A key attribute (table or index) whose value has the wrong type, is
-  // non-scalar, or is an empty string is rejected. BatchWriteItem validates the
-  // item up front, so every variant is a top-level ValidationException for the
-  // whole request - there is no cancellation path here, unlike TransactWriteItems.
-  // Exact strings are pinned in tests/tier3/error-messages/batchWriteItem.test.ts.
+  // A table key attribute whose value has the wrong type, is non-scalar, or is
+  // an empty string is rejected. BatchWriteItem validates the item up front, so
+  // every variant is a top-level ValidationException for the whole request -
+  // there is no cancellation path here, unlike TransactWriteItems. Exact
+  // strings are pinned in tests/tier3/error-messages/batchWriteItem.test.ts.
   it('rejects a wrong-typed table key value', async () => {
     await expectDynamoError(
       () => ddb.send(
@@ -140,66 +139,6 @@ describe('BatchWriteItem — validation', { tags: ['batch', 'data-plane', 'negat
       ),
       'ValidationException',
       /empty string value/i,
-    )
-  })
-
-  it('rejects a wrong-typed index key value', async () => {
-    await expectDynamoError(
-      () => ddb.send(
-        new BatchWriteItemCommand({
-          RequestItems: {
-            [compositeTableDef.name]: [
-              {
-                PutRequest: {
-                  Item: { pk: { S: 'bw-idx-type' }, sk: { S: 'a' }, lsi1sk: { N: '5' } },
-                },
-              },
-            ],
-          },
-        }),
-      ),
-      'ValidationException',
-      /Type mismatch for Index Key/,
-    )
-  })
-
-  it('rejects a non-scalar index key value', async () => {
-    await expectDynamoError(
-      () => ddb.send(
-        new BatchWriteItemCommand({
-          RequestItems: {
-            [compositeTableDef.name]: [
-              {
-                PutRequest: {
-                  Item: { pk: { S: 'bw-idx-nonscalar' }, sk: { S: 'b' }, lsi1sk: { L: [{ S: 'x' }] } },
-                },
-              },
-            ],
-          },
-        }),
-      ),
-      'ValidationException',
-      /Type mismatch for Index Key/,
-    )
-  })
-
-  it('rejects an empty-string index key value', async () => {
-    await expectDynamoError(
-      () => ddb.send(
-        new BatchWriteItemCommand({
-          RequestItems: {
-            [compositeTableDef.name]: [
-              {
-                PutRequest: {
-                  Item: { pk: { S: 'bw-idx-empty' }, sk: { S: 'c' }, lsi1sk: { S: '' } },
-                },
-              },
-            ],
-          },
-        }),
-      ),
-      'ValidationException',
-      /secondary index key/i,
     )
   })
 })

--- a/tests/tier1/createTable/basic.test.ts
+++ b/tests/tier1/createTable/basic.test.ts
@@ -10,7 +10,10 @@ import {
   deleteTable,
   expectDynamoError,
   hashTableDef,
+  declareTables,
 } from '../../../src/helpers.js'
+
+declareTables(hashTableDef)
 
 describe('CreateTable — basic', { tags: ['create-table', 'control-plane'] }, () => {
   const tablesToCleanup: string[] = []

--- a/tests/tier1/createTable/basic.test.ts
+++ b/tests/tier1/createTable/basic.test.ts
@@ -261,7 +261,7 @@ describe('CreateTable — validation', { tags: ['create-table', 'control-plane',
 
   // ProjectionType INCLUDE means "key attributes plus this explicit list"; the list is
   // mandatory, so INCLUDE without NonKeyAttributes is rejected.
-  it('rejects a GSI INCLUDE projection without NonKeyAttributes', async () => {
+  it('rejects a GSI INCLUDE projection without NonKeyAttributes', { tags: ['gsi'] }, async () => {
     await expectDynamoError(
       () => ddb.send(
         new CreateTableCommand({

--- a/tests/tier1/createTable/specValidation.test.ts
+++ b/tests/tier1/createTable/specValidation.test.ts
@@ -5,7 +5,7 @@ import { uniqueTableName } from '../../../src/helpers.js'
 // The INCLUDE-without-NonKeyAttributes and disabled-stream-with-StreamViewType
 // rejections are already covered in createTable/basic.test.ts; this pins the
 // remaining corner real AWS rejects.
-describe('CreateTable — index and stream spec validation', { tags: ['create-table', 'control-plane', 'negative-path'] }, () => {
+describe('CreateTable — index and stream spec validation', { tags: ['create-table', 'control-plane', 'negative-path', 'gsi'] }, () => {
   it('rejects a KEYS_ONLY GSI projection carrying NonKeyAttributes', async () => {
     try {
       await ddb.send(

--- a/tests/tier1/deleteItem/basic.test.ts
+++ b/tests/tier1/deleteItem/basic.test.ts
@@ -9,7 +9,10 @@ import {
   compositeTableDef,
   expectDynamoError,
   cleanupItems,
+  declareTables,
 } from '../../../src/helpers.js'
+
+declareTables(hashTableDef, compositeTableDef)
 
 describe('DeleteItem — basic', { tags: ['delete-item', 'data-plane'] }, () => {
   it('deletes an existing item', async () => {

--- a/tests/tier1/deleteItem/conditionExpressionParens.test.ts
+++ b/tests/tier1/deleteItem/conditionExpressionParens.test.ts
@@ -4,7 +4,9 @@ import {
   DeleteItemCommand,
 } from '@aws-sdk/client-dynamodb'
 import { ddb } from '../../../src/client.js'
-import { hashTableDef, expectDynamoError, cleanupItems } from '../../../src/helpers.js'
+import { declareTables, hashTableDef, expectDynamoError, cleanupItems } from '../../../src/helpers.js'
+
+declareTables(hashTableDef)
 
 // Exercises the DeleteItem ConditionExpression parser with parenthesised forms.
 describe('DeleteItem — ConditionExpression parens', { tags: ['delete-item', 'data-plane'] }, () => {

--- a/tests/tier1/describeTable/basic.test.ts
+++ b/tests/tier1/describeTable/basic.test.ts
@@ -4,7 +4,10 @@ import {
   hashTableDef,
   compositeTableDef,
   expectDynamoError,
+  declareTables,
 } from '../../../src/helpers.js'
+
+declareTables(hashTableDef, compositeTableDef)
 
 describe('DescribeTable — basic', { tags: ['describe-table', 'control-plane'] }, () => {
   it('returns table metadata for a hash-only table', async () => {

--- a/tests/tier1/describeTable/basic.test.ts
+++ b/tests/tier1/describeTable/basic.test.ts
@@ -2,12 +2,11 @@ import { DescribeTableCommand } from '@aws-sdk/client-dynamodb'
 import { ddb } from '../../../src/client.js'
 import {
   hashTableDef,
-  compositeTableDef,
   expectDynamoError,
   declareTables,
 } from '../../../src/helpers.js'
 
-declareTables(hashTableDef, compositeTableDef)
+declareTables(hashTableDef)
 
 describe('DescribeTable — basic', { tags: ['describe-table', 'control-plane'] }, () => {
   it('returns table metadata for a hash-only table', async () => {
@@ -28,32 +27,6 @@ describe('DescribeTable — basic', { tags: ['describe-table', 'control-plane'] 
     expect(table.CreationDateTime).toBeDefined()
     expect(table.ItemCount).toBeDefined()
     expect(table.TableSizeBytes).toBeDefined()
-  })
-
-  it('returns table metadata for a composite table with indexes', async () => {
-    const result = await ddb.send(
-      new DescribeTableCommand({ TableName: compositeTableDef.name }),
-    )
-    const table = result.Table!
-
-    expect(table.TableName).toBe(compositeTableDef.name)
-    expect(table.KeySchema).toHaveLength(2)
-
-    // LSIs
-    expect(table.LocalSecondaryIndexes).toBeDefined()
-    expect(table.LocalSecondaryIndexes).toHaveLength(2)
-
-    // GSIs
-    expect(table.GlobalSecondaryIndexes).toBeDefined()
-    expect(table.GlobalSecondaryIndexes).toHaveLength(2)
-
-    // Each GSI should have IndexStatus
-    for (const gsi of table.GlobalSecondaryIndexes!) {
-      expect(gsi.IndexName).toBeDefined()
-      expect(gsi.IndexStatus).toBe('ACTIVE')
-      expect(gsi.KeySchema).toBeDefined()
-      expect(gsi.Projection).toBeDefined()
-    }
   })
 })
 

--- a/tests/tier1/describeTable/indexes.test.ts
+++ b/tests/tier1/describeTable/indexes.test.ts
@@ -1,0 +1,36 @@
+import { DescribeTableCommand } from '@aws-sdk/client-dynamodb'
+import { ddb } from '../../../src/client.js'
+import {
+  compositeIndexedTableDef,
+  declareTables,
+} from '../../../src/helpers.js'
+
+declareTables(compositeIndexedTableDef)
+
+describe('DescribeTable — secondary indexes', { tags: ['describe-table', 'control-plane', 'gsi', 'lsi'] }, () => {
+  it('returns table metadata for a composite table with indexes', async () => {
+    const result = await ddb.send(
+      new DescribeTableCommand({ TableName: compositeIndexedTableDef.name }),
+    )
+    const table = result.Table!
+
+    expect(table.TableName).toBe(compositeIndexedTableDef.name)
+    expect(table.KeySchema).toHaveLength(2)
+
+    // LSIs
+    expect(table.LocalSecondaryIndexes).toBeDefined()
+    expect(table.LocalSecondaryIndexes).toHaveLength(2)
+
+    // GSIs
+    expect(table.GlobalSecondaryIndexes).toBeDefined()
+    expect(table.GlobalSecondaryIndexes).toHaveLength(2)
+
+    // Each GSI should have IndexStatus
+    for (const gsi of table.GlobalSecondaryIndexes!) {
+      expect(gsi.IndexName).toBeDefined()
+      expect(gsi.IndexStatus).toBe('ACTIVE')
+      expect(gsi.KeySchema).toBeDefined()
+      expect(gsi.Projection).toBeDefined()
+    }
+  })
+})

--- a/tests/tier1/getItem/basic.test.ts
+++ b/tests/tier1/getItem/basic.test.ts
@@ -8,7 +8,10 @@ import {
   hashTableDef,
   compositeTableDef,
   cleanupItems,
+  declareTables,
 } from '../../../src/helpers.js'
+
+declareTables(hashTableDef, compositeTableDef)
 
 describe('GetItem — basic', { tags: ['get-item', 'data-plane'] }, () => {
   beforeAll(async () => {

--- a/tests/tier1/getItem/basic.test.ts
+++ b/tests/tier1/getItem/basic.test.ts
@@ -1,7 +1,6 @@
 import {
   PutItemCommand,
   GetItemCommand,
-  DeleteItemCommand,
 } from '@aws-sdk/client-dynamodb'
 import { ddb } from '../../../src/client.js'
 import {

--- a/tests/tier1/getItem/consumedCapacity.test.ts
+++ b/tests/tier1/getItem/consumedCapacity.test.ts
@@ -8,7 +8,9 @@ import {
   BatchWriteItemCommand,
 } from '@aws-sdk/client-dynamodb'
 import { ddb } from '../../../src/client.js'
-import { hashTableDef, compositeTableDef, cleanupItems } from '../../../src/helpers.js'
+import { declareTables, hashTableDef, compositeTableDef, cleanupItems } from '../../../src/helpers.js'
+
+declareTables(hashTableDef, compositeTableDef)
 
 describe('ConsumedCapacity across operations', { tags: ['get-item', 'data-plane'] }, () => {
   const hashKeys = [

--- a/tests/tier1/getItem/consumedCapacity.test.ts
+++ b/tests/tier1/getItem/consumedCapacity.test.ts
@@ -21,9 +21,6 @@ describe('ConsumedCapacity across operations', { tags: ['get-item', 'data-plane'
     { pk: { S: 'cc-bw-1' } },
     { pk: { S: 'cc-bw-2' } },
   ]
-  const compositeKeys = [
-    { pk: { S: 'cc-qidx-1' }, sk: { S: 'a' } },
-  ]
 
   beforeAll(async () => {
     await Promise.all([
@@ -51,23 +48,11 @@ describe('ConsumedCapacity across operations', { tags: ['get-item', 'data-plane'
           Item: { pk: { S: 'cc-scan-1' }, data: { S: 'scanme' } },
         }),
       ),
-      ddb.send(
-        new PutItemCommand({
-          TableName: compositeTableDef.name,
-          Item: {
-            pk: { S: 'cc-qidx-1' },
-            sk: { S: 'a' },
-            lsi1sk: { S: 'lval' },
-            data: { S: 'indexed' },
-          },
-        }),
-      ),
     ])
   })
 
   afterAll(async () => {
     await cleanupItems(hashTableDef.name, hashKeys)
-    await cleanupItems(compositeTableDef.name, compositeKeys)
   })
 
   it('GetItem with TOTAL returns ConsumedCapacity', async () => {
@@ -117,25 +102,6 @@ describe('ConsumedCapacity across operations', { tags: ['get-item', 'data-plane'
     expect(result.ConsumedCapacity!.TableName).toBe(hashTableDef.name)
     expect(typeof result.ConsumedCapacity!.CapacityUnits).toBe('number')
     expect(result.ConsumedCapacity!.CapacityUnits).toBeGreaterThan(0)
-  })
-
-  it('Query with INDEXES returns per-index breakdown', async () => {
-    const result = await ddb.send(
-      new QueryCommand({
-        TableName: compositeTableDef.name,
-        KeyConditionExpression: '#pk = :pk',
-        ExpressionAttributeNames: { '#pk': 'pk' },
-        ExpressionAttributeValues: { ':pk': { S: 'cc-qidx-1' } },
-        ConsistentRead: true,
-        ReturnConsumedCapacity: 'INDEXES',
-      }),
-    )
-
-    expect(result.ConsumedCapacity).toBeDefined()
-    expect(result.ConsumedCapacity!.TableName).toBe(compositeTableDef.name)
-    expect(typeof result.ConsumedCapacity!.CapacityUnits).toBe('number')
-    expect(result.ConsumedCapacity!.Table).toBeDefined()
-    expect(typeof result.ConsumedCapacity!.Table!.CapacityUnits).toBe('number')
   })
 
   it('Scan with TOTAL returns ConsumedCapacity', async () => {
@@ -201,7 +167,7 @@ describe('ConsumedCapacity — single-item ops report only the aggregate, no rea
       ddb.send(new PutItemCommand({ TableName: hashTableDef.name, Item: { pk: delKey.pk, data: { S: 'x' } } })),
       ddb.send(new PutItemCommand({
         TableName: compositeTableDef.name,
-        Item: { pk: { S: 'cc-split-q' }, sk: { S: 'a' }, lsi1sk: { S: 'l' }, data: { S: 'x' } },
+        Item: { pk: { S: 'cc-split-q' }, sk: { S: 'a' }, data: { S: 'x' } },
       })),
     ])
   })
@@ -235,6 +201,9 @@ describe('ConsumedCapacity — single-item ops report only the aggregate, no rea
     expect(res.ConsumedCapacity!.WriteCapacityUnits).toBeUndefined()
   })
 
+  // INDEXES here is about the split, not about index coverage: this table carries
+  // no secondary index, so the response has a Table arm and nothing else. The
+  // per-index arm is asserted in tests/tier1/query/indexConsumedCapacity.test.ts.
   it('a Query under INDEXES omits the split at the top level and on Table', async () => {
     const res = await ddb.send(new QueryCommand({
       TableName: compositeTableDef.name,

--- a/tests/tier1/getItem/projection.test.ts
+++ b/tests/tier1/getItem/projection.test.ts
@@ -6,7 +6,9 @@ import {
   type AttributeValue,
 } from '@aws-sdk/client-dynamodb'
 import { ddb } from '../../../src/client.js'
-import { hashTableDef, compositeTableDef, cleanupItems } from '../../../src/helpers.js'
+import { declareTables, hashTableDef, compositeTableDef, cleanupItems } from '../../../src/helpers.js'
+
+declareTables(hashTableDef, compositeTableDef)
 
 describe('Nested attribute projection', { tags: ['get-item', 'data-plane'] }, () => {
   const hashPk = 'proj-nested'

--- a/tests/tier1/getItem/validation.test.ts
+++ b/tests/tier1/getItem/validation.test.ts
@@ -1,6 +1,8 @@
 import { GetItemCommand } from '@aws-sdk/client-dynamodb'
 import { ddb } from '../../../src/client.js'
-import { compositeTableDef, expectDynamoError } from '../../../src/helpers.js'
+import { declareTables, compositeTableDef, expectDynamoError } from '../../../src/helpers.js'
+
+declareTables(compositeTableDef)
 
 describe('GetItem — validation', { tags: ['get-item', 'data-plane', 'negative-path'] }, () => {
   it('rejects GetItem on a non-existent table', async () => {

--- a/tests/tier1/listTables/basic.test.ts
+++ b/tests/tier1/listTables/basic.test.ts
@@ -1,6 +1,8 @@
 import { ListTablesCommand } from '@aws-sdk/client-dynamodb'
 import { ddb } from '../../../src/client.js'
-import { hashTableDef } from '../../../src/helpers.js'
+import { declareTables, hashTableDef } from '../../../src/helpers.js'
+
+declareTables(hashTableDef)
 
 describe('ListTables — basic', { tags: ['list-tables', 'control-plane'] }, () => {
   it('returns an array of table names', async () => {

--- a/tests/tier1/listTables/basic.test.ts
+++ b/tests/tier1/listTables/basic.test.ts
@@ -1,8 +1,11 @@
 import { ListTablesCommand } from '@aws-sdk/client-dynamodb'
 import { ddb } from '../../../src/client.js'
-import { declareTables, hashTableDef } from '../../../src/helpers.js'
+import { compositeTableDef, declareTables, hashTableDef } from '../../../src/helpers.js'
 
-declareTables(hashTableDef)
+// Two tables, because the Limit and pagination cases below need a second page
+// to exist. Provisioning follows what a file declares, so this file has to ask
+// for both rather than lean on whatever other files happened to create.
+declareTables(hashTableDef, compositeTableDef)
 
 describe('ListTables — basic', { tags: ['list-tables', 'control-plane'] }, () => {
   it('returns an array of table names', async () => {

--- a/tests/tier1/putItem/basic.test.ts
+++ b/tests/tier1/putItem/basic.test.ts
@@ -3,7 +3,9 @@ import {
   GetItemCommand,
 } from '@aws-sdk/client-dynamodb'
 import { ddb } from '../../../src/client.js'
-import { hashTableDef, compositeTableDef, cleanupItems } from '../../../src/helpers.js'
+import { declareTables, hashTableDef, compositeTableDef, cleanupItems } from '../../../src/helpers.js'
+
+declareTables(hashTableDef, compositeTableDef)
 
 describe('PutItem — basic', { tags: ['put-item', 'data-plane'] }, () => {
   afterAll(async () => {

--- a/tests/tier1/putItem/binaryKeys.test.ts
+++ b/tests/tier1/putItem/binaryKeys.test.ts
@@ -3,7 +3,9 @@ import {
   GetItemCommand,
 } from '@aws-sdk/client-dynamodb'
 import { ddb } from '../../../src/client.js'
-import { compositeBTableDef, cleanupItems } from '../../../src/helpers.js'
+import { declareTables, compositeBTableDef, cleanupItems } from '../../../src/helpers.js'
+
+declareTables(compositeBTableDef)
 
 describe('PutItem — binary sort key', { tags: ['put-item', 'data-plane'] }, () => {
   const bin1 = new Uint8Array([0x01, 0x02, 0x03])

--- a/tests/tier1/putItem/conditionExpressionParens.test.ts
+++ b/tests/tier1/putItem/conditionExpressionParens.test.ts
@@ -3,7 +3,9 @@ import {
   GetItemCommand,
 } from '@aws-sdk/client-dynamodb'
 import { ddb } from '../../../src/client.js'
-import { hashTableDef, expectDynamoError, cleanupItems } from '../../../src/helpers.js'
+import { declareTables, hashTableDef, expectDynamoError, cleanupItems } from '../../../src/helpers.js'
+
+declareTables(hashTableDef)
 
 // Exercises the ConditionExpression parser with parenthesised forms.
 // Emulator parsers are often not shared across expression contexts, so

--- a/tests/tier1/putItem/conditions.test.ts
+++ b/tests/tier1/putItem/conditions.test.ts
@@ -5,7 +5,9 @@ import {
   DynamoDBServiceException,
 } from '@aws-sdk/client-dynamodb'
 import { ddb } from '../../../src/client.js'
-import { hashTableDef, expectDynamoError, cleanupItems } from '../../../src/helpers.js'
+import { declareTables, hashTableDef, expectDynamoError, cleanupItems } from '../../../src/helpers.js'
+
+declareTables(hashTableDef)
 
 describe('PutItem — ConditionExpression', { tags: ['put-item', 'data-plane'] }, () => {
   const pk = 'put-cond'

--- a/tests/tier1/putItem/consumedCapacity.test.ts
+++ b/tests/tier1/putItem/consumedCapacity.test.ts
@@ -5,7 +5,9 @@ import {
   ScanCommand,
 } from '@aws-sdk/client-dynamodb'
 import { ddb } from '../../../src/client.js'
-import { hashTableDef, compositeTableDef, cleanupItems } from '../../../src/helpers.js'
+import { declareTables, hashTableDef, compositeTableDef, cleanupItems } from '../../../src/helpers.js'
+
+declareTables(hashTableDef, compositeTableDef)
 
 describe('ReturnConsumedCapacity', { tags: ['put-item', 'data-plane'] }, () => {
   const hashKeys = [

--- a/tests/tier1/putItem/consumedCapacity.test.ts
+++ b/tests/tier1/putItem/consumedCapacity.test.ts
@@ -17,7 +17,6 @@ describe('ReturnConsumedCapacity', { tags: ['put-item', 'data-plane'] }, () => {
   ]
   const compositeKeys = [
     { pk: { S: 'cc-query-1' }, sk: { S: 'a' } },
-    { pk: { S: 'cc-idx-1' }, sk: { S: 'a' } },
   ]
 
   afterAll(async () => {
@@ -117,36 +116,6 @@ describe('ReturnConsumedCapacity', { tags: ['put-item', 'data-plane'] }, () => {
     )
 
     expect(result.ConsumedCapacity).toBeUndefined()
-  })
-
-  it('Query with INDEXES returns per-index capacity breakdown', async () => {
-    await ddb.send(
-      new PutItemCommand({
-        TableName: compositeTableDef.name,
-        Item: {
-          pk: { S: 'cc-idx-1' },
-          sk: { S: 'a' },
-          lsi1sk: { S: 'lval' },
-          data: { S: 'indexed' },
-        },
-      }),
-    )
-
-    const result = await ddb.send(
-      new QueryCommand({
-        TableName: compositeTableDef.name,
-        KeyConditionExpression: 'pk = :pk',
-        ExpressionAttributeValues: { ':pk': { S: 'cc-idx-1' } },
-        ConsistentRead: true,
-        ReturnConsumedCapacity: 'INDEXES',
-      }),
-    )
-
-    expect(result.ConsumedCapacity).toBeDefined()
-    expect(result.ConsumedCapacity!.TableName).toBe(compositeTableDef.name)
-    expect(typeof result.ConsumedCapacity!.CapacityUnits).toBe('number')
-    expect(result.ConsumedCapacity!.Table).toBeDefined()
-    expect(typeof result.ConsumedCapacity!.Table!.CapacityUnits).toBe('number')
   })
 })
 

--- a/tests/tier1/putItem/dataTypes.test.ts
+++ b/tests/tier1/putItem/dataTypes.test.ts
@@ -3,7 +3,9 @@ import {
   GetItemCommand,
 } from '@aws-sdk/client-dynamodb'
 import { ddb } from '../../../src/client.js'
-import { hashTableDef, cleanupItems } from '../../../src/helpers.js'
+import { declareTables, hashTableDef, cleanupItems } from '../../../src/helpers.js'
+
+declareTables(hashTableDef)
 
 describe('PutItem — data types depth and edge cases', { tags: ['put-item', 'data-plane'] }, () => {
   const keys = [

--- a/tests/tier1/putItem/expressions.test.ts
+++ b/tests/tier1/putItem/expressions.test.ts
@@ -3,7 +3,7 @@ import {
   GetItemCommand,
 } from '@aws-sdk/client-dynamodb'
 import { ddb } from '../../../src/client.js'
-import { declareTables, hashTableDef, expectDynamoError, cleanupItems } from '../../../src/helpers.js'
+import { declareTables, hashTableDef, cleanupItems } from '../../../src/helpers.js'
 
 declareTables(hashTableDef)
 

--- a/tests/tier1/putItem/expressions.test.ts
+++ b/tests/tier1/putItem/expressions.test.ts
@@ -3,7 +3,9 @@ import {
   GetItemCommand,
 } from '@aws-sdk/client-dynamodb'
 import { ddb } from '../../../src/client.js'
-import { hashTableDef, expectDynamoError, cleanupItems } from '../../../src/helpers.js'
+import { declareTables, hashTableDef, expectDynamoError, cleanupItems } from '../../../src/helpers.js'
+
+declareTables(hashTableDef)
 
 describe('PutItem — ConditionExpression functions and operators', { tags: ['put-item', 'data-plane'] }, () => {
   const pk = 'put-expr'

--- a/tests/tier1/putItem/indexKeyValidation.test.ts
+++ b/tests/tier1/putItem/indexKeyValidation.test.ts
@@ -1,0 +1,57 @@
+import { PutItemCommand } from '@aws-sdk/client-dynamodb'
+import { ddb } from '../../../src/client.js'
+import {
+  compositeIndexedTableDef,
+  expectDynamoError,
+  declareTables,
+} from '../../../src/helpers.js'
+
+declareTables(compositeIndexedTableDef)
+
+describe('PutItem — index key validation', { tags: ['put-item', 'data-plane', 'negative-path', 'lsi'] }, () => {
+  // An attribute used as a table or index key must match its declared scalar
+  // type and may not be empty. lsi1sk is declared S and is an index key on the
+  // composite table, so these writes are rejected even though the base-table
+  // keys (pk, sk) are valid.
+  it('rejects a wrong-typed index key attribute', async () => {
+    await expectDynamoError(
+      () => ddb.send(
+        new PutItemCommand({
+          TableName: compositeIndexedTableDef.name,
+          Item: { pk: { S: 'idxkey-type' }, sk: { S: 'a' }, lsi1sk: { N: '5' } },
+        }),
+      ),
+      'ValidationException',
+      /Type mismatch for Index Key/,
+    )
+  })
+
+  it('rejects a non-scalar index key attribute', async () => {
+    await expectDynamoError(
+      () => ddb.send(
+        new PutItemCommand({
+          TableName: compositeIndexedTableDef.name,
+          Item: {
+            pk: { S: 'idxkey-nonscalar' },
+            sk: { S: 'b' },
+            lsi1sk: { L: [{ S: 'x' }] },
+          },
+        }),
+      ),
+      'ValidationException',
+    )
+  })
+
+  it('rejects an empty-string index key attribute', async () => {
+    await expectDynamoError(
+      () => ddb.send(
+        new PutItemCommand({
+          TableName: compositeIndexedTableDef.name,
+          Item: { pk: { S: 'idxkey-empty' }, sk: { S: 'c' }, lsi1sk: { S: '' } },
+        }),
+      ),
+      'ValidationException',
+      /empty string/i,
+    )
+  })
+})

--- a/tests/tier1/putItem/indexKeyValidation.test.ts
+++ b/tests/tier1/putItem/indexKeyValidation.test.ts
@@ -8,7 +8,7 @@ import {
 
 declareTables(compositeIndexedTableDef)
 
-describe('PutItem — index key validation', { tags: ['put-item', 'data-plane', 'negative-path', 'lsi'] }, () => {
+describe('PutItem — index key validation', { tags: ['put-item', 'data-plane', 'negative-path', 'gsi', 'lsi'] }, () => {
   // An attribute used as a table or index key must match its declared scalar
   // type and may not be empty. lsi1sk is declared S and is an index key on the
   // composite table, so these writes are rejected even though the base-table

--- a/tests/tier1/putItem/itemCollectionMetrics.test.ts
+++ b/tests/tier1/putItem/itemCollectionMetrics.test.ts
@@ -4,7 +4,9 @@ import {
   UpdateItemCommand,
 } from '@aws-sdk/client-dynamodb'
 import { ddb } from '../../../src/client.js'
-import { compositeTableDef, cleanupItems } from '../../../src/helpers.js'
+import { declareTables, compositeTableDef, cleanupItems } from '../../../src/helpers.js'
+
+declareTables(compositeTableDef)
 
 describe('ReturnItemCollectionMetrics', { tags: ['put-item', 'data-plane'] }, () => {
   const keys = [

--- a/tests/tier1/putItem/itemCollectionMetrics.test.ts
+++ b/tests/tier1/putItem/itemCollectionMetrics.test.ts
@@ -8,7 +8,7 @@ import { declareTables, compositeIndexedTableDef, cleanupItems } from '../../../
 
 declareTables(compositeIndexedTableDef)
 
-describe('ReturnItemCollectionMetrics', { tags: ['put-item', 'data-plane', 'lsi'] }, () => {
+describe('ReturnItemCollectionMetrics', { tags: ['put-item', 'data-plane', 'gsi', 'lsi'] }, () => {
   const keys = [
     { pk: { S: 'icm-put-1' }, sk: { S: 'a' } },
     { pk: { S: 'icm-del-1' }, sk: { S: 'a' } },

--- a/tests/tier1/putItem/itemCollectionMetrics.test.ts
+++ b/tests/tier1/putItem/itemCollectionMetrics.test.ts
@@ -4,11 +4,11 @@ import {
   UpdateItemCommand,
 } from '@aws-sdk/client-dynamodb'
 import { ddb } from '../../../src/client.js'
-import { declareTables, compositeTableDef, cleanupItems } from '../../../src/helpers.js'
+import { declareTables, compositeIndexedTableDef, cleanupItems } from '../../../src/helpers.js'
 
-declareTables(compositeTableDef)
+declareTables(compositeIndexedTableDef)
 
-describe('ReturnItemCollectionMetrics', { tags: ['put-item', 'data-plane'] }, () => {
+describe('ReturnItemCollectionMetrics', { tags: ['put-item', 'data-plane', 'lsi'] }, () => {
   const keys = [
     { pk: { S: 'icm-put-1' }, sk: { S: 'a' } },
     { pk: { S: 'icm-del-1' }, sk: { S: 'a' } },
@@ -17,13 +17,13 @@ describe('ReturnItemCollectionMetrics', { tags: ['put-item', 'data-plane'] }, ()
   ]
 
   afterAll(async () => {
-    await cleanupItems(compositeTableDef.name, keys)
+    await cleanupItems(compositeIndexedTableDef.name, keys)
   })
 
   it('PutItem with SIZE returns ItemCollectionMetrics', async () => {
     const result = await ddb.send(
       new PutItemCommand({
-        TableName: compositeTableDef.name,
+        TableName: compositeIndexedTableDef.name,
         Item: {
           pk: { S: 'icm-put-1' },
           sk: { S: 'a' },
@@ -44,7 +44,7 @@ describe('ReturnItemCollectionMetrics', { tags: ['put-item', 'data-plane'] }, ()
   it('DeleteItem with SIZE returns ItemCollectionMetrics', async () => {
     await ddb.send(
       new PutItemCommand({
-        TableName: compositeTableDef.name,
+        TableName: compositeIndexedTableDef.name,
         Item: {
           pk: { S: 'icm-del-1' },
           sk: { S: 'a' },
@@ -56,7 +56,7 @@ describe('ReturnItemCollectionMetrics', { tags: ['put-item', 'data-plane'] }, ()
 
     const result = await ddb.send(
       new DeleteItemCommand({
-        TableName: compositeTableDef.name,
+        TableName: compositeIndexedTableDef.name,
         Key: { pk: { S: 'icm-del-1' }, sk: { S: 'a' } },
         ReturnItemCollectionMetrics: 'SIZE',
       }),
@@ -71,7 +71,7 @@ describe('ReturnItemCollectionMetrics', { tags: ['put-item', 'data-plane'] }, ()
   it('UpdateItem with SIZE returns ItemCollectionMetrics', async () => {
     await ddb.send(
       new PutItemCommand({
-        TableName: compositeTableDef.name,
+        TableName: compositeIndexedTableDef.name,
         Item: {
           pk: { S: 'icm-upd-1' },
           sk: { S: 'a' },
@@ -83,7 +83,7 @@ describe('ReturnItemCollectionMetrics', { tags: ['put-item', 'data-plane'] }, ()
 
     const result = await ddb.send(
       new UpdateItemCommand({
-        TableName: compositeTableDef.name,
+        TableName: compositeIndexedTableDef.name,
         Key: { pk: { S: 'icm-upd-1' }, sk: { S: 'a' } },
         UpdateExpression: 'SET #d = :v',
         ExpressionAttributeNames: { '#d': 'data' },
@@ -101,7 +101,7 @@ describe('ReturnItemCollectionMetrics', { tags: ['put-item', 'data-plane'] }, ()
   it('PutItem with NONE does not return ItemCollectionMetrics', async () => {
     const result = await ddb.send(
       new PutItemCommand({
-        TableName: compositeTableDef.name,
+        TableName: compositeIndexedTableDef.name,
         Item: {
           pk: { S: 'icm-none-1' },
           sk: { S: 'a' },

--- a/tests/tier1/putItem/numberFormat.test.ts
+++ b/tests/tier1/putItem/numberFormat.test.ts
@@ -5,7 +5,10 @@ import {
   compositeNTableDef,
   cleanupItems,
   expectDynamoError,
+  declareTables,
 } from '../../../src/helpers.js'
+
+declareTables(hashTableDef, compositeNTableDef)
 
 // Number format: which N strings DynamoDB accepts, what it stores them as,
 // and which it rejects. Captured against real DynamoDB. A leading '+' on the

--- a/tests/tier1/putItem/numericKeys.test.ts
+++ b/tests/tier1/putItem/numericKeys.test.ts
@@ -3,7 +3,9 @@ import {
   GetItemCommand,
 } from '@aws-sdk/client-dynamodb'
 import { ddb } from '../../../src/client.js'
-import { hashNTableDef, compositeNTableDef, cleanupItems } from '../../../src/helpers.js'
+import { declareTables, hashNTableDef, compositeNTableDef, cleanupItems } from '../../../src/helpers.js'
+
+declareTables(hashNTableDef, compositeNTableDef)
 
 describe('PutItem — numeric hash key', { tags: ['put-item', 'data-plane'] }, () => {
   afterAll(async () => {

--- a/tests/tier1/putItem/validation.test.ts
+++ b/tests/tier1/putItem/validation.test.ts
@@ -4,7 +4,10 @@ import {
   hashTableDef,
   compositeTableDef,
   expectDynamoError,
+  declareTables,
 } from '../../../src/helpers.js'
+
+declareTables(hashTableDef, compositeTableDef)
 
 describe('PutItem — validation', { tags: ['put-item', 'data-plane', 'negative-path'] }, () => {
   it('rejects PutItem to a non-existent table', async () => {

--- a/tests/tier1/putItem/validation.test.ts
+++ b/tests/tier1/putItem/validation.test.ts
@@ -2,12 +2,11 @@ import { PutItemCommand } from '@aws-sdk/client-dynamodb'
 import { ddb } from '../../../src/client.js'
 import {
   hashTableDef,
-  compositeTableDef,
   expectDynamoError,
   declareTables,
 } from '../../../src/helpers.js'
 
-declareTables(hashTableDef, compositeTableDef)
+declareTables(hashTableDef)
 
 describe('PutItem — validation', { tags: ['put-item', 'data-plane', 'negative-path'] }, () => {
   it('rejects PutItem to a non-existent table', async () => {
@@ -181,52 +180,6 @@ describe('PutItem — validation', { tags: ['put-item', 'data-plane', 'negative-
       ),
       'ValidationException',
       'Can not use both expression and non-expression',
-    )
-  })
-
-  // An attribute used as a table or index key must match its declared scalar
-  // type and may not be empty. lsi1sk is declared S and is an index key on the
-  // composite table, so these writes are rejected even though the base-table
-  // keys (pk, sk) are valid.
-  it('rejects a wrong-typed index key attribute', async () => {
-    await expectDynamoError(
-      () => ddb.send(
-        new PutItemCommand({
-          TableName: compositeTableDef.name,
-          Item: { pk: { S: 'idxkey-type' }, sk: { S: 'a' }, lsi1sk: { N: '5' } },
-        }),
-      ),
-      'ValidationException',
-      /Type mismatch for Index Key/,
-    )
-  })
-
-  it('rejects a non-scalar index key attribute', async () => {
-    await expectDynamoError(
-      () => ddb.send(
-        new PutItemCommand({
-          TableName: compositeTableDef.name,
-          Item: {
-            pk: { S: 'idxkey-nonscalar' },
-            sk: { S: 'b' },
-            lsi1sk: { L: [{ S: 'x' }] },
-          },
-        }),
-      ),
-      'ValidationException',
-    )
-  })
-
-  it('rejects an empty-string index key attribute', async () => {
-    await expectDynamoError(
-      () => ddb.send(
-        new PutItemCommand({
-          TableName: compositeTableDef.name,
-          Item: { pk: { S: 'idxkey-empty' }, sk: { S: 'c' }, lsi1sk: { S: '' } },
-        }),
-      ),
-      'ValidationException',
-      /empty string/i,
     )
   })
 

--- a/tests/tier1/query/basic.test.ts
+++ b/tests/tier1/query/basic.test.ts
@@ -10,7 +10,10 @@ import {
   compositeTableDef,
   cleanupItems,
   expectDynamoError,
+  declareTables,
 } from '../../../src/helpers.js'
+
+declareTables(compositeTableDef)
 
 describe('Query — basic', { tags: ['query', 'data-plane'] }, () => {
   const pk = 'query-basic'

--- a/tests/tier1/query/basic.test.ts
+++ b/tests/tier1/query/basic.test.ts
@@ -412,24 +412,6 @@ describe('Query — Limit + FilterExpression interaction', { tags: ['query', 'da
       /provided starting key is invalid/,
     )
   })
-
-  it('rejects ExclusiveStartKey missing the index key on a GSI query', async () => {
-    await expectDynamoError(
-      () =>
-        ddb.send(
-          new QueryCommand({
-            TableName: compositeTableDef.name,
-            IndexName: 'gsi1',
-            KeyConditionExpression: '#hk = :v',
-            ExpressionAttributeNames: { '#hk': 'lsi1sk' },
-            ExpressionAttributeValues: { ':v': { S: 'x' } },
-            ExclusiveStartKey: { pk: { S: 'x' } },
-          }),
-        ),
-      'ValidationException',
-      /provided starting key is invalid/,
-    )
-  })
 })
 
 describe('Query — ExclusiveStartKey exclusivity', { tags: ['query', 'data-plane'] }, () => {

--- a/tests/tier1/query/basic.test.ts
+++ b/tests/tier1/query/basic.test.ts
@@ -1,7 +1,6 @@
 import {
   PutItemCommand,
   QueryCommand,
-  DeleteItemCommand,
   type AttributeValue,
   type QueryCommandOutput,
 } from '@aws-sdk/client-dynamodb'

--- a/tests/tier1/query/binaryKeys.test.ts
+++ b/tests/tier1/query/binaryKeys.test.ts
@@ -3,7 +3,9 @@ import {
   QueryCommand,
 } from '@aws-sdk/client-dynamodb'
 import { ddb } from '../../../src/client.js'
-import { compositeBTableDef, cleanupItems } from '../../../src/helpers.js'
+import { declareTables, compositeBTableDef, cleanupItems } from '../../../src/helpers.js'
+
+declareTables(compositeBTableDef)
 
 describe('Query — binary sort key', { tags: ['query', 'data-plane'] }, () => {
   const pk = 'binq'

--- a/tests/tier1/query/expressions.test.ts
+++ b/tests/tier1/query/expressions.test.ts
@@ -3,7 +3,9 @@ import {
   QueryCommand,
 } from '@aws-sdk/client-dynamodb'
 import { ddb } from '../../../src/client.js'
-import { compositeTableDef, cleanupItems } from '../../../src/helpers.js'
+import { declareTables, compositeTableDef, cleanupItems } from '../../../src/helpers.js'
+
+declareTables(compositeTableDef)
 
 describe('Query — FilterExpression functions and operators', { tags: ['query', 'data-plane'] }, () => {
   const pk = 'query-expr'

--- a/tests/tier1/query/filterExpressionParens.test.ts
+++ b/tests/tier1/query/filterExpressionParens.test.ts
@@ -3,7 +3,9 @@ import {
   QueryCommand,
 } from '@aws-sdk/client-dynamodb'
 import { ddb } from '../../../src/client.js'
-import { compositeTableDef, cleanupItems } from '../../../src/helpers.js'
+import { declareTables, compositeTableDef, cleanupItems } from '../../../src/helpers.js'
+
+declareTables(compositeTableDef)
 
 // Query FilterExpression parser is distinct from KeyConditionExpression in
 // most emulators, so parens working there does not imply they work here.

--- a/tests/tier1/query/gsi.test.ts
+++ b/tests/tier1/query/gsi.test.ts
@@ -6,13 +6,14 @@ import {
 } from '@aws-sdk/client-dynamodb'
 import { ddb } from '../../../src/client.js'
 import {
-  compositeTableDef,
+  compositeIndexedTableDef,
   cleanupItems,
   waitForGsiConsistency,
   declareTables,
+  expectDynamoError,
 } from '../../../src/helpers.js'
 
-declareTables(compositeTableDef)
+declareTables(compositeIndexedTableDef)
 
 describe('Query — GSI', { tags: ['query', 'data-plane', 'gsi'] }, () => {
   const items = [
@@ -43,13 +44,13 @@ describe('Query — GSI', { tags: ['query', 'data-plane', 'gsi'] }, () => {
     await Promise.all(
       items.map((item) =>
         ddb.send(
-          new PutItemCommand({ TableName: compositeTableDef.name, Item: item }),
+          new PutItemCommand({ TableName: compositeIndexedTableDef.name, Item: item }),
         ),
       ),
     )
     // GSI propagation can be eventually consistent, wait for items to appear
     await waitForGsiConsistency({
-      tableName: compositeTableDef.name,
+      tableName: compositeIndexedTableDef.name,
       indexName: 'gsi1',
       partitionKey: { name: 'lsi1sk', value: { S: 'gsi-hash-A' } },
       expectedCount: 2,
@@ -58,7 +59,7 @@ describe('Query — GSI', { tags: ['query', 'data-plane', 'gsi'] }, () => {
 
   afterAll(async () => {
     await cleanupItems(
-      compositeTableDef.name,
+      compositeIndexedTableDef.name,
       items.map((item) => ({ pk: item.pk, sk: item.sk })),
     )
   })
@@ -66,7 +67,7 @@ describe('Query — GSI', { tags: ['query', 'data-plane', 'gsi'] }, () => {
   it('queries a hash-only GSI (gsi1)', async () => {
     const result = await ddb.send(
       new QueryCommand({
-        TableName: compositeTableDef.name,
+        TableName: compositeIndexedTableDef.name,
         IndexName: 'gsi1',
         KeyConditionExpression: 'lsi1sk = :v',
         ExpressionAttributeValues: { ':v': { S: 'gsi-hash-A' } },
@@ -79,7 +80,7 @@ describe('Query — GSI', { tags: ['query', 'data-plane', 'gsi'] }, () => {
   it('queries a composite GSI (gsi2) with hash and range', async () => {
     const result = await ddb.send(
       new QueryCommand({
-        TableName: compositeTableDef.name,
+        TableName: compositeIndexedTableDef.name,
         IndexName: 'gsi2',
         KeyConditionExpression: 'lsi1sk = :pk AND lsi2sk = :sk',
         ExpressionAttributeValues: {
@@ -96,7 +97,7 @@ describe('Query — GSI', { tags: ['query', 'data-plane', 'gsi'] }, () => {
   it('returns empty results for non-existent GSI key', async () => {
     const result = await ddb.send(
       new QueryCommand({
-        TableName: compositeTableDef.name,
+        TableName: compositeIndexedTableDef.name,
         IndexName: 'gsi1',
         KeyConditionExpression: 'lsi1sk = :v',
         ExpressionAttributeValues: { ':v': { S: 'does-not-exist' } },
@@ -111,7 +112,7 @@ describe('Query — GSI', { tags: ['query', 'data-plane', 'gsi'] }, () => {
     const sparseItem = { pk: { S: 'gsi-sparse' }, sk: { S: 'x' } }
     await ddb.send(
       new PutItemCommand({
-        TableName: compositeTableDef.name,
+        TableName: compositeIndexedTableDef.name,
         Item: sparseItem,
       }),
     )
@@ -119,7 +120,7 @@ describe('Query — GSI', { tags: ['query', 'data-plane', 'gsi'] }, () => {
     // Query the GSI — the sparse item should not appear
     const result = await ddb.send(
       new QueryCommand({
-        TableName: compositeTableDef.name,
+        TableName: compositeIndexedTableDef.name,
         IndexName: 'gsi1',
         KeyConditionExpression: 'lsi1sk = :v',
         ExpressionAttributeValues: { ':v': { S: 'gsi-hash-A' } },
@@ -131,7 +132,7 @@ describe('Query — GSI', { tags: ['query', 'data-plane', 'gsi'] }, () => {
 
     await ddb.send(
       new DeleteItemCommand({
-        TableName: compositeTableDef.name,
+        TableName: compositeIndexedTableDef.name,
         Key: { pk: sparseItem.pk, sk: sparseItem.sk },
       }),
     )
@@ -147,13 +148,13 @@ describe('Query — GSI', { tags: ['query', 'data-plane', 'gsi'] }, () => {
     }
     await ddb.send(
       new PutItemCommand({
-        TableName: compositeTableDef.name,
+        TableName: compositeIndexedTableDef.name,
         Item: noRangeItem,
       }),
     )
     // Confirm it propagated into the hash-only GSI (so it was written and indexed there).
     await waitForGsiConsistency({
-      tableName: compositeTableDef.name,
+      tableName: compositeIndexedTableDef.name,
       indexName: 'gsi1',
       partitionKey: { name: 'lsi1sk', value: { S: 'gsi-hash-sparse-range' } },
       expectedCount: 1,
@@ -161,7 +162,7 @@ describe('Query — GSI', { tags: ['query', 'data-plane', 'gsi'] }, () => {
 
     const result = await ddb.send(
       new QueryCommand({
-        TableName: compositeTableDef.name,
+        TableName: compositeIndexedTableDef.name,
         IndexName: 'gsi2',
         KeyConditionExpression: 'lsi1sk = :v',
         ExpressionAttributeValues: { ':v': { S: 'gsi-hash-sparse-range' } },
@@ -172,7 +173,7 @@ describe('Query — GSI', { tags: ['query', 'data-plane', 'gsi'] }, () => {
 
     await ddb.send(
       new DeleteItemCommand({
-        TableName: compositeTableDef.name,
+        TableName: compositeIndexedTableDef.name,
         Key: { pk: noRangeItem.pk, sk: noRangeItem.sk },
       }),
     )
@@ -197,12 +198,12 @@ describe('Query — GSI pagination across tied sort keys', { tags: ['query', 'da
     await Promise.all(
       tied.map((item) =>
         ddb.send(
-          new PutItemCommand({ TableName: compositeTableDef.name, Item: item }),
+          new PutItemCommand({ TableName: compositeIndexedTableDef.name, Item: item }),
         ),
       ),
     )
     await waitForGsiConsistency({
-      tableName: compositeTableDef.name,
+      tableName: compositeIndexedTableDef.name,
       indexName: 'gsi2',
       partitionKey: { name: 'lsi1sk', value: { S: 'gsi-tie-hash' } },
       expectedCount: tied.length,
@@ -211,7 +212,7 @@ describe('Query — GSI pagination across tied sort keys', { tags: ['query', 'da
 
   afterAll(async () => {
     await cleanupItems(
-      compositeTableDef.name,
+      compositeIndexedTableDef.name,
       tied.map((item) => ({ pk: item.pk, sk: item.sk })),
     )
   })
@@ -224,7 +225,7 @@ describe('Query — GSI pagination across tied sort keys', { tags: ['query', 'da
     do {
       const page = await ddb.send(
         new QueryCommand({
-          TableName: compositeTableDef.name,
+          TableName: compositeIndexedTableDef.name,
           IndexName: 'gsi2',
           KeyConditionExpression: 'lsi1sk = :h AND lsi2sk = :r',
           ExpressionAttributeValues: {
@@ -254,5 +255,30 @@ describe('Query — GSI pagination across tied sort keys', { tags: ['query', 'da
 
     expect(seen.sort()).toEqual(tied.map((t) => t.pk.S).sort())
     expect(new Set(seen).size).toBe(tied.length) // no repeats
+  })
+})
+
+// Pagination only ever feeds back a well-formed LastEvaluatedKey. A GSI cursor
+// must carry the index key as well as the base key, so a target that does not
+// validate ExclusiveStartKey against the index schema is too lenient; real
+// DynamoDB rejects a key that does not match. Needs no seeded data: the
+// rejection happens before any item is read.
+describe('Query — GSI ExclusiveStartKey validation', { tags: ['query', 'data-plane', 'gsi', 'negative-path'] }, () => {
+  it('rejects ExclusiveStartKey missing the index key on a GSI query', async () => {
+    await expectDynamoError(
+      () =>
+        ddb.send(
+          new QueryCommand({
+            TableName: compositeIndexedTableDef.name,
+            IndexName: 'gsi1',
+            KeyConditionExpression: '#hk = :v',
+            ExpressionAttributeNames: { '#hk': 'lsi1sk' },
+            ExpressionAttributeValues: { ':v': { S: 'x' } },
+            ExclusiveStartKey: { pk: { S: 'x' } },
+          }),
+        ),
+      'ValidationException',
+      /provided starting key is invalid/,
+    )
   })
 })

--- a/tests/tier1/query/gsi.test.ts
+++ b/tests/tier1/query/gsi.test.ts
@@ -9,7 +9,10 @@ import {
   compositeTableDef,
   cleanupItems,
   waitForGsiConsistency,
+  declareTables,
 } from '../../../src/helpers.js'
+
+declareTables(compositeTableDef)
 
 describe('Query — GSI', { tags: ['query', 'data-plane', 'gsi'] }, () => {
   const items = [

--- a/tests/tier1/query/gsi.test.ts
+++ b/tests/tier1/query/gsi.test.ts
@@ -15,7 +15,7 @@ import {
 
 declareTables(compositeIndexedTableDef)
 
-describe('Query — GSI', { tags: ['query', 'data-plane', 'gsi'] }, () => {
+describe('Query — GSI', { tags: ['query', 'data-plane', 'gsi', 'lsi'] }, () => {
   const items = [
     {
       pk: { S: 'gsi-q-1' },
@@ -180,7 +180,7 @@ describe('Query — GSI', { tags: ['query', 'data-plane', 'gsi'] }, () => {
   })
 })
 
-describe('Query — GSI pagination across tied sort keys', { tags: ['query', 'data-plane', 'gsi'] }, () => {
+describe('Query — GSI pagination across tied sort keys', { tags: ['query', 'data-plane', 'gsi', 'lsi'] }, () => {
   // All items share both GSI keys (lsi1sk + lsi2sk), so the GSI cursor is
   // ambiguous without the base-table key. Real AWS composes LastEvaluatedKey
   // from the base key (pk, sk) AND the index keys (lsi1sk, lsi2sk) — captured
@@ -263,7 +263,7 @@ describe('Query — GSI pagination across tied sort keys', { tags: ['query', 'da
 // validate ExclusiveStartKey against the index schema is too lenient; real
 // DynamoDB rejects a key that does not match. Needs no seeded data: the
 // rejection happens before any item is read.
-describe('Query — GSI ExclusiveStartKey validation', { tags: ['query', 'data-plane', 'gsi', 'negative-path'] }, () => {
+describe('Query — GSI ExclusiveStartKey validation', { tags: ['query', 'data-plane', 'negative-path', 'gsi', 'lsi'] }, () => {
   it('rejects ExclusiveStartKey missing the index key on a GSI query', async () => {
     await expectDynamoError(
       () =>

--- a/tests/tier1/query/indexConsumedCapacity.test.ts
+++ b/tests/tier1/query/indexConsumedCapacity.test.ts
@@ -1,0 +1,95 @@
+import { PutItemCommand, QueryCommand } from '@aws-sdk/client-dynamodb'
+import { ddb } from '../../../src/client.js'
+import {
+  declareTables,
+  compositeIndexedTableDef,
+  cleanupItems,
+  waitForGsiConsistency,
+} from '../../../src/helpers.js'
+
+declareTables(compositeIndexedTableDef)
+
+// ReturnConsumedCapacity: 'INDEXES' only has more to say than TOTAL when the read
+// is actually served by a secondary index, so these query `gsi1` and assert the
+// GlobalSecondaryIndexes arm itself. The base table's own consumption is reported
+// separately under Table, and the aggregate is the sum of the two. The
+// aggregate-only side of ConsumedCapacity lives in
+// tests/tier1/getItem/consumedCapacity.test.ts and
+// tests/tier1/putItem/consumedCapacity.test.ts.
+describe('ConsumedCapacity — INDEXES on a secondary-index Query', { tags: ['query', 'data-plane', 'gsi', 'lsi'] }, () => {
+  const item = {
+    pk: { S: 'cc-idx-q-1' },
+    sk: { S: 'a' },
+    lsi1sk: { S: 'cc-idx-hash-1' },
+    data: { S: 'indexed' },
+  }
+
+  beforeAll(async () => {
+    await ddb.send(
+      new PutItemCommand({ TableName: compositeIndexedTableDef.name, Item: item }),
+    )
+    // A GSI is written asynchronously; wait for the item to reach gsi1 so the
+    // query below is genuinely served by the index.
+    await waitForGsiConsistency({
+      tableName: compositeIndexedTableDef.name,
+      indexName: 'gsi1',
+      partitionKey: { name: 'lsi1sk', value: item.lsi1sk },
+      expectedCount: 1,
+    })
+  })
+
+  afterAll(async () => {
+    await cleanupItems(compositeIndexedTableDef.name, [{ pk: item.pk, sk: item.sk }])
+  })
+
+  it('Query with INDEXES returns per-index breakdown', async () => {
+    const result = await ddb.send(
+      new QueryCommand({
+        TableName: compositeIndexedTableDef.name,
+        IndexName: 'gsi1',
+        KeyConditionExpression: '#h = :h',
+        ExpressionAttributeNames: { '#h': 'lsi1sk' },
+        ExpressionAttributeValues: { ':h': item.lsi1sk },
+        ReturnConsumedCapacity: 'INDEXES',
+      }),
+    )
+
+    // The item coming back is the evidence that gsi1 served the read.
+    expect(result.Count).toBe(1)
+    expect(result.ConsumedCapacity).toBeDefined()
+    expect(result.ConsumedCapacity!.TableName).toBe(compositeIndexedTableDef.name)
+    expect(typeof result.ConsumedCapacity!.CapacityUnits).toBe('number')
+    expect(result.ConsumedCapacity!.Table).toBeDefined()
+    expect(typeof result.ConsumedCapacity!.Table!.CapacityUnits).toBe('number')
+
+    const gsis = result.ConsumedCapacity!.GlobalSecondaryIndexes
+    expect(gsis).toBeDefined()
+    expect(Object.keys(gsis!)).toContain('gsi1')
+    expect(typeof gsis!.gsi1.CapacityUnits).toBe('number')
+    expect(gsis!.gsi1.CapacityUnits).toBeGreaterThan(0)
+  })
+
+  it('Query with INDEXES returns per-index capacity breakdown', async () => {
+    const result = await ddb.send(
+      new QueryCommand({
+        TableName: compositeIndexedTableDef.name,
+        IndexName: 'gsi1',
+        KeyConditionExpression: '#h = :h',
+        ExpressionAttributeNames: { '#h': 'lsi1sk' },
+        ExpressionAttributeValues: { ':h': item.lsi1sk },
+        ReturnConsumedCapacity: 'INDEXES',
+      }),
+    )
+
+    const cc = result.ConsumedCapacity!
+    const indexUnits = cc.GlobalSecondaryIndexes!.gsi1.CapacityUnits!
+    const tableUnits = cc.Table!.CapacityUnits!
+
+    // The index carries the read; the aggregate is the table's share plus the
+    // index's, which is what makes the breakdown a breakdown rather than a copy
+    // of the total.
+    expect(indexUnits).toBeGreaterThan(0)
+    expect(typeof tableUnits).toBe('number')
+    expect(cc.CapacityUnits).toBeCloseTo(tableUnits + indexUnits, 5)
+  })
+})

--- a/tests/tier1/query/keyConditionParens.test.ts
+++ b/tests/tier1/query/keyConditionParens.test.ts
@@ -7,7 +7,10 @@ import {
   compositeTableDef,
   cleanupItems,
   expectDynamoError,
+  declareTables,
 } from '../../../src/helpers.js'
+
+declareTables(compositeTableDef)
 
 describe('Query — KeyConditionExpression with parentheses', { tags: ['query', 'data-plane'] }, () => {
   const pk = 'kce-parens'

--- a/tests/tier1/query/keyConditionSemantics.test.ts
+++ b/tests/tier1/query/keyConditionSemantics.test.ts
@@ -4,7 +4,9 @@ import {
   DynamoDBServiceException,
 } from '@aws-sdk/client-dynamodb'
 import { ddb } from '../../../src/client.js'
-import { compositeTableDef, cleanupItems } from '../../../src/helpers.js'
+import { declareTables, compositeTableDef, cleanupItems } from '../../../src/helpers.js'
+
+declareTables(compositeTableDef)
 
 describe('Query — KeyConditionExpression semantics', { tags: ['query', 'data-plane'] }, () => {
   const pk = 'kce-sem'

--- a/tests/tier1/query/lsi.test.ts
+++ b/tests/tier1/query/lsi.test.ts
@@ -5,12 +5,12 @@ import {
 } from '@aws-sdk/client-dynamodb'
 import { ddb } from '../../../src/client.js'
 import {
-  compositeTableDef,
+  compositeIndexedTableDef,
   cleanupItems,
   declareTables,
 } from '../../../src/helpers.js'
 
-declareTables(compositeTableDef)
+declareTables(compositeIndexedTableDef)
 
 describe('Query — LSI', { tags: ['query', 'data-plane', 'lsi'] }, () => {
   const items = [
@@ -48,7 +48,7 @@ describe('Query — LSI', { tags: ['query', 'data-plane', 'lsi'] }, () => {
     await Promise.all(
       items.map((item) =>
         ddb.send(
-          new PutItemCommand({ TableName: compositeTableDef.name, Item: item }),
+          new PutItemCommand({ TableName: compositeIndexedTableDef.name, Item: item }),
         ),
       ),
     )
@@ -56,7 +56,7 @@ describe('Query — LSI', { tags: ['query', 'data-plane', 'lsi'] }, () => {
 
   afterAll(async () => {
     await cleanupItems(
-      compositeTableDef.name,
+      compositeIndexedTableDef.name,
       items.map((item) => ({ pk: item.pk, sk: item.sk })),
     )
   })
@@ -64,7 +64,7 @@ describe('Query — LSI', { tags: ['query', 'data-plane', 'lsi'] }, () => {
   it('queries LSI with equality on sort key', async () => {
     const result = await ddb.send(
       new QueryCommand({
-        TableName: compositeTableDef.name,
+        TableName: compositeIndexedTableDef.name,
         IndexName: 'lsi1',
         KeyConditionExpression: 'pk = :pk AND lsi1sk = :sk',
         ExpressionAttributeValues: {
@@ -82,7 +82,7 @@ describe('Query — LSI', { tags: ['query', 'data-plane', 'lsi'] }, () => {
   it('queries LSI with begins_with on sort key', async () => {
     const result = await ddb.send(
       new QueryCommand({
-        TableName: compositeTableDef.name,
+        TableName: compositeIndexedTableDef.name,
         IndexName: 'lsi1',
         KeyConditionExpression: 'pk = :pk AND begins_with(lsi1sk, :prefix)',
         ExpressionAttributeValues: {
@@ -102,7 +102,7 @@ describe('Query — LSI', { tags: ['query', 'data-plane', 'lsi'] }, () => {
   it('queries LSI with BETWEEN on sort key', async () => {
     const result = await ddb.send(
       new QueryCommand({
-        TableName: compositeTableDef.name,
+        TableName: compositeIndexedTableDef.name,
         IndexName: 'lsi2',
         KeyConditionExpression: 'pk = :pk AND lsi2sk BETWEEN :lo AND :hi',
         ExpressionAttributeValues: {
@@ -124,7 +124,7 @@ describe('Query — LSI', { tags: ['query', 'data-plane', 'lsi'] }, () => {
   it('supports ConsistentRead on LSI (unlike GSI)', async () => {
     const result = await ddb.send(
       new QueryCommand({
-        TableName: compositeTableDef.name,
+        TableName: compositeIndexedTableDef.name,
         IndexName: 'lsi1',
         KeyConditionExpression: 'pk = :pk',
         ExpressionAttributeValues: { ':pk': { S: 'lsi-q-1' } },
@@ -138,7 +138,7 @@ describe('Query — LSI', { tags: ['query', 'data-plane', 'lsi'] }, () => {
   it('ALL projection returns all base table attributes', async () => {
     const result = await ddb.send(
       new QueryCommand({
-        TableName: compositeTableDef.name,
+        TableName: compositeIndexedTableDef.name,
         IndexName: 'lsi1',
         KeyConditionExpression: 'pk = :pk AND lsi1sk = :sk',
         ExpressionAttributeValues: {
@@ -163,7 +163,7 @@ describe('Query — LSI', { tags: ['query', 'data-plane', 'lsi'] }, () => {
     // lsi2 has projectionType INCLUDE with nonKeyAttributes ['lsi1sk']
     const result = await ddb.send(
       new QueryCommand({
-        TableName: compositeTableDef.name,
+        TableName: compositeIndexedTableDef.name,
         IndexName: 'lsi2',
         KeyConditionExpression: 'pk = :pk AND lsi2sk = :sk',
         ExpressionAttributeValues: {
@@ -189,7 +189,7 @@ describe('Query — LSI', { tags: ['query', 'data-plane', 'lsi'] }, () => {
   it('returns items only from the queried partition', async () => {
     const result = await ddb.send(
       new QueryCommand({
-        TableName: compositeTableDef.name,
+        TableName: compositeIndexedTableDef.name,
         IndexName: 'lsi1',
         KeyConditionExpression: 'pk = :pk',
         ExpressionAttributeValues: { ':pk': { S: 'lsi-q-1' } },
@@ -206,7 +206,7 @@ describe('Query — LSI', { tags: ['query', 'data-plane', 'lsi'] }, () => {
   it('returns empty results for non-existent partition key on LSI', async () => {
     const result = await ddb.send(
       new QueryCommand({
-        TableName: compositeTableDef.name,
+        TableName: compositeIndexedTableDef.name,
         IndexName: 'lsi1',
         KeyConditionExpression: 'pk = :pk',
         ExpressionAttributeValues: { ':pk': { S: 'does-not-exist' } },
@@ -223,7 +223,7 @@ describe('Query — LSI', { tags: ['query', 'data-plane', 'lsi'] }, () => {
     const noLsiSkItem = { pk: { S: 'lsi-sparse-q' }, sk: { S: 'x' } }
     await ddb.send(
       new PutItemCommand({
-        TableName: compositeTableDef.name,
+        TableName: compositeIndexedTableDef.name,
         Item: noLsiSkItem,
       }),
     )
@@ -231,7 +231,7 @@ describe('Query — LSI', { tags: ['query', 'data-plane', 'lsi'] }, () => {
     // Absent from the LSI...
     const lsiResult = await ddb.send(
       new QueryCommand({
-        TableName: compositeTableDef.name,
+        TableName: compositeIndexedTableDef.name,
         IndexName: 'lsi1',
         KeyConditionExpression: 'pk = :p',
         ExpressionAttributeValues: { ':p': { S: 'lsi-sparse-q' } },
@@ -243,7 +243,7 @@ describe('Query — LSI', { tags: ['query', 'data-plane', 'lsi'] }, () => {
     // ...but present in the base table.
     const baseResult = await ddb.send(
       new QueryCommand({
-        TableName: compositeTableDef.name,
+        TableName: compositeIndexedTableDef.name,
         KeyConditionExpression: 'pk = :p',
         ExpressionAttributeValues: { ':p': { S: 'lsi-sparse-q' } },
         ConsistentRead: true,
@@ -251,7 +251,7 @@ describe('Query — LSI', { tags: ['query', 'data-plane', 'lsi'] }, () => {
     )
     expect(baseResult.Items).toHaveLength(1)
 
-    await cleanupItems(compositeTableDef.name, [
+    await cleanupItems(compositeIndexedTableDef.name, [
       { pk: noLsiSkItem.pk, sk: noLsiSkItem.sk },
     ])
   })
@@ -272,7 +272,7 @@ describe('Query — LSI pagination across tied sort keys', { tags: ['query', 'da
     await Promise.all(
       tied.map((item) =>
         ddb.send(
-          new PutItemCommand({ TableName: compositeTableDef.name, Item: item }),
+          new PutItemCommand({ TableName: compositeIndexedTableDef.name, Item: item }),
         ),
       ),
     )
@@ -280,7 +280,7 @@ describe('Query — LSI pagination across tied sort keys', { tags: ['query', 'da
 
   afterAll(async () => {
     await cleanupItems(
-      compositeTableDef.name,
+      compositeIndexedTableDef.name,
       tied.map((item) => ({ pk: item.pk, sk: item.sk })),
     )
   })
@@ -293,7 +293,7 @@ describe('Query — LSI pagination across tied sort keys', { tags: ['query', 'da
     do {
       const page = await ddb.send(
         new QueryCommand({
-          TableName: compositeTableDef.name,
+          TableName: compositeIndexedTableDef.name,
           IndexName: 'lsi1',
           KeyConditionExpression: 'pk = :p AND lsi1sk = :v',
           ExpressionAttributeValues: {

--- a/tests/tier1/query/lsi.test.ts
+++ b/tests/tier1/query/lsi.test.ts
@@ -12,7 +12,7 @@ import {
 
 declareTables(compositeIndexedTableDef)
 
-describe('Query — LSI', { tags: ['query', 'data-plane', 'lsi'] }, () => {
+describe('Query — LSI', { tags: ['query', 'data-plane', 'gsi', 'lsi'] }, () => {
   const items = [
     {
       pk: { S: 'lsi-q-1' },
@@ -257,7 +257,7 @@ describe('Query — LSI', { tags: ['query', 'data-plane', 'lsi'] }, () => {
   })
 })
 
-describe('Query — LSI pagination across tied sort keys', { tags: ['query', 'data-plane', 'lsi'] }, () => {
+describe('Query — LSI pagination across tied sort keys', { tags: ['query', 'data-plane', 'gsi', 'lsi'] }, () => {
   // Items in one partition sharing the LSI sort key (lsi1sk), distinct base sk.
   // The LSI continuation key must carry the base-table keys (pk, sk) alongside
   // the index sort key, or a paged walk loops or drops rows on the tie.

--- a/tests/tier1/query/lsi.test.ts
+++ b/tests/tier1/query/lsi.test.ts
@@ -7,7 +7,10 @@ import { ddb } from '../../../src/client.js'
 import {
   compositeTableDef,
   cleanupItems,
+  declareTables,
 } from '../../../src/helpers.js'
+
+declareTables(compositeTableDef)
 
 describe('Query — LSI', { tags: ['query', 'data-plane', 'lsi'] }, () => {
   const items = [

--- a/tests/tier1/query/numericKeys.test.ts
+++ b/tests/tier1/query/numericKeys.test.ts
@@ -3,7 +3,9 @@ import {
   QueryCommand,
 } from '@aws-sdk/client-dynamodb'
 import { ddb } from '../../../src/client.js'
-import { compositeNTableDef, cleanupItems } from '../../../src/helpers.js'
+import { declareTables, compositeNTableDef, cleanupItems } from '../../../src/helpers.js'
+
+declareTables(compositeNTableDef)
 
 describe('Query — numeric sort key', { tags: ['query', 'data-plane'] }, () => {
   const pk = 'numq'

--- a/tests/tier1/query/projection.test.ts
+++ b/tests/tier1/query/projection.test.ts
@@ -1,6 +1,8 @@
 import { PutItemCommand, QueryCommand } from '@aws-sdk/client-dynamodb'
 import { ddb } from '../../../src/client.js'
-import { hashTableDef, cleanupItems } from '../../../src/helpers.js'
+import { declareTables, hashTableDef, cleanupItems } from '../../../src/helpers.js'
+
+declareTables(hashTableDef)
 
 describe('Query — legal shared-prefix projections', { tags: ['query', 'data-plane'] }, () => {
   // Projection paths that share a prefix without one being a prefix of the

--- a/tests/tier1/query/select.test.ts
+++ b/tests/tier1/query/select.test.ts
@@ -3,7 +3,7 @@ import {
   QueryCommand,
 } from '@aws-sdk/client-dynamodb'
 import { ddb } from '../../../src/client.js'
-import { declareTables, compositeTableDef, cleanupItems, waitForGsiConsistency, expectDynamoError } from '../../../src/helpers.js'
+import { declareTables, compositeTableDef, cleanupItems, expectDynamoError } from '../../../src/helpers.js'
 
 declareTables(compositeTableDef)
 
@@ -67,102 +67,6 @@ describe('Query — Select COUNT', { tags: ['query', 'data-plane'] }, () => {
     expect(result.Count).toBe(2)
     expect(result.ScannedCount).toBe(3)
     expect(result.Items).toBeUndefined()
-  })
-})
-
-describe('Query — Select modes on indexes', { tags: ['query', 'data-plane'] }, () => {
-  const pk = 'query-select-idx'
-  const items = [
-    {
-      pk: { S: pk },
-      sk: { S: 'a' },
-      lsi1sk: { S: 'gsi-hash-1' },
-      lsi2sk: { S: 'gsi-range-1' },
-      data: { S: 'projected-data' },
-      extra: { S: 'not-projected' },
-    },
-    {
-      pk: { S: pk },
-      sk: { S: 'b' },
-      lsi1sk: { S: 'gsi-hash-1' },
-      lsi2sk: { S: 'gsi-range-2' },
-      data: { S: 'projected-data-2' },
-      extra: { S: 'also-not-projected' },
-    },
-  ]
-
-  beforeAll(async () => {
-    await Promise.all(
-      items.map((item) =>
-        ddb.send(
-          new PutItemCommand({ TableName: compositeTableDef.name, Item: item }),
-        ),
-      ),
-    )
-    // Wait for GSI to reflect the items
-    await waitForGsiConsistency({
-      tableName: compositeTableDef.name,
-      indexName: 'gsi2',
-      partitionKey: { name: 'lsi1sk', value: { S: 'gsi-hash-1' } },
-      expectedCount: 2,
-    })
-  })
-
-  afterAll(async () => {
-    await cleanupItems(
-      compositeTableDef.name,
-      items.map((item) => ({ pk: item.pk, sk: item.sk })),
-    )
-  })
-
-  it('Select ALL_PROJECTED_ATTRIBUTES on GSI returns only projected attributes', async () => {
-    const result = await ddb.send(
-      new QueryCommand({
-        TableName: compositeTableDef.name,
-        IndexName: 'gsi2',
-        KeyConditionExpression: '#hk = :hk',
-        ExpressionAttributeNames: { '#hk': 'lsi1sk' },
-        ExpressionAttributeValues: { ':hk': { S: 'gsi-hash-1' } },
-        Select: 'ALL_PROJECTED_ATTRIBUTES',
-      }),
-    )
-
-    expect(result.Items).toBeDefined()
-    expect(result.Items!.length).toBe(2)
-    for (const item of result.Items!) {
-      // GSI2 is INCLUDE with nonKeyAttributes: ['data']
-      // Should have: table keys (pk, sk), GSI keys (lsi1sk, lsi2sk), projected (data)
-      expect(item.lsi1sk).toBeDefined()
-      expect(item.lsi2sk).toBeDefined()
-      expect(item.data).toBeDefined()
-      // Should NOT have non-projected attributes
-      expect(item.extra).toBeUndefined()
-    }
-  })
-
-  it('Select ALL_ATTRIBUTES on LSI returns all base table attributes', async () => {
-    const result = await ddb.send(
-      new QueryCommand({
-        TableName: compositeTableDef.name,
-        IndexName: 'lsi1',
-        KeyConditionExpression: '#pk = :pk',
-        ExpressionAttributeNames: { '#pk': 'pk' },
-        ExpressionAttributeValues: { ':pk': { S: pk } },
-        Select: 'ALL_ATTRIBUTES',
-        ConsistentRead: true,
-      }),
-    )
-
-    expect(result.Items).toBeDefined()
-    expect(result.Items!.length).toBe(2)
-    for (const item of result.Items!) {
-      // LSI1 has projectionType ALL, so all base table attributes should be present
-      expect(item.pk).toBeDefined()
-      expect(item.sk).toBeDefined()
-      expect(item.lsi1sk).toBeDefined()
-      expect(item.data).toBeDefined()
-      expect(item.extra).toBeDefined()
-    }
   })
 })
 

--- a/tests/tier1/query/select.test.ts
+++ b/tests/tier1/query/select.test.ts
@@ -3,7 +3,9 @@ import {
   QueryCommand,
 } from '@aws-sdk/client-dynamodb'
 import { ddb } from '../../../src/client.js'
-import { compositeTableDef, cleanupItems, waitForGsiConsistency, expectDynamoError } from '../../../src/helpers.js'
+import { declareTables, compositeTableDef, cleanupItems, waitForGsiConsistency, expectDynamoError } from '../../../src/helpers.js'
+
+declareTables(compositeTableDef)
 
 describe('Query — Select COUNT', { tags: ['query', 'data-plane'] }, () => {
   const pk = 'query-select-count'

--- a/tests/tier1/query/selectOnIndexes.test.ts
+++ b/tests/tier1/query/selectOnIndexes.test.ts
@@ -1,0 +1,109 @@
+import {
+  PutItemCommand,
+  QueryCommand,
+} from '@aws-sdk/client-dynamodb'
+import { ddb } from '../../../src/client.js'
+import {
+  declareTables,
+  compositeIndexedTableDef,
+  cleanupItems,
+  waitForGsiConsistency,
+} from '../../../src/helpers.js'
+
+declareTables(compositeIndexedTableDef)
+
+describe('Query — Select modes on indexes', { tags: ['query', 'data-plane', 'gsi', 'lsi'] }, () => {
+  const pk = 'query-select-idx'
+  const items = [
+    {
+      pk: { S: pk },
+      sk: { S: 'a' },
+      lsi1sk: { S: 'gsi-hash-1' },
+      lsi2sk: { S: 'gsi-range-1' },
+      data: { S: 'projected-data' },
+      extra: { S: 'not-projected' },
+    },
+    {
+      pk: { S: pk },
+      sk: { S: 'b' },
+      lsi1sk: { S: 'gsi-hash-1' },
+      lsi2sk: { S: 'gsi-range-2' },
+      data: { S: 'projected-data-2' },
+      extra: { S: 'also-not-projected' },
+    },
+  ]
+
+  beforeAll(async () => {
+    await Promise.all(
+      items.map((item) =>
+        ddb.send(
+          new PutItemCommand({ TableName: compositeIndexedTableDef.name, Item: item }),
+        ),
+      ),
+    )
+    // Wait for GSI to reflect the items
+    await waitForGsiConsistency({
+      tableName: compositeIndexedTableDef.name,
+      indexName: 'gsi2',
+      partitionKey: { name: 'lsi1sk', value: { S: 'gsi-hash-1' } },
+      expectedCount: 2,
+    })
+  })
+
+  afterAll(async () => {
+    await cleanupItems(
+      compositeIndexedTableDef.name,
+      items.map((item) => ({ pk: item.pk, sk: item.sk })),
+    )
+  })
+
+  it('Select ALL_PROJECTED_ATTRIBUTES on GSI returns only projected attributes', async () => {
+    const result = await ddb.send(
+      new QueryCommand({
+        TableName: compositeIndexedTableDef.name,
+        IndexName: 'gsi2',
+        KeyConditionExpression: '#hk = :hk',
+        ExpressionAttributeNames: { '#hk': 'lsi1sk' },
+        ExpressionAttributeValues: { ':hk': { S: 'gsi-hash-1' } },
+        Select: 'ALL_PROJECTED_ATTRIBUTES',
+      }),
+    )
+
+    expect(result.Items).toBeDefined()
+    expect(result.Items!.length).toBe(2)
+    for (const item of result.Items!) {
+      // GSI2 is INCLUDE with nonKeyAttributes: ['data']
+      // Should have: table keys (pk, sk), GSI keys (lsi1sk, lsi2sk), projected (data)
+      expect(item.lsi1sk).toBeDefined()
+      expect(item.lsi2sk).toBeDefined()
+      expect(item.data).toBeDefined()
+      // Should NOT have non-projected attributes
+      expect(item.extra).toBeUndefined()
+    }
+  })
+
+  it('Select ALL_ATTRIBUTES on LSI returns all base table attributes', async () => {
+    const result = await ddb.send(
+      new QueryCommand({
+        TableName: compositeIndexedTableDef.name,
+        IndexName: 'lsi1',
+        KeyConditionExpression: '#pk = :pk',
+        ExpressionAttributeNames: { '#pk': 'pk' },
+        ExpressionAttributeValues: { ':pk': { S: pk } },
+        Select: 'ALL_ATTRIBUTES',
+        ConsistentRead: true,
+      }),
+    )
+
+    expect(result.Items).toBeDefined()
+    expect(result.Items!.length).toBe(2)
+    for (const item of result.Items!) {
+      // LSI1 has projectionType ALL, so all base table attributes should be present
+      expect(item.pk).toBeDefined()
+      expect(item.sk).toBeDefined()
+      expect(item.lsi1sk).toBeDefined()
+      expect(item.data).toBeDefined()
+      expect(item.extra).toBeDefined()
+    }
+  })
+})

--- a/tests/tier1/query/validation.test.ts
+++ b/tests/tier1/query/validation.test.ts
@@ -1,6 +1,8 @@
 import { QueryCommand } from '@aws-sdk/client-dynamodb'
 import { ddb } from '../../../src/client.js'
-import { compositeTableDef, expectDynamoError } from '../../../src/helpers.js'
+import { declareTables, compositeTableDef, expectDynamoError } from '../../../src/helpers.js'
+
+declareTables(compositeTableDef)
 
 describe('Query — validation', { tags: ['query', 'data-plane', 'negative-path'] }, () => {
   it('rejects query on non-existent table', async () => {

--- a/tests/tier1/scan/basic.test.ts
+++ b/tests/tier1/scan/basic.test.ts
@@ -10,7 +10,10 @@ import {
   hashTableDef,
   cleanupItems,
   expectDynamoError,
+  declareTables,
 } from '../../../src/helpers.js'
+
+declareTables(hashTableDef)
 
 describe('Scan — basic', { tags: ['scan', 'data-plane'] }, () => {
   const items = Array.from({ length: 5 }, (_, i) => ({

--- a/tests/tier1/scan/basic.test.ts
+++ b/tests/tier1/scan/basic.test.ts
@@ -1,7 +1,6 @@
 import {
   PutItemCommand,
   ScanCommand,
-  DeleteItemCommand,
   type AttributeValue,
   type ScanCommandOutput,
 } from '@aws-sdk/client-dynamodb'

--- a/tests/tier1/scan/filterExpressionParens.test.ts
+++ b/tests/tier1/scan/filterExpressionParens.test.ts
@@ -9,17 +9,17 @@ declareTables(compositeTableDef)
 
 // Scan FilterExpression parser is distinct from KeyConditionExpression and
 // may also differ from Query's FilterExpression path in some emulators.
-// Items carry a unique `lsi1sk` marker so scans can isolate this test's
+// Items carry a unique `mark` attribute so scans can isolate this test's
 // data from whatever else is in the shared compositeTableDef. The marker is a
 // plain attribute here, not an index key — the index-scan case lives in
 // tests/tier1/scan/gsi.test.ts so this file needs no secondary index.
 describe('Scan — FilterExpression parens', { tags: ['scan', 'data-plane'] }, () => {
   const marker = 'fes-parens-marker'
   const items = [
-    { pk: { S: 'fes-parens-1' }, sk: { S: 'x' }, lsi1sk: { S: marker }, type: { S: 'alpha' }, status: { S: 'active' } },
-    { pk: { S: 'fes-parens-2' }, sk: { S: 'x' }, lsi1sk: { S: marker }, type: { S: 'beta' }, status: { S: 'inactive' } },
-    { pk: { S: 'fes-parens-3' }, sk: { S: 'x' }, lsi1sk: { S: marker }, type: { S: 'gamma' }, status: { S: 'active' } },
-    { pk: { S: 'fes-parens-4' }, sk: { S: 'x' }, lsi1sk: { S: marker }, type: { S: 'alpha' }, status: { S: 'active' } },
+    { pk: { S: 'fes-parens-1' }, sk: { S: 'x' }, mark: { S: marker }, type: { S: 'alpha' }, status: { S: 'active' } },
+    { pk: { S: 'fes-parens-2' }, sk: { S: 'x' }, mark: { S: marker }, type: { S: 'beta' }, status: { S: 'inactive' } },
+    { pk: { S: 'fes-parens-3' }, sk: { S: 'x' }, mark: { S: marker }, type: { S: 'gamma' }, status: { S: 'active' } },
+    { pk: { S: 'fes-parens-4' }, sk: { S: 'x' }, mark: { S: marker }, type: { S: 'alpha' }, status: { S: 'active' } },
   ]
 
   beforeAll(async () => {
@@ -44,7 +44,7 @@ describe('Scan — FilterExpression parens', { tags: ['scan', 'data-plane'] }, (
       new ScanCommand({
         TableName: compositeTableDef.name,
         FilterExpression: '(#m = :m) AND ((#t = :a) OR (#t = :b))',
-        ExpressionAttributeNames: { '#m': 'lsi1sk', '#t': 'type' },
+        ExpressionAttributeNames: { '#m': 'mark', '#t': 'type' },
         ExpressionAttributeValues: {
           ':m': { S: marker },
           ':a': { S: 'alpha' },
@@ -63,7 +63,7 @@ describe('Scan — FilterExpression parens', { tags: ['scan', 'data-plane'] }, (
       new ScanCommand({
         TableName: compositeTableDef.name,
         FilterExpression: '(#m = :m) AND (#t = :a OR #t = :b)',
-        ExpressionAttributeNames: { '#m': 'lsi1sk', '#t': 'type' },
+        ExpressionAttributeNames: { '#m': 'mark', '#t': 'type' },
         ExpressionAttributeValues: {
           ':m': { S: marker },
           ':a': { S: 'alpha' },
@@ -81,7 +81,7 @@ describe('Scan — FilterExpression parens', { tags: ['scan', 'data-plane'] }, (
       new ScanCommand({
         TableName: compositeTableDef.name,
         FilterExpression: '(#m = :m) AND (#t = :a OR (#t = :b))',
-        ExpressionAttributeNames: { '#m': 'lsi1sk', '#t': 'type' },
+        ExpressionAttributeNames: { '#m': 'mark', '#t': 'type' },
         ExpressionAttributeValues: {
           ':m': { S: marker },
           ':a': { S: 'alpha' },
@@ -99,7 +99,7 @@ describe('Scan — FilterExpression parens', { tags: ['scan', 'data-plane'] }, (
       new ScanCommand({
         TableName: compositeTableDef.name,
         FilterExpression: '(#m = :m) AND (NOT (#s = :s))',
-        ExpressionAttributeNames: { '#m': 'lsi1sk', '#s': 'status' },
+        ExpressionAttributeNames: { '#m': 'mark', '#s': 'status' },
         ExpressionAttributeValues: {
           ':m': { S: marker },
           ':s': { S: 'active' },

--- a/tests/tier1/scan/filterExpressionParens.test.ts
+++ b/tests/tier1/scan/filterExpressionParens.test.ts
@@ -3,7 +3,9 @@ import {
   ScanCommand,
 } from '@aws-sdk/client-dynamodb'
 import { ddb } from '../../../src/client.js'
-import { compositeTableDef, cleanupItems, waitForGsiConsistency } from '../../../src/helpers.js'
+import { declareTables, compositeTableDef, cleanupItems, waitForGsiConsistency } from '../../../src/helpers.js'
+
+declareTables(compositeTableDef)
 
 // Scan FilterExpression parser is distinct from KeyConditionExpression and
 // may also differ from Query's FilterExpression path in some emulators.

--- a/tests/tier1/scan/filterExpressionParens.test.ts
+++ b/tests/tier1/scan/filterExpressionParens.test.ts
@@ -3,14 +3,16 @@ import {
   ScanCommand,
 } from '@aws-sdk/client-dynamodb'
 import { ddb } from '../../../src/client.js'
-import { declareTables, compositeTableDef, cleanupItems, waitForGsiConsistency } from '../../../src/helpers.js'
+import { declareTables, compositeTableDef, cleanupItems } from '../../../src/helpers.js'
 
 declareTables(compositeTableDef)
 
 // Scan FilterExpression parser is distinct from KeyConditionExpression and
 // may also differ from Query's FilterExpression path in some emulators.
 // Items carry a unique `lsi1sk` marker so scans can isolate this test's
-// data from whatever else is in the shared compositeTableDef.
+// data from whatever else is in the shared compositeTableDef. The marker is a
+// plain attribute here, not an index key — the index-scan case lives in
+// tests/tier1/scan/gsi.test.ts so this file needs no secondary index.
 describe('Scan — FilterExpression parens', { tags: ['scan', 'data-plane'] }, () => {
   const marker = 'fes-parens-marker'
   const items = [
@@ -28,12 +30,6 @@ describe('Scan — FilterExpression parens', { tags: ['scan', 'data-plane'] }, (
         ),
       ),
     )
-    await waitForGsiConsistency({
-      tableName: compositeTableDef.name,
-      indexName: 'gsi1',
-      partitionKey: { name: 'lsi1sk', value: { S: marker } },
-      expectedCount: items.length,
-    })
   }, 30_000)
 
   afterAll(async () => {
@@ -95,25 +91,6 @@ describe('Scan — FilterExpression parens', { tags: ['scan', 'data-plane'] }, (
       }),
     )
 
-    expect(result.Items).toHaveLength(3)
-  })
-
-  it('GSI scan — parens filter returns matching items', async () => {
-    const result = await ddb.send(
-      new ScanCommand({
-        TableName: compositeTableDef.name,
-        IndexName: 'gsi1',
-        FilterExpression: '(#m = :m) AND ((#t = :a) OR (#t = :b))',
-        ExpressionAttributeNames: { '#m': 'lsi1sk', '#t': 'type' },
-        ExpressionAttributeValues: {
-          ':m': { S: marker },
-          ':a': { S: 'alpha' },
-          ':b': { S: 'beta' },
-        },
-      }),
-    )
-
-    // Same three items show through the GSI (all four have lsi1sk=marker)
     expect(result.Items).toHaveLength(3)
   })
 

--- a/tests/tier1/scan/filterOperandOrder.test.ts
+++ b/tests/tier1/scan/filterOperandOrder.test.ts
@@ -1,6 +1,8 @@
 import { ScanCommand, DynamoDBServiceException } from '@aws-sdk/client-dynamodb'
 import { ddb } from '../../../src/client.js'
-import { hashTableDef } from '../../../src/helpers.js'
+import { declareTables, hashTableDef } from '../../../src/helpers.js'
+
+declareTables(hashTableDef)
 
 describe('Scan — FilterExpression operand validation order', { tags: ['scan', 'data-plane', 'negative-path'] }, () => {
   it('rejects a non-string begins_with operand even when nothing matches', async () => {

--- a/tests/tier1/scan/filterOperators.test.ts
+++ b/tests/tier1/scan/filterOperators.test.ts
@@ -7,7 +7,10 @@ import {
   hashTableDef,
   cleanupItems,
   expectDynamoError,
+  declareTables,
 } from '../../../src/helpers.js'
+
+declareTables(hashTableDef)
 
 describe('Scan — filter operators on different types', { tags: ['scan', 'data-plane'] }, () => {
   const items = [

--- a/tests/tier1/scan/gsi.test.ts
+++ b/tests/tier1/scan/gsi.test.ts
@@ -12,7 +12,7 @@ import {
 
 declareTables(compositeIndexedTableDef)
 
-describe('Scan — GSI', { tags: ['scan', 'data-plane', 'gsi'] }, () => {
+describe('Scan — GSI', { tags: ['scan', 'data-plane', 'gsi', 'lsi'] }, () => {
   const items = [
     {
       pk: { S: 'scan-gsi-1' },
@@ -178,7 +178,7 @@ describe('Scan — GSI', { tags: ['scan', 'data-plane', 'gsi'] }, () => {
 // base table in some emulators, so the parens forms are re-checked here. Items
 // carry a unique `lsi1sk` marker, which is also gsi1's hash key, so the scan
 // isolates this describe's data from whatever else is in the shared table.
-describe('Scan — GSI FilterExpression parens', { tags: ['scan', 'data-plane', 'gsi'] }, () => {
+describe('Scan — GSI FilterExpression parens', { tags: ['scan', 'data-plane', 'gsi', 'lsi'] }, () => {
   const marker = 'fes-parens-marker'
   const items = [
     { pk: { S: 'fes-parens-1' }, sk: { S: 'x' }, lsi1sk: { S: marker }, type: { S: 'alpha' }, status: { S: 'active' } },

--- a/tests/tier1/scan/gsi.test.ts
+++ b/tests/tier1/scan/gsi.test.ts
@@ -7,7 +7,10 @@ import {
   compositeTableDef,
   cleanupItems,
   waitForGsiConsistency,
+  declareTables,
 } from '../../../src/helpers.js'
+
+declareTables(compositeTableDef)
 
 describe('Scan — GSI', { tags: ['scan', 'data-plane', 'gsi'] }, () => {
   const items = [

--- a/tests/tier1/scan/gsi.test.ts
+++ b/tests/tier1/scan/gsi.test.ts
@@ -4,13 +4,13 @@ import {
 } from '@aws-sdk/client-dynamodb'
 import { ddb } from '../../../src/client.js'
 import {
-  compositeTableDef,
+  compositeIndexedTableDef,
   cleanupItems,
   waitForGsiConsistency,
   declareTables,
 } from '../../../src/helpers.js'
 
-declareTables(compositeTableDef)
+declareTables(compositeIndexedTableDef)
 
 describe('Scan — GSI', { tags: ['scan', 'data-plane', 'gsi'] }, () => {
   const items = [
@@ -44,12 +44,12 @@ describe('Scan — GSI', { tags: ['scan', 'data-plane', 'gsi'] }, () => {
     await Promise.all(
       items.map((item) =>
         ddb.send(
-          new PutItemCommand({ TableName: compositeTableDef.name, Item: item }),
+          new PutItemCommand({ TableName: compositeIndexedTableDef.name, Item: item }),
         ),
       ),
     )
     await waitForGsiConsistency({
-      tableName: compositeTableDef.name,
+      tableName: compositeIndexedTableDef.name,
       indexName: 'gsi1',
       partitionKey: { name: 'lsi1sk', value: { S: 'scan-gsi-hash-A' } },
       expectedCount: 2,
@@ -58,7 +58,7 @@ describe('Scan — GSI', { tags: ['scan', 'data-plane', 'gsi'] }, () => {
 
   afterAll(async () => {
     await cleanupItems(
-      compositeTableDef.name,
+      compositeIndexedTableDef.name,
       items.map((item) => ({ pk: item.pk, sk: item.sk })),
     )
   })
@@ -66,7 +66,7 @@ describe('Scan — GSI', { tags: ['scan', 'data-plane', 'gsi'] }, () => {
   it('scans a GSI with ALL projection and returns all attributes', async () => {
     const result = await ddb.send(
       new ScanCommand({
-        TableName: compositeTableDef.name,
+        TableName: compositeIndexedTableDef.name,
         IndexName: 'gsi1',
         FilterExpression: 'begins_with(lsi1sk, :prefix)',
         ExpressionAttributeValues: { ':prefix': { S: 'scan-gsi-hash-' } },
@@ -89,7 +89,7 @@ describe('Scan — GSI', { tags: ['scan', 'data-plane', 'gsi'] }, () => {
     // Keys: lsi1sk (HASH), lsi2sk (RANGE)
     const result = await ddb.send(
       new ScanCommand({
-        TableName: compositeTableDef.name,
+        TableName: compositeIndexedTableDef.name,
         IndexName: 'gsi2',
         FilterExpression: 'begins_with(lsi1sk, :prefix)',
         ExpressionAttributeValues: { ':prefix': { S: 'scan-gsi-hash-' } },
@@ -111,7 +111,7 @@ describe('Scan — GSI', { tags: ['scan', 'data-plane', 'gsi'] }, () => {
   it('scans a GSI with FilterExpression', async () => {
     const result = await ddb.send(
       new ScanCommand({
-        TableName: compositeTableDef.name,
+        TableName: compositeIndexedTableDef.name,
         IndexName: 'gsi1',
         FilterExpression: 'lsi1sk = :v AND #d = :data',
         ExpressionAttributeNames: { '#d': 'data' },
@@ -137,12 +137,12 @@ describe('Scan — GSI', { tags: ['scan', 'data-plane', 'gsi'] }, () => {
     }
     await ddb.send(
       new PutItemCommand({
-        TableName: compositeTableDef.name,
+        TableName: compositeIndexedTableDef.name,
         Item: noRangeItem,
       }),
     )
     await waitForGsiConsistency({
-      tableName: compositeTableDef.name,
+      tableName: compositeIndexedTableDef.name,
       indexName: 'gsi1',
       partitionKey: { name: 'lsi1sk', value: { S: 'scan-gsi-hash-sparse' } },
       expectedCount: 1,
@@ -151,7 +151,7 @@ describe('Scan — GSI', { tags: ['scan', 'data-plane', 'gsi'] }, () => {
     // Present in the hash-only GSI...
     const gsi1Scan = await ddb.send(
       new ScanCommand({
-        TableName: compositeTableDef.name,
+        TableName: compositeIndexedTableDef.name,
         IndexName: 'gsi1',
         FilterExpression: 'lsi1sk = :v',
         ExpressionAttributeValues: { ':v': { S: 'scan-gsi-hash-sparse' } },
@@ -162,14 +162,70 @@ describe('Scan — GSI', { tags: ['scan', 'data-plane', 'gsi'] }, () => {
     // ...but never scanned from the composite GSI.
     const gsi2Scan = await ddb.send(
       new ScanCommand({
-        TableName: compositeTableDef.name,
+        TableName: compositeIndexedTableDef.name,
         IndexName: 'gsi2',
       }),
     )
     expect(gsi2Scan.Items!.map((i) => i.pk?.S)).not.toContain('scan-gsi-sparse')
 
-    await cleanupItems(compositeTableDef.name, [
+    await cleanupItems(compositeIndexedTableDef.name, [
       { pk: noRangeItem.pk, sk: noRangeItem.sk },
     ])
+  })
+})
+
+// Scanning an index runs a different FilterExpression path from scanning the
+// base table in some emulators, so the parens forms are re-checked here. Items
+// carry a unique `lsi1sk` marker, which is also gsi1's hash key, so the scan
+// isolates this describe's data from whatever else is in the shared table.
+describe('Scan — GSI FilterExpression parens', { tags: ['scan', 'data-plane', 'gsi'] }, () => {
+  const marker = 'fes-parens-marker'
+  const items = [
+    { pk: { S: 'fes-parens-1' }, sk: { S: 'x' }, lsi1sk: { S: marker }, type: { S: 'alpha' }, status: { S: 'active' } },
+    { pk: { S: 'fes-parens-2' }, sk: { S: 'x' }, lsi1sk: { S: marker }, type: { S: 'beta' }, status: { S: 'inactive' } },
+    { pk: { S: 'fes-parens-3' }, sk: { S: 'x' }, lsi1sk: { S: marker }, type: { S: 'gamma' }, status: { S: 'active' } },
+    { pk: { S: 'fes-parens-4' }, sk: { S: 'x' }, lsi1sk: { S: marker }, type: { S: 'alpha' }, status: { S: 'active' } },
+  ]
+
+  beforeAll(async () => {
+    await Promise.all(
+      items.map((item) =>
+        ddb.send(
+          new PutItemCommand({ TableName: compositeIndexedTableDef.name, Item: item }),
+        ),
+      ),
+    )
+    await waitForGsiConsistency({
+      tableName: compositeIndexedTableDef.name,
+      indexName: 'gsi1',
+      partitionKey: { name: 'lsi1sk', value: { S: marker } },
+      expectedCount: items.length,
+    })
+  }, 30_000)
+
+  afterAll(async () => {
+    await cleanupItems(
+      compositeIndexedTableDef.name,
+      items.map((item) => ({ pk: item.pk, sk: item.sk })),
+    )
+  })
+
+  it('GSI scan — parens filter returns matching items', async () => {
+    const result = await ddb.send(
+      new ScanCommand({
+        TableName: compositeIndexedTableDef.name,
+        IndexName: 'gsi1',
+        FilterExpression: '(#m = :m) AND ((#t = :a) OR (#t = :b))',
+        ExpressionAttributeNames: { '#m': 'lsi1sk', '#t': 'type' },
+        ExpressionAttributeValues: {
+          ':m': { S: marker },
+          ':a': { S: 'alpha' },
+          ':b': { S: 'beta' },
+        },
+      }),
+    )
+
+    // Same three items show through the GSI (all four have lsi1sk=marker)
+    expect(result.Items).toHaveLength(3)
   })
 })

--- a/tests/tier1/scan/lsi.test.ts
+++ b/tests/tier1/scan/lsi.test.ts
@@ -6,7 +6,10 @@ import { ddb } from '../../../src/client.js'
 import {
   compositeTableDef,
   cleanupItems,
+  declareTables,
 } from '../../../src/helpers.js'
+
+declareTables(compositeTableDef)
 
 describe('Scan — LSI', { tags: ['scan', 'data-plane', 'lsi'] }, () => {
   const items = [

--- a/tests/tier1/scan/lsi.test.ts
+++ b/tests/tier1/scan/lsi.test.ts
@@ -4,12 +4,12 @@ import {
 } from '@aws-sdk/client-dynamodb'
 import { ddb } from '../../../src/client.js'
 import {
-  compositeTableDef,
+  compositeIndexedTableDef,
   cleanupItems,
   declareTables,
 } from '../../../src/helpers.js'
 
-declareTables(compositeTableDef)
+declareTables(compositeIndexedTableDef)
 
 describe('Scan — LSI', { tags: ['scan', 'data-plane', 'lsi'] }, () => {
   const items = [
@@ -40,7 +40,7 @@ describe('Scan — LSI', { tags: ['scan', 'data-plane', 'lsi'] }, () => {
     await Promise.all(
       items.map((item) =>
         ddb.send(
-          new PutItemCommand({ TableName: compositeTableDef.name, Item: item }),
+          new PutItemCommand({ TableName: compositeIndexedTableDef.name, Item: item }),
         ),
       ),
     )
@@ -48,7 +48,7 @@ describe('Scan — LSI', { tags: ['scan', 'data-plane', 'lsi'] }, () => {
 
   afterAll(async () => {
     await cleanupItems(
-      compositeTableDef.name,
+      compositeIndexedTableDef.name,
       items.map((item) => ({ pk: item.pk, sk: item.sk })),
     )
   })
@@ -56,7 +56,7 @@ describe('Scan — LSI', { tags: ['scan', 'data-plane', 'lsi'] }, () => {
   it('scans an LSI and returns items', async () => {
     const result = await ddb.send(
       new ScanCommand({
-        TableName: compositeTableDef.name,
+        TableName: compositeIndexedTableDef.name,
         IndexName: 'lsi1',
         FilterExpression: 'begins_with(pk, :prefix)',
         ExpressionAttributeValues: { ':prefix': { S: 'scan-lsi-' } },
@@ -77,7 +77,7 @@ describe('Scan — LSI', { tags: ['scan', 'data-plane', 'lsi'] }, () => {
   it('scans an LSI with FilterExpression', async () => {
     const result = await ddb.send(
       new ScanCommand({
-        TableName: compositeTableDef.name,
+        TableName: compositeIndexedTableDef.name,
         IndexName: 'lsi1',
         FilterExpression: 'pk = :pk AND #d = :data',
         ExpressionAttributeNames: { '#d': 'data' },
@@ -97,7 +97,7 @@ describe('Scan — LSI', { tags: ['scan', 'data-plane', 'lsi'] }, () => {
   it('supports ConsistentRead on LSI scan', async () => {
     const result = await ddb.send(
       new ScanCommand({
-        TableName: compositeTableDef.name,
+        TableName: compositeIndexedTableDef.name,
         IndexName: 'lsi2',
         FilterExpression: 'begins_with(pk, :prefix)',
         ExpressionAttributeValues: { ':prefix': { S: 'scan-lsi-' } },
@@ -122,7 +122,7 @@ describe('Scan — LSI', { tags: ['scan', 'data-plane', 'lsi'] }, () => {
     const noLsiSkItem = { pk: { S: 'scan-lsi-sparse' }, sk: { S: 'x' } }
     await ddb.send(
       new PutItemCommand({
-        TableName: compositeTableDef.name,
+        TableName: compositeIndexedTableDef.name,
         Item: noLsiSkItem,
       }),
     )
@@ -130,7 +130,7 @@ describe('Scan — LSI', { tags: ['scan', 'data-plane', 'lsi'] }, () => {
     // Absent from an LSI scan...
     const lsiScan = await ddb.send(
       new ScanCommand({
-        TableName: compositeTableDef.name,
+        TableName: compositeIndexedTableDef.name,
         IndexName: 'lsi1',
         ConsistentRead: true,
       }),
@@ -140,7 +140,7 @@ describe('Scan — LSI', { tags: ['scan', 'data-plane', 'lsi'] }, () => {
     // ...but present in a base-table scan.
     const baseScan = await ddb.send(
       new ScanCommand({
-        TableName: compositeTableDef.name,
+        TableName: compositeIndexedTableDef.name,
         ConsistentRead: true,
         FilterExpression: 'pk = :p',
         ExpressionAttributeValues: { ':p': { S: 'scan-lsi-sparse' } },
@@ -148,7 +148,7 @@ describe('Scan — LSI', { tags: ['scan', 'data-plane', 'lsi'] }, () => {
     )
     expect(baseScan.Items!.map((i) => i.pk?.S)).toContain('scan-lsi-sparse')
 
-    await cleanupItems(compositeTableDef.name, [
+    await cleanupItems(compositeIndexedTableDef.name, [
       { pk: noLsiSkItem.pk, sk: noLsiSkItem.sk },
     ])
   })

--- a/tests/tier1/scan/lsi.test.ts
+++ b/tests/tier1/scan/lsi.test.ts
@@ -11,7 +11,7 @@ import {
 
 declareTables(compositeIndexedTableDef)
 
-describe('Scan — LSI', { tags: ['scan', 'data-plane', 'lsi'] }, () => {
+describe('Scan — LSI', { tags: ['scan', 'data-plane', 'gsi', 'lsi'] }, () => {
   const items = [
     {
       pk: { S: 'scan-lsi-1' },

--- a/tests/tier1/scan/parallel.test.ts
+++ b/tests/tier1/scan/parallel.test.ts
@@ -4,7 +4,9 @@ import {
   type AttributeValue,
 } from '@aws-sdk/client-dynamodb'
 import { ddb } from '../../../src/client.js'
-import { hashTableDef, cleanupItems } from '../../../src/helpers.js'
+import { declareTables, hashTableDef, cleanupItems } from '../../../src/helpers.js'
+
+declareTables(hashTableDef)
 
 describe('Scan — parallel', { tags: ['scan', 'data-plane'] }, () => {
   const TOTAL_SEGMENTS = 4

--- a/tests/tier1/scan/projection.test.ts
+++ b/tests/tier1/scan/projection.test.ts
@@ -1,6 +1,8 @@
 import { PutItemCommand, ScanCommand } from '@aws-sdk/client-dynamodb'
 import { ddb } from '../../../src/client.js'
-import { hashTableDef, cleanupItems } from '../../../src/helpers.js'
+import { declareTables, hashTableDef, cleanupItems } from '../../../src/helpers.js'
+
+declareTables(hashTableDef)
 
 describe('Scan — legal shared-prefix projections', { tags: ['scan', 'data-plane'] }, () => {
   // Projection paths that share a prefix without one being a prefix of the

--- a/tests/tier1/scan/select.test.ts
+++ b/tests/tier1/scan/select.test.ts
@@ -3,7 +3,9 @@ import {
   ScanCommand,
 } from '@aws-sdk/client-dynamodb'
 import { ddb } from '../../../src/client.js'
-import { hashTableDef, cleanupItems, expectDynamoError } from '../../../src/helpers.js'
+import { declareTables, hashTableDef, cleanupItems, expectDynamoError } from '../../../src/helpers.js'
+
+declareTables(hashTableDef)
 
 describe('Scan — Select COUNT', { tags: ['scan', 'data-plane'] }, () => {
   const items = [

--- a/tests/tier1/scan/validation.test.ts
+++ b/tests/tier1/scan/validation.test.ts
@@ -1,6 +1,8 @@
 import { ScanCommand } from '@aws-sdk/client-dynamodb'
 import { ddb } from '../../../src/client.js'
-import { hashTableDef, expectDynamoError } from '../../../src/helpers.js'
+import { declareTables, hashTableDef, expectDynamoError } from '../../../src/helpers.js'
+
+declareTables(hashTableDef)
 
 describe('Scan — validation', { tags: ['scan', 'data-plane', 'negative-path'] }, () => {
   it('rejects scan on non-existent table', async () => {

--- a/tests/tier1/updateItem/basic.test.ts
+++ b/tests/tier1/updateItem/basic.test.ts
@@ -4,7 +4,9 @@ import {
   UpdateItemCommand,
 } from '@aws-sdk/client-dynamodb'
 import { ddb } from '../../../src/client.js'
-import { hashTableDef, cleanupItems } from '../../../src/helpers.js'
+import { declareTables, hashTableDef, cleanupItems } from '../../../src/helpers.js'
+
+declareTables(hashTableDef)
 
 describe('UpdateItem — SET', { tags: ['update-item', 'data-plane'] }, () => {
   afterEach(async () => {

--- a/tests/tier1/updateItem/conditions.test.ts
+++ b/tests/tier1/updateItem/conditions.test.ts
@@ -5,7 +5,9 @@ import {
   ConditionalCheckFailedException,
 } from '@aws-sdk/client-dynamodb'
 import { ddb } from '../../../src/client.js'
-import { hashTableDef, cleanupItems, expectDynamoError } from '../../../src/helpers.js'
+import { declareTables, hashTableDef, cleanupItems, expectDynamoError } from '../../../src/helpers.js'
+
+declareTables(hashTableDef)
 
 describe('UpdateItem — ConditionExpression', { tags: ['update-item', 'data-plane'] }, () => {
   afterAll(async () => {

--- a/tests/tier1/updateItem/expressionHygiene.test.ts
+++ b/tests/tier1/updateItem/expressionHygiene.test.ts
@@ -4,7 +4,9 @@ import {
   type UpdateItemCommandInput,
 } from '@aws-sdk/client-dynamodb'
 import { ddb } from '../../../src/client.js'
-import { hashTableDef } from '../../../src/helpers.js'
+import { declareTables, hashTableDef } from '../../../src/helpers.js'
+
+declareTables(hashTableDef)
 
 describe('UpdateItem — expression attribute hygiene', { tags: ['update-item', 'data-plane', 'negative-path'] }, () => {
   const key = { pk: { S: 'expr-hygiene' } }

--- a/tests/tier1/updateItem/paths.test.ts
+++ b/tests/tier1/updateItem/paths.test.ts
@@ -4,7 +4,9 @@ import {
   UpdateItemCommand,
 } from '@aws-sdk/client-dynamodb'
 import { ddb } from '../../../src/client.js'
-import { hashTableDef, cleanupItems, expectDynamoError } from '../../../src/helpers.js'
+import { declareTables, hashTableDef, cleanupItems, expectDynamoError } from '../../../src/helpers.js'
+
+declareTables(hashTableDef)
 
 describe('UpdateItem — nested path semantics', { tags: ['update-item', 'data-plane'] }, () => {
   const keysToCleanup: { pk: { S: string } }[] = []

--- a/tests/tier1/updateItem/validation.test.ts
+++ b/tests/tier1/updateItem/validation.test.ts
@@ -1,6 +1,8 @@
 import { UpdateItemCommand } from '@aws-sdk/client-dynamodb'
 import { ddb } from '../../../src/client.js'
-import { hashTableDef, expectDynamoError } from '../../../src/helpers.js'
+import { declareTables, hashTableDef, expectDynamoError } from '../../../src/helpers.js'
+
+declareTables(hashTableDef)
 
 describe('UpdateItem — validation', { tags: ['update-item', 'data-plane', 'negative-path'] }, () => {
   it('rejects update on non-existent table', async () => {

--- a/tests/tier2/partiql/batchExecuteStatement.test.ts
+++ b/tests/tier2/partiql/batchExecuteStatement.test.ts
@@ -6,7 +6,9 @@ import {
 } from '@aws-sdk/client-dynamodb'
 import { ddb } from '../../../src/client.js'
 import { isUnsupportedFault } from '../../../src/infra.js'
-import { hashTableDef, cleanupItems, expectDynamoError } from '../../../src/helpers.js'
+import { declareTables, hashTableDef, cleanupItems, expectDynamoError } from '../../../src/helpers.js'
+
+declareTables(hashTableDef)
 
 describe('BatchExecuteStatement — PartiQL', { tags: ['partiql', 'data-plane'] }, () => {
   let supported = true

--- a/tests/tier2/partiql/executeStatement.test.ts
+++ b/tests/tier2/partiql/executeStatement.test.ts
@@ -7,8 +7,10 @@ import {
 } from '@aws-sdk/client-dynamodb'
 import { ddb } from '../../../src/client.js'
 import { isUnsupportedFault } from '../../../src/infra.js'
-import { hashTableDef, compositeTableDef, cleanupItems, expectDynamoError } from '../../../src/helpers.js'
+import { declareTables, hashTableDef, compositeTableDef, cleanupItems, expectDynamoError } from '../../../src/helpers.js'
 import type { AttributeValue } from '@aws-sdk/client-dynamodb'
+
+declareTables(hashTableDef, compositeTableDef)
 
 describe('ExecuteStatement — PartiQL', { tags: ['partiql', 'data-plane'] }, () => {
   let supported = true

--- a/tests/tier2/partiql/executeTransaction.test.ts
+++ b/tests/tier2/partiql/executeTransaction.test.ts
@@ -6,7 +6,9 @@ import {
 } from '@aws-sdk/client-dynamodb'
 import { ddb } from '../../../src/client.js'
 import { isUnsupportedFault } from '../../../src/infra.js'
-import { hashTableDef, cleanupItems, expectDynamoError } from '../../../src/helpers.js'
+import { declareTables, hashTableDef, cleanupItems, expectDynamoError } from '../../../src/helpers.js'
+
+declareTables(hashTableDef)
 
 describe('ExecuteTransaction — PartiQL', { tags: ['partiql', 'data-plane'] }, () => {
   let supported = true

--- a/tests/tier2/transactions/transactGet.test.ts
+++ b/tests/tier2/transactions/transactGet.test.ts
@@ -9,7 +9,10 @@ import {
   compositeTableDef,
   cleanupItems,
   expectDynamoError,
+  declareTables,
 } from '../../../src/helpers.js'
+
+declareTables(hashTableDef, compositeTableDef)
 
 const hashKeys = [
   { pk: { S: 'tg-basic-1' } },

--- a/tests/tier2/transactions/transactGet.test.ts
+++ b/tests/tier2/transactions/transactGet.test.ts
@@ -1,7 +1,6 @@
 import {
   PutItemCommand,
   TransactGetItemsCommand,
-  TransactWriteItemsCommand,
 } from '@aws-sdk/client-dynamodb'
 import { ddb } from '../../../src/client.js'
 import {

--- a/tests/tier2/transactions/transactWrite.test.ts
+++ b/tests/tier2/transactions/transactWrite.test.ts
@@ -60,15 +60,6 @@ const hashKeys = [
 
 const compositeKeys = [
   { pk: { S: 'tw-cross-comp' }, sk: { S: 'sk1' } },
-  // Defensive: the invalid-index-key cases below must all fail validation and
-  // write nothing. Clean up anyway so a too-lenient target that wrongly persists
-  // them does not leak rows into later tests.
-  { pk: { S: 'tw-idx-type' }, sk: { S: 'a' } },
-  { pk: { S: 'tw-idx-nonscalar' }, sk: { S: 'b' } },
-  { pk: { S: 'tw-idx-empty' }, sk: { S: 'c' } },
-  { pk: { S: 'tw-idx-upd-type' }, sk: { S: 'a' } },
-  { pk: { S: 'tw-idx-upd-nonscalar' }, sk: { S: 'b' } },
-  { pk: { S: 'tw-idx-upd-empty' }, sk: { S: 'c' } },
 ]
 
 afterAll(async () => {
@@ -745,8 +736,8 @@ describe('TransactWriteItems - validation', { tags: ['transactions', 'data-plane
     )
   })
 
-  // An item carrying a malformed key value (table or index key) is rejected, but
-  // the error SHAPE depends on the fault, and the two halves are opposite traps:
+  // An item carrying a malformed table key value is rejected, but the error
+  // SHAPE depends on the fault, and the two halves are opposite traps:
   //
   //   - Wrong type / non-scalar: caught during transaction execution, so AWS
   //     cancels with a TransactionCanceledException whose reason Code is
@@ -756,8 +747,9 @@ describe('TransactWriteItems - validation', { tags: ['transactions', 'data-plane
   //     top-level ValidationException even inside a transaction. An engine that
   //     wraps this as a TransactionCanceledException diverges.
   //
-  // Both directions are asserted below. Exact strings live in
-  // tests/tier3/error-messages/transactWriteItems.test.ts.
+  // Both directions are asserted below. The equivalent secondary-index key cases
+  // live in tests/tier2/transactions/transactWriteIndexKeys.test.ts; exact
+  // strings live in tests/tier3/error-messages/transactWriteItems.test.ts.
 
   const expectCancelledForValidation = async (transactItems: unknown[]) => {
     try {
@@ -786,54 +778,6 @@ describe('TransactWriteItems - validation', { tags: ['transactions', 'data-plane
     ])
   })
 
-  it('Put with a wrong-typed index key cancels with a ValidationError reason', async () => {
-    await expectCancelledForValidation([
-      {
-        Put: {
-          TableName: compositeTableDef.name,
-          Item: { pk: { S: 'tw-idx-type' }, sk: { S: 'a' }, lsi1sk: { N: '5' } },
-        },
-      },
-    ])
-  })
-
-  it('Put with a non-scalar index key cancels with a ValidationError reason', async () => {
-    await expectCancelledForValidation([
-      {
-        Put: {
-          TableName: compositeTableDef.name,
-          Item: { pk: { S: 'tw-idx-nonscalar' }, sk: { S: 'b' }, lsi1sk: { L: [{ S: 'x' }] } },
-        },
-      },
-    ])
-  })
-
-  it('Update setting a wrong-typed index key cancels with a ValidationError reason', async () => {
-    await expectCancelledForValidation([
-      {
-        Update: {
-          TableName: compositeTableDef.name,
-          Key: { pk: { S: 'tw-idx-upd-type' }, sk: { S: 'a' } },
-          UpdateExpression: 'SET lsi1sk = :v',
-          ExpressionAttributeValues: { ':v': { N: '5' } },
-        },
-      },
-    ])
-  })
-
-  it('Update setting a non-scalar index key cancels with a ValidationError reason', async () => {
-    await expectCancelledForValidation([
-      {
-        Update: {
-          TableName: compositeTableDef.name,
-          Key: { pk: { S: 'tw-idx-upd-nonscalar' }, sk: { S: 'b' } },
-          UpdateExpression: 'SET lsi1sk = :v',
-          ExpressionAttributeValues: { ':v': { L: [{ S: 'x' }] } },
-        },
-      },
-    ])
-  })
-
   it('Put with an empty-string table key is a top-level ValidationException', async () => {
     // Not a TransactionCanceledException — expectDynamoError asserts the name is
     // ValidationException, which a cancellation wrapper would fail.
@@ -847,46 +791,6 @@ describe('TransactWriteItems - validation', { tags: ['transactions', 'data-plane
       ),
       'ValidationException',
       /empty string value/i,
-    )
-  })
-
-  it('Put with an empty-string index key is a top-level ValidationException', async () => {
-    await expectDynamoError(
-      () => ddb.send(
-        new TransactWriteItemsCommand({
-          TransactItems: [
-            {
-              Put: {
-                TableName: compositeTableDef.name,
-                Item: { pk: { S: 'tw-idx-empty' }, sk: { S: 'c' }, lsi1sk: { S: '' } },
-              },
-            },
-          ],
-        }),
-      ),
-      'ValidationException',
-      /secondary index key/i,
-    )
-  })
-
-  it('Update setting an empty-string index key is a top-level ValidationException', async () => {
-    await expectDynamoError(
-      () => ddb.send(
-        new TransactWriteItemsCommand({
-          TransactItems: [
-            {
-              Update: {
-                TableName: compositeTableDef.name,
-                Key: { pk: { S: 'tw-idx-upd-empty' }, sk: { S: 'c' } },
-                UpdateExpression: 'SET lsi1sk = :v',
-                ExpressionAttributeValues: { ':v': { S: '' } },
-              },
-            },
-          ],
-        }),
-      ),
-      'ValidationException',
-      /secondary index key/i,
     )
   })
 

--- a/tests/tier2/transactions/transactWrite.test.ts
+++ b/tests/tier2/transactions/transactWrite.test.ts
@@ -13,7 +13,10 @@ import {
   compositeTableDef,
   cleanupItems,
   expectDynamoError,
+  declareTables,
 } from '../../../src/helpers.js'
+
+declareTables(hashTableDef, compositeTableDef)
 
 const hashKeys = [
   { pk: { S: 'tw-basic-1' } },

--- a/tests/tier2/transactions/transactWrite.test.ts
+++ b/tests/tier2/transactions/transactWrite.test.ts
@@ -1,10 +1,9 @@
 import {
   PutItemCommand,
   GetItemCommand,
-  UpdateItemCommand,
-  DeleteItemCommand,
   TransactWriteItemsCommand,
   TransactionCanceledException,
+  type TransactWriteItem,
 } from '@aws-sdk/client-dynamodb'
 import { ddb } from '../../../src/client.js'
 import { skipUnlessSupported } from '../../../src/infra.js'
@@ -754,7 +753,7 @@ describe('TransactWriteItems - validation', { tags: ['transactions', 'data-plane
   const expectCancelledForValidation = async (transactItems: unknown[]) => {
     try {
       await ddb.send(
-        new TransactWriteItemsCommand({ TransactItems: transactItems as never }),
+        new TransactWriteItemsCommand({ TransactItems: transactItems as TransactWriteItem[] }),
       )
       expect.unreachable('should have thrown')
     } catch (err) {
@@ -808,7 +807,7 @@ describe('TransactWriteItems - validation', { tags: ['transactions', 'data-plane
 
   const expectKeyTopLevelValidation = (transactItem: unknown) =>
     expectDynamoError(
-      () => ddb.send(new TransactWriteItemsCommand({ TransactItems: [transactItem] as never })),
+      () => ddb.send(new TransactWriteItemsCommand({ TransactItems: [transactItem] as TransactWriteItem[] })),
       'ValidationException',
       /empty string value/i,
     )

--- a/tests/tier2/transactions/transactWriteIndexKeys.test.ts
+++ b/tests/tier2/transactions/transactWriteIndexKeys.test.ts
@@ -1,0 +1,154 @@
+import {
+  TransactWriteItemsCommand,
+  TransactionCanceledException,
+} from '@aws-sdk/client-dynamodb'
+import { ddb } from '../../../src/client.js'
+import { skipUnlessSupported } from '../../../src/infra.js'
+import {
+  compositeIndexedTableDef,
+  cleanupItems,
+  expectDynamoError,
+  declareTables,
+} from '../../../src/helpers.js'
+
+declareTables(compositeIndexedTableDef)
+
+// Defensive: the invalid-index-key cases below must all fail validation and
+// write nothing. Clean up anyway so a too-lenient target that wrongly persists
+// them does not leak rows into later tests.
+const compositeKeys = [
+  { pk: { S: 'tw-idx-type' }, sk: { S: 'a' } },
+  { pk: { S: 'tw-idx-nonscalar' }, sk: { S: 'b' } },
+  { pk: { S: 'tw-idx-empty' }, sk: { S: 'c' } },
+  { pk: { S: 'tw-idx-upd-type' }, sk: { S: 'a' } },
+  { pk: { S: 'tw-idx-upd-nonscalar' }, sk: { S: 'b' } },
+  { pk: { S: 'tw-idx-upd-empty' }, sk: { S: 'c' } },
+]
+
+afterAll(async () => {
+  await cleanupItems(compositeIndexedTableDef.name, compositeKeys)
+})
+
+describe('TransactWriteItems — index key validation', { tags: ['transactions', 'data-plane', 'negative-path', 'lsi'] }, () => {
+  // An empty TransactItems is rejected by any target that implements the
+  // operation, so this separates "not implemented" from "implemented".
+  skipUnlessSupported(() => ddb.send(new TransactWriteItemsCommand({ TransactItems: [] })))
+
+  // An item carrying a malformed secondary-index key value is rejected, but the
+  // error SHAPE depends on the fault, and the two halves are opposite traps:
+  //
+  //   - Wrong type / non-scalar: caught during transaction execution, so AWS
+  //     cancels with a TransactionCanceledException whose reason Code is
+  //     'ValidationError'. An engine that "validates up front" and returns a
+  //     top-level ValidationException here diverges from real DynamoDB.
+  //   - Empty string: caught by up-front input validation, so AWS returns a
+  //     top-level ValidationException even inside a transaction. An engine that
+  //     wraps this as a TransactionCanceledException diverges.
+  //
+  // Both directions are asserted below. The equivalent table-key cases live in
+  // tests/tier2/transactions/transactWrite.test.ts; exact strings live in
+  // tests/tier3/error-messages/transactIndexKeys.test.ts.
+
+  const expectCancelledForValidation = async (transactItems: unknown[]) => {
+    try {
+      await ddb.send(
+        new TransactWriteItemsCommand({ TransactItems: transactItems as never }),
+      )
+      expect.unreachable('should have thrown')
+    } catch (err) {
+      expect(err).toBeInstanceOf(TransactionCanceledException)
+      const txErr = err as TransactionCanceledException
+      // name is TransactionCanceledException, NOT a top-level ValidationException.
+      expect(txErr.name).toBe('TransactionCanceledException')
+      expect(txErr.CancellationReasons?.[0]?.Code).toBe('ValidationError')
+    }
+  }
+
+  it('Put with a wrong-typed index key cancels with a ValidationError reason', async () => {
+    await expectCancelledForValidation([
+      {
+        Put: {
+          TableName: compositeIndexedTableDef.name,
+          Item: { pk: { S: 'tw-idx-type' }, sk: { S: 'a' }, lsi1sk: { N: '5' } },
+        },
+      },
+    ])
+  })
+
+  it('Put with a non-scalar index key cancels with a ValidationError reason', async () => {
+    await expectCancelledForValidation([
+      {
+        Put: {
+          TableName: compositeIndexedTableDef.name,
+          Item: { pk: { S: 'tw-idx-nonscalar' }, sk: { S: 'b' }, lsi1sk: { L: [{ S: 'x' }] } },
+        },
+      },
+    ])
+  })
+
+  it('Update setting a wrong-typed index key cancels with a ValidationError reason', async () => {
+    await expectCancelledForValidation([
+      {
+        Update: {
+          TableName: compositeIndexedTableDef.name,
+          Key: { pk: { S: 'tw-idx-upd-type' }, sk: { S: 'a' } },
+          UpdateExpression: 'SET lsi1sk = :v',
+          ExpressionAttributeValues: { ':v': { N: '5' } },
+        },
+      },
+    ])
+  })
+
+  it('Update setting a non-scalar index key cancels with a ValidationError reason', async () => {
+    await expectCancelledForValidation([
+      {
+        Update: {
+          TableName: compositeIndexedTableDef.name,
+          Key: { pk: { S: 'tw-idx-upd-nonscalar' }, sk: { S: 'b' } },
+          UpdateExpression: 'SET lsi1sk = :v',
+          ExpressionAttributeValues: { ':v': { L: [{ S: 'x' }] } },
+        },
+      },
+    ])
+  })
+
+  it('Put with an empty-string index key is a top-level ValidationException', async () => {
+    await expectDynamoError(
+      () => ddb.send(
+        new TransactWriteItemsCommand({
+          TransactItems: [
+            {
+              Put: {
+                TableName: compositeIndexedTableDef.name,
+                Item: { pk: { S: 'tw-idx-empty' }, sk: { S: 'c' }, lsi1sk: { S: '' } },
+              },
+            },
+          ],
+        }),
+      ),
+      'ValidationException',
+      /secondary index key/i,
+    )
+  })
+
+  it('Update setting an empty-string index key is a top-level ValidationException', async () => {
+    await expectDynamoError(
+      () => ddb.send(
+        new TransactWriteItemsCommand({
+          TransactItems: [
+            {
+              Update: {
+                TableName: compositeIndexedTableDef.name,
+                Key: { pk: { S: 'tw-idx-upd-empty' }, sk: { S: 'c' } },
+                UpdateExpression: 'SET lsi1sk = :v',
+                ExpressionAttributeValues: { ':v': { S: '' } },
+              },
+            },
+          ],
+        }),
+      ),
+      'ValidationException',
+      /secondary index key/i,
+    )
+  })
+})

--- a/tests/tier2/transactions/transactWriteIndexKeys.test.ts
+++ b/tests/tier2/transactions/transactWriteIndexKeys.test.ts
@@ -1,6 +1,7 @@
 import {
   TransactWriteItemsCommand,
   TransactionCanceledException,
+  type TransactWriteItem,
 } from '@aws-sdk/client-dynamodb'
 import { ddb } from '../../../src/client.js'
 import { skipUnlessSupported } from '../../../src/infra.js'
@@ -29,7 +30,7 @@ afterAll(async () => {
   await cleanupItems(compositeIndexedTableDef.name, compositeKeys)
 })
 
-describe('TransactWriteItems — index key validation', { tags: ['transactions', 'data-plane', 'negative-path', 'lsi'] }, () => {
+describe('TransactWriteItems — index key validation', { tags: ['transactions', 'data-plane', 'negative-path', 'gsi', 'lsi'] }, () => {
   // An empty TransactItems is rejected by any target that implements the
   // operation, so this separates "not implemented" from "implemented".
   skipUnlessSupported(() => ddb.send(new TransactWriteItemsCommand({ TransactItems: [] })))
@@ -52,7 +53,7 @@ describe('TransactWriteItems — index key validation', { tags: ['transactions',
   const expectCancelledForValidation = async (transactItems: unknown[]) => {
     try {
       await ddb.send(
-        new TransactWriteItemsCommand({ TransactItems: transactItems as never }),
+        new TransactWriteItemsCommand({ TransactItems: transactItems as TransactWriteItem[] }),
       )
       expect.unreachable('should have thrown')
     } catch (err) {

--- a/tests/tier3/error-messages/batchGetItem.test.ts
+++ b/tests/tier3/error-messages/batchGetItem.test.ts
@@ -4,7 +4,9 @@ import {
   ResourceNotFoundException,
 } from '@aws-sdk/client-dynamodb'
 import { ddb } from '../../../src/client.js'
-import { hashTableDef, hashBTableDef, compositeTableDef } from '../../../src/helpers.js'
+import { declareTables, hashTableDef, hashBTableDef, compositeTableDef } from '../../../src/helpers.js'
+
+declareTables(hashTableDef, hashBTableDef, compositeTableDef)
 
 describe('BatchGetItem — exact error messages', { tags: ['batch', 'data-plane', 'negative-path'] }, () => {
   it('empty RequestItems: full required-parameter error', async () => {

--- a/tests/tier3/error-messages/batchWriteItem.test.ts
+++ b/tests/tier3/error-messages/batchWriteItem.test.ts
@@ -7,29 +7,18 @@ import { ddb } from '../../../src/client.js'
 import {
   hashTableDef,
   hashBTableDef,
-  gsiBTableDef,
-  compositeTableDef,
   cleanupItems,
   declareTables,
 } from '../../../src/helpers.js'
 
-declareTables(hashTableDef, hashBTableDef, gsiBTableDef, compositeTableDef)
+declareTables(hashTableDef, hashBTableDef)
 
 const keysToCleanup = [
   { pk: { S: 'em-bw-dup' } },
 ]
 
-// Defensive: the invalid-index-key cases below fail validation and write
-// nothing; clean up anyway in case a too-lenient target persists them.
-const compositeKeysToCleanup = [
-  { pk: { S: 'em-bw-idx-type' }, sk: { S: 'a' } },
-  { pk: { S: 'em-bw-idx-nonscalar' }, sk: { S: 'b' } },
-  { pk: { S: 'em-bw-idx-empty' }, sk: { S: 'c' } },
-]
-
 afterAll(async () => {
   await cleanupItems(hashTableDef.name, keysToCleanup)
-  await cleanupItems(compositeTableDef.name, compositeKeysToCleanup)
 })
 
 describe('BatchWriteItem — exact error messages', { tags: ['batch', 'data-plane', 'negative-path'] }, () => {
@@ -127,8 +116,8 @@ describe('BatchWriteItem — exact error messages', { tags: ['batch', 'data-plan
   // Strings captured from real AWS, invariant across four regions (eu-west-2,
   // us-east-1, ap-southeast-2, eu-central-1; 2026-06-23) — so the table-key
   // schema-mismatch message is the contract, not a region-local wording.
-  // Index-key messages name gsi1, the alphabetically-first index lsi1sk keys on
-  // compositeTableDef.
+  // The secondary-index-key variants live in indexKeyValues.test.ts, so this
+  // file declares no indexed table.
   const expectExactValidation = async (
     command: BatchWriteItemCommand,
     message: string,
@@ -185,58 +174,6 @@ describe('BatchWriteItem — exact error messages', { tags: ['batch', 'data-plan
         RequestItems: { [hashBTableDef.name]: [{ DeleteRequest: { Key: { pk: { B: new Uint8Array([]) } } } }] },
       }),
       'One or more parameter values are not valid. The AttributeValue for a key attribute cannot contain an empty binary value. Key: pk',
-    )
-  })
-
-  it('wrong-typed index key: full type-mismatch message', async () => {
-    await expectExactValidation(
-      new BatchWriteItemCommand({
-        RequestItems: {
-          [compositeTableDef.name]: [
-            { PutRequest: { Item: { pk: { S: 'em-bw-idx-type' }, sk: { S: 'a' }, lsi1sk: { N: '5' } } } },
-          ],
-        },
-      }),
-      'One or more parameter values were invalid: Type mismatch for Index Key lsi1sk Expected: S Actual: N IndexName: gsi1',
-    )
-  })
-
-  it('non-scalar index key: full type-mismatch message', async () => {
-    await expectExactValidation(
-      new BatchWriteItemCommand({
-        RequestItems: {
-          [compositeTableDef.name]: [
-            { PutRequest: { Item: { pk: { S: 'em-bw-idx-nonscalar' }, sk: { S: 'b' }, lsi1sk: { L: [{ S: 'x' }] } } } },
-          ],
-        },
-      }),
-      'One or more parameter values were invalid: Type mismatch for Index Key lsi1sk Expected: S Actual: L IndexName: gsi1',
-    )
-  })
-
-  it('empty-string index key: full secondary-index-key message', async () => {
-    await expectExactValidation(
-      new BatchWriteItemCommand({
-        RequestItems: {
-          [compositeTableDef.name]: [
-            { PutRequest: { Item: { pk: { S: 'em-bw-idx-empty' }, sk: { S: 'c' }, lsi1sk: { S: '' } } } },
-          ],
-        },
-      }),
-      'One or more parameter values are not valid. A value specified for a secondary index key is not supported. The AttributeValue for a key attribute cannot contain an empty string value. IndexName: gsi1, IndexKey: lsi1sk',
-    )
-  })
-
-  it('empty-binary index key: full secondary-index-key message', async () => {
-    await expectExactValidation(
-      new BatchWriteItemCommand({
-        RequestItems: {
-          [gsiBTableDef.name]: [
-            { PutRequest: { Item: { pk: { S: 'eb-bw-idx' }, bidx: { B: new Uint8Array([]) } } } },
-          ],
-        },
-      }),
-      'One or more parameter values are not valid. A value specified for a secondary index key is not supported. The AttributeValue for a key attribute cannot contain an empty binary value. IndexName: gsib, IndexKey: bidx',
     )
   })
 })

--- a/tests/tier3/error-messages/batchWriteItem.test.ts
+++ b/tests/tier3/error-messages/batchWriteItem.test.ts
@@ -10,7 +10,10 @@ import {
   gsiBTableDef,
   compositeTableDef,
   cleanupItems,
+  declareTables,
 } from '../../../src/helpers.js'
+
+declareTables(hashTableDef, hashBTableDef, gsiBTableDef, compositeTableDef)
 
 const keysToCleanup = [
   { pk: { S: 'em-bw-dup' } },

--- a/tests/tier3/error-messages/conditionalCheck.test.ts
+++ b/tests/tier3/error-messages/conditionalCheck.test.ts
@@ -12,7 +12,10 @@ import { supportsControlPlaneOp } from '../../../src/infra.js'
 import {
   hashTableDef,
   cleanupItems,
+  declareTables,
 } from '../../../src/helpers.js'
+
+declareTables(hashTableDef)
 
 const keysToCleanup = [
   { pk: { S: 'em-ccf-put' } },

--- a/tests/tier3/error-messages/createTable.test.ts
+++ b/tests/tier3/error-messages/createTable.test.ts
@@ -161,7 +161,7 @@ describe('CreateTable — exact error messages', { tags: ['create-table', 'contr
     }
   })
 
-  it('LSI without range key on base table', async () => {
+  it('LSI without range key on base table', { tags: ['lsi'] }, async () => {
     try {
       await ddb.send(
         new CreateTableCommand({
@@ -194,7 +194,7 @@ describe('CreateTable — exact error messages', { tags: ['create-table', 'contr
     }
   })
 
-  it('duplicate index names', async () => {
+  it('duplicate index names', { tags: ['gsi'] }, async () => {
     try {
       await ddb.send(
         new CreateTableCommand({
@@ -257,7 +257,7 @@ describe('CreateTable — exact error messages', { tags: ['create-table', 'contr
     }
   })
 
-  it('GSI INCLUDE projection without NonKeyAttributes: full missing-attributes message', async () => {
+  it('GSI INCLUDE projection without NonKeyAttributes: full missing-attributes message', { tags: ['gsi'] }, async () => {
     try {
       await ddb.send(
         new CreateTableCommand({
@@ -289,7 +289,7 @@ describe('CreateTable — exact error messages', { tags: ['create-table', 'contr
 
   // LSI uses the same Projection model as GSI, so the missing-attributes rejection
   // is identical. Sibling of the GSI case above.
-  it('LSI INCLUDE projection without NonKeyAttributes: full missing-attributes message', async () => {
+  it('LSI INCLUDE projection without NonKeyAttributes: full missing-attributes message', { tags: ['lsi'] }, async () => {
     try {
       await ddb.send(
         new CreateTableCommand({

--- a/tests/tier3/error-messages/deleteItem.test.ts
+++ b/tests/tier3/error-messages/deleteItem.test.ts
@@ -4,7 +4,9 @@ import {
   ResourceNotFoundException,
 } from '@aws-sdk/client-dynamodb'
 import { ddb } from '../../../src/client.js'
-import { compositeTableDef, hashTableDef, hashBTableDef } from '../../../src/helpers.js'
+import { declareTables, compositeTableDef, hashTableDef, hashBTableDef } from '../../../src/helpers.js'
+
+declareTables(compositeTableDef, hashTableDef, hashBTableDef)
 
 // Conditional-check failures for DeleteItem live in conditionalCheck.test.ts —
 // that file owns the conditional-check error family across operations.

--- a/tests/tier3/error-messages/getItem.test.ts
+++ b/tests/tier3/error-messages/getItem.test.ts
@@ -8,7 +8,10 @@ import {
   hashTableDef,
   hashBTableDef,
   compositeTableDef,
+  declareTables,
 } from '../../../src/helpers.js'
+
+declareTables(hashTableDef, hashBTableDef, compositeTableDef)
 
 describe('GetItem — exact error messages', { tags: ['get-item', 'data-plane', 'negative-path'] }, () => {
   it('non-existent table: full ResourceNotFoundException message', async () => {

--- a/tests/tier3/error-messages/indexKeyValues.test.ts
+++ b/tests/tier3/error-messages/indexKeyValues.test.ts
@@ -38,7 +38,7 @@ afterAll(async () => {
   await cleanupItems(compositeIndexedTableDef.name, compositeKeysToCleanup)
 })
 
-describe('BatchWriteItem — index key error messages', { tags: ['batch', 'data-plane', 'negative-path', 'gsi'] }, () => {
+describe('BatchWriteItem — index key error messages', { tags: ['batch', 'data-plane', 'negative-path', 'gsi', 'lsi'] }, () => {
   // BatchWriteItem validates up front, so every variant is a top-level
   // ValidationException (no cancellation path).
   const expectExactValidation = async (
@@ -108,7 +108,7 @@ describe('BatchWriteItem — index key error messages', { tags: ['batch', 'data-
   })
 })
 
-describe('PutItem — index key error messages', { tags: ['put-item', 'data-plane', 'negative-path', 'gsi'] }, () => {
+describe('PutItem — index key error messages', { tags: ['put-item', 'data-plane', 'negative-path', 'gsi', 'lsi'] }, () => {
   it('empty-binary index key value: full secondary-index-key message', async () => {
     // Real AWS rejects a zero-length binary value on a secondary index key with
     // the put-form secondary-index message, naming the index and key.
@@ -130,7 +130,7 @@ describe('PutItem — index key error messages', { tags: ['put-item', 'data-plan
   })
 })
 
-describe('UpdateItem — index key error messages', { tags: ['update-item', 'data-plane', 'negative-path', 'gsi'] }, () => {
+describe('UpdateItem — index key error messages', { tags: ['update-item', 'data-plane', 'negative-path', 'gsi', 'lsi'] }, () => {
   it('empty-binary index key value: full secondary-index-key message', async () => {
     // Real AWS rejects a SET of a zero-length binary value on a secondary index
     // key with the update-form message (no IndexName/IndexKey suffix).

--- a/tests/tier3/error-messages/indexKeyValues.test.ts
+++ b/tests/tier3/error-messages/indexKeyValues.test.ts
@@ -1,0 +1,155 @@
+import {
+  BatchWriteItemCommand,
+  PutItemCommand,
+  UpdateItemCommand,
+  DynamoDBServiceException,
+} from '@aws-sdk/client-dynamodb'
+import { ddb } from '../../../src/client.js'
+import {
+  compositeIndexedTableDef,
+  gsiBTableDef,
+  cleanupItems,
+  declareTables,
+} from '../../../src/helpers.js'
+
+// The write cases that put an invalid value on a secondary index key, kept out
+// of batchWriteItem.test.ts, putItem.test.ts and updateItem.test.ts so those
+// files declare no indexed table. Every case here needs a real index for the
+// index-key validator to run at all, so they group by operation rather than by
+// file of origin.
+//
+// Strings captured from real AWS, invariant across four regions (eu-west-2,
+// us-east-1, ap-southeast-2, eu-central-1; 2026-06-23). The composite messages
+// name gsi1, the alphabetically-first index lsi1sk keys on
+// compositeIndexedTableDef; the binary ones name gsib on gsiBTableDef, whose
+// index key attribute is declared type B so an empty binary value reaches the
+// secondary-index-key validator rather than a type-mismatch check.
+declareTables(compositeIndexedTableDef, gsiBTableDef)
+
+// Defensive: these cases fail validation and write nothing; clean up anyway in
+// case a too-lenient target persists them.
+const compositeKeysToCleanup = [
+  { pk: { S: 'em-bw-idx-type' }, sk: { S: 'a' } },
+  { pk: { S: 'em-bw-idx-nonscalar' }, sk: { S: 'b' } },
+  { pk: { S: 'em-bw-idx-empty' }, sk: { S: 'c' } },
+]
+
+afterAll(async () => {
+  await cleanupItems(compositeIndexedTableDef.name, compositeKeysToCleanup)
+})
+
+describe('BatchWriteItem — index key error messages', { tags: ['batch', 'data-plane', 'negative-path', 'gsi'] }, () => {
+  // BatchWriteItem validates up front, so every variant is a top-level
+  // ValidationException (no cancellation path).
+  const expectExactValidation = async (
+    command: BatchWriteItemCommand,
+    message: string,
+  ) => {
+    try {
+      await ddb.send(command)
+      expect.unreachable('should have thrown')
+    } catch (err) {
+      expect(err).toBeInstanceOf(DynamoDBServiceException)
+      expect((err as DynamoDBServiceException).name).toBe('ValidationException')
+      expect((err as DynamoDBServiceException).message).toBe(message)
+    }
+  }
+
+  it('wrong-typed index key: full type-mismatch message', async () => {
+    await expectExactValidation(
+      new BatchWriteItemCommand({
+        RequestItems: {
+          [compositeIndexedTableDef.name]: [
+            { PutRequest: { Item: { pk: { S: 'em-bw-idx-type' }, sk: { S: 'a' }, lsi1sk: { N: '5' } } } },
+          ],
+        },
+      }),
+      'One or more parameter values were invalid: Type mismatch for Index Key lsi1sk Expected: S Actual: N IndexName: gsi1',
+    )
+  })
+
+  it('non-scalar index key: full type-mismatch message', async () => {
+    await expectExactValidation(
+      new BatchWriteItemCommand({
+        RequestItems: {
+          [compositeIndexedTableDef.name]: [
+            { PutRequest: { Item: { pk: { S: 'em-bw-idx-nonscalar' }, sk: { S: 'b' }, lsi1sk: { L: [{ S: 'x' }] } } } },
+          ],
+        },
+      }),
+      'One or more parameter values were invalid: Type mismatch for Index Key lsi1sk Expected: S Actual: L IndexName: gsi1',
+    )
+  })
+
+  it('empty-string index key: full secondary-index-key message', async () => {
+    await expectExactValidation(
+      new BatchWriteItemCommand({
+        RequestItems: {
+          [compositeIndexedTableDef.name]: [
+            { PutRequest: { Item: { pk: { S: 'em-bw-idx-empty' }, sk: { S: 'c' }, lsi1sk: { S: '' } } } },
+          ],
+        },
+      }),
+      'One or more parameter values are not valid. A value specified for a secondary index key is not supported. The AttributeValue for a key attribute cannot contain an empty string value. IndexName: gsi1, IndexKey: lsi1sk',
+    )
+  })
+
+  it('empty-binary index key: full secondary-index-key message', async () => {
+    await expectExactValidation(
+      new BatchWriteItemCommand({
+        RequestItems: {
+          [gsiBTableDef.name]: [
+            { PutRequest: { Item: { pk: { S: 'eb-bw-idx' }, bidx: { B: new Uint8Array([]) } } } },
+          ],
+        },
+      }),
+      'One or more parameter values are not valid. A value specified for a secondary index key is not supported. The AttributeValue for a key attribute cannot contain an empty binary value. IndexName: gsib, IndexKey: bidx',
+    )
+  })
+})
+
+describe('PutItem — index key error messages', { tags: ['put-item', 'data-plane', 'negative-path', 'gsi'] }, () => {
+  it('empty-binary index key value: full secondary-index-key message', async () => {
+    // Real AWS rejects a zero-length binary value on a secondary index key with
+    // the put-form secondary-index message, naming the index and key.
+    try {
+      await ddb.send(
+        new PutItemCommand({
+          TableName: gsiBTableDef.name,
+          Item: { pk: { S: 'eb-idx' }, bidx: { B: new Uint8Array([]) } },
+        }),
+      )
+      expect.unreachable('should have thrown')
+    } catch (err) {
+      expect(err).toBeInstanceOf(DynamoDBServiceException)
+      expect((err as DynamoDBServiceException).name).toBe('ValidationException')
+      expect((err as DynamoDBServiceException).message).toBe(
+        'One or more parameter values are not valid. A value specified for a secondary index key is not supported. The AttributeValue for a key attribute cannot contain an empty binary value. IndexName: gsib, IndexKey: bidx',
+      )
+    }
+  })
+})
+
+describe('UpdateItem — index key error messages', { tags: ['update-item', 'data-plane', 'negative-path', 'gsi'] }, () => {
+  it('empty-binary index key value: full secondary-index-key message', async () => {
+    // Real AWS rejects a SET of a zero-length binary value on a secondary index
+    // key with the update-form message (no IndexName/IndexKey suffix).
+    try {
+      await ddb.send(
+        new UpdateItemCommand({
+          TableName: gsiBTableDef.name,
+          Key: { pk: { S: 'eb-idx-upd' } },
+          UpdateExpression: 'SET bidx = :v',
+          ExpressionAttributeValues: { ':v': { B: new Uint8Array([]) } },
+        }),
+      )
+      expect.unreachable('should have thrown')
+    } catch (err) {
+      expect(err).toBeInstanceOf(DynamoDBServiceException)
+      expect((err as DynamoDBServiceException).name).toBe('ValidationException')
+      expect((err as DynamoDBServiceException).message).toBe(
+        'One or more parameter values are not valid. The update expression attempted to update a secondary index key to a value that is not supported. The AttributeValue for a key attribute cannot contain an empty binary value.',
+      )
+    }
+  })
+})

--- a/tests/tier3/error-messages/indexReads.test.ts
+++ b/tests/tier3/error-messages/indexReads.test.ts
@@ -12,7 +12,7 @@ import { compositeIndexedTableDef, declareTables } from '../../../src/helpers.js
 // index-not-found error.
 declareTables(compositeIndexedTableDef)
 
-describe('Query — index error messages', { tags: ['query', 'data-plane', 'negative-path', 'gsi'] }, () => {
+describe('Query — index error messages', { tags: ['query', 'data-plane', 'negative-path', 'gsi', 'lsi'] }, () => {
   it('ConsistentRead on GSI', async () => {
     try {
       await ddb.send(
@@ -36,7 +36,7 @@ describe('Query — index error messages', { tags: ['query', 'data-plane', 'nega
   })
 })
 
-describe('Scan — index error messages', { tags: ['scan', 'data-plane', 'negative-path', 'gsi'] }, () => {
+describe('Scan — index error messages', { tags: ['scan', 'data-plane', 'negative-path', 'gsi', 'lsi'] }, () => {
   // Parity with Query: a Scan on a GSI cannot ask for a strongly consistent read.
   it('ConsistentRead on a GSI: full consistent-reads-unsupported message', async () => {
     try {

--- a/tests/tier3/error-messages/indexReads.test.ts
+++ b/tests/tier3/error-messages/indexReads.test.ts
@@ -1,0 +1,59 @@
+import {
+  QueryCommand,
+  ScanCommand,
+  DynamoDBServiceException,
+} from '@aws-sdk/client-dynamodb'
+import { ddb } from '../../../src/client.js'
+import { compositeIndexedTableDef, declareTables } from '../../../src/helpers.js'
+
+// The index-bearing error-message cases, kept out of query.test.ts and
+// scan.test.ts so those files declare no indexed table. Each request names a
+// real index, so the rejection is the message under test rather than an
+// index-not-found error.
+declareTables(compositeIndexedTableDef)
+
+describe('Query — index error messages', { tags: ['query', 'data-plane', 'negative-path', 'gsi'] }, () => {
+  it('ConsistentRead on GSI', async () => {
+    try {
+      await ddb.send(
+        new QueryCommand({
+          TableName: compositeIndexedTableDef.name,
+          IndexName: 'gsi1',
+          KeyConditionExpression: '#hk = :v',
+          ExpressionAttributeNames: { '#hk': 'lsi1sk' },
+          ExpressionAttributeValues: { ':v': { S: 'val' } },
+          ConsistentRead: true,
+        }),
+      )
+      expect.unreachable('should have thrown')
+    } catch (err) {
+      expect(err).toBeInstanceOf(DynamoDBServiceException)
+      expect((err as DynamoDBServiceException).name).toBe('ValidationException')
+      expect((err as DynamoDBServiceException).message).toBe(
+        'Consistent reads are not supported on global secondary indexes',
+      )
+    }
+  })
+})
+
+describe('Scan — index error messages', { tags: ['scan', 'data-plane', 'negative-path', 'gsi'] }, () => {
+  // Parity with Query: a Scan on a GSI cannot ask for a strongly consistent read.
+  it('ConsistentRead on a GSI: full consistent-reads-unsupported message', async () => {
+    try {
+      await ddb.send(
+        new ScanCommand({
+          TableName: compositeIndexedTableDef.name,
+          IndexName: 'gsi1',
+          ConsistentRead: true,
+        }),
+      )
+      expect.unreachable('should have thrown')
+    } catch (err) {
+      expect(err).toBeInstanceOf(DynamoDBServiceException)
+      expect((err as DynamoDBServiceException).name).toBe('ValidationException')
+      expect((err as DynamoDBServiceException).message).toBe(
+        'Consistent reads are not supported on global secondary indexes',
+      )
+    }
+  })
+})

--- a/tests/tier3/error-messages/partiql.test.ts
+++ b/tests/tier3/error-messages/partiql.test.ts
@@ -5,7 +5,9 @@ import {
 } from '@aws-sdk/client-dynamodb'
 import { ddb } from '../../../src/client.js'
 import { isUnsupportedFault } from '../../../src/infra.js'
-import { hashTableDef } from '../../../src/helpers.js'
+import { declareTables, hashTableDef } from '../../../src/helpers.js'
+
+declareTables(hashTableDef)
 
 // Exact AWS strings for the PartiQL RETURNING rejections, pinned against real
 // AWS (eu-west-2). Tier 2 (tests/tier2/partiql/) asserts the error shape; this

--- a/tests/tier3/error-messages/putItem.test.ts
+++ b/tests/tier3/error-messages/putItem.test.ts
@@ -8,7 +8,10 @@ import {
   hashBTableDef,
   gsiBTableDef,
   cleanupItems,
+  declareTables,
 } from '../../../src/helpers.js'
+
+declareTables(hashTableDef, hashBTableDef, gsiBTableDef)
 
 const keysToCleanup = [
   { pk: { S: 'em-put-null-false' } },

--- a/tests/tier3/error-messages/putItem.test.ts
+++ b/tests/tier3/error-messages/putItem.test.ts
@@ -6,12 +6,11 @@ import { ddb } from '../../../src/client.js'
 import {
   hashTableDef,
   hashBTableDef,
-  gsiBTableDef,
   cleanupItems,
   declareTables,
 } from '../../../src/helpers.js'
 
-declareTables(hashTableDef, hashBTableDef, gsiBTableDef)
+declareTables(hashTableDef, hashBTableDef)
 
 const keysToCleanup = [
   { pk: { S: 'em-put-null-false' } },
@@ -371,26 +370,6 @@ describe('PutItem — exact error messages', { tags: ['put-item', 'data-plane'] 
       expect((err as DynamoDBServiceException).name).toBe('ValidationException')
       expect((err as DynamoDBServiceException).message).toBe(
         'One or more parameter values are not valid. The AttributeValue for a key attribute cannot contain an empty binary value. Key: pk',
-      )
-    }
-  })
-
-  it('empty-binary index key value: full secondary-index-key message', async () => {
-    // Real AWS rejects a zero-length binary value on a secondary index key with
-    // the put-form secondary-index message, naming the index and key.
-    try {
-      await ddb.send(
-        new PutItemCommand({
-          TableName: gsiBTableDef.name,
-          Item: { pk: { S: 'eb-idx' }, bidx: { B: new Uint8Array([]) } },
-        }),
-      )
-      expect.unreachable('should have thrown')
-    } catch (err) {
-      expect(err).toBeInstanceOf(DynamoDBServiceException)
-      expect((err as DynamoDBServiceException).name).toBe('ValidationException')
-      expect((err as DynamoDBServiceException).message).toBe(
-        'One or more parameter values are not valid. A value specified for a secondary index key is not supported. The AttributeValue for a key attribute cannot contain an empty binary value. IndexName: gsib, IndexKey: bidx',
       )
     }
   })

--- a/tests/tier3/error-messages/query.test.ts
+++ b/tests/tier3/error-messages/query.test.ts
@@ -8,7 +8,10 @@ import {
   compositeTableDef,
   hashTableDef,
   cleanupItems,
+  declareTables,
 } from '../../../src/helpers.js'
+
+declareTables(compositeTableDef, hashTableDef)
 
 describe('Query — exact error messages', { tags: ['query', 'data-plane', 'negative-path'] }, () => {
   it('missing hash key in KeyConditionExpression', async () => {

--- a/tests/tier3/error-messages/query.test.ts
+++ b/tests/tier3/error-messages/query.test.ts
@@ -93,28 +93,6 @@ describe('Query — exact error messages', { tags: ['query', 'data-plane', 'nega
     }
   })
 
-  it('ConsistentRead on GSI', async () => {
-    try {
-      await ddb.send(
-        new QueryCommand({
-          TableName: compositeTableDef.name,
-          IndexName: 'gsi1',
-          KeyConditionExpression: '#hk = :v',
-          ExpressionAttributeNames: { '#hk': 'lsi1sk' },
-          ExpressionAttributeValues: { ':v': { S: 'val' } },
-          ConsistentRead: true,
-        }),
-      )
-      expect.unreachable('should have thrown')
-    } catch (err) {
-      expect(err).toBeInstanceOf(DynamoDBServiceException)
-      expect((err as DynamoDBServiceException).name).toBe('ValidationException')
-      expect((err as DynamoDBServiceException).message).toBe(
-        'Consistent reads are not supported on global secondary indexes',
-      )
-    }
-  })
-
   it('Limit of 0', async () => {
     try {
       await ddb.send(

--- a/tests/tier3/error-messages/scan.test.ts
+++ b/tests/tier3/error-messages/scan.test.ts
@@ -9,7 +9,10 @@ import {
   hashTableDef,
   compositeTableDef,
   cleanupItems,
+  declareTables,
 } from '../../../src/helpers.js'
+
+declareTables(hashTableDef, compositeTableDef)
 
 describe('Scan — exact error messages', { tags: ['scan', 'data-plane', 'negative-path'] }, () => {
   it('Segment without TotalSegments: full required-parameter error', async () => {

--- a/tests/tier3/error-messages/scan.test.ts
+++ b/tests/tier3/error-messages/scan.test.ts
@@ -7,12 +7,11 @@ import {
 import { ddb } from '../../../src/client.js'
 import {
   hashTableDef,
-  compositeTableDef,
   cleanupItems,
   declareTables,
 } from '../../../src/helpers.js'
 
-declareTables(hashTableDef, compositeTableDef)
+declareTables(hashTableDef)
 
 describe('Scan — exact error messages', { tags: ['scan', 'data-plane', 'negative-path'] }, () => {
   it('Segment without TotalSegments: full required-parameter error', async () => {
@@ -163,26 +162,6 @@ describe('Scan — exact error messages', { tags: ['scan', 'data-plane', 'negati
       expect((err as DynamoDBServiceException).name).toBe('ValidationException')
       expect((err as DynamoDBServiceException).message).toBe(
         'The provided starting key is invalid: The provided key element does not match the schema',
-      )
-    }
-  })
-
-  // Parity with Query: a Scan on a GSI cannot ask for a strongly consistent read.
-  it('ConsistentRead on a GSI: full consistent-reads-unsupported message', async () => {
-    try {
-      await ddb.send(
-        new ScanCommand({
-          TableName: compositeTableDef.name,
-          IndexName: 'gsi1',
-          ConsistentRead: true,
-        }),
-      )
-      expect.unreachable('should have thrown')
-    } catch (err) {
-      expect(err).toBeInstanceOf(DynamoDBServiceException)
-      expect((err as DynamoDBServiceException).name).toBe('ValidationException')
-      expect((err as DynamoDBServiceException).message).toBe(
-        'Consistent reads are not supported on global secondary indexes',
       )
     }
   })

--- a/tests/tier3/error-messages/transactGetItems.test.ts
+++ b/tests/tier3/error-messages/transactGetItems.test.ts
@@ -5,7 +5,9 @@ import {
   TransactionCanceledException,
 } from '@aws-sdk/client-dynamodb'
 import { ddb } from '../../../src/client.js'
-import { hashTableDef } from '../../../src/helpers.js'
+import { declareTables, hashTableDef } from '../../../src/helpers.js'
+
+declareTables(hashTableDef)
 
 describe('TransactGetItems — exact error messages', { tags: ['transactions', 'data-plane', 'negative-path'] }, () => {
   it('empty TransactItems: full minimum-length error', async () => {

--- a/tests/tier3/error-messages/transactIndexKeys.test.ts
+++ b/tests/tier3/error-messages/transactIndexKeys.test.ts
@@ -32,7 +32,7 @@ afterAll(async () => {
   await cleanupItems(compositeIndexedTableDef.name, compositeKeysToCleanup)
 })
 
-describe('TransactWriteItems — index key error messages', { tags: ['transactions', 'data-plane', 'negative-path', 'gsi'] }, () => {
+describe('TransactWriteItems — index key error messages', { tags: ['transactions', 'data-plane', 'negative-path', 'gsi', 'lsi'] }, () => {
   // An empty TransactItems is rejected by any target that implements the
   // operation, so this separates "not implemented" from "implemented".
   skipUnlessSupported(() => ddb.send(new TransactWriteItemsCommand({ TransactItems: [] })))

--- a/tests/tier3/error-messages/transactIndexKeys.test.ts
+++ b/tests/tier3/error-messages/transactIndexKeys.test.ts
@@ -1,0 +1,215 @@
+import {
+  TransactWriteItemsCommand,
+  DynamoDBServiceException,
+  TransactionCanceledException,
+} from '@aws-sdk/client-dynamodb'
+import { ddb } from '../../../src/client.js'
+import { skipUnlessSupported } from '../../../src/infra.js'
+import {
+  compositeIndexedTableDef,
+  gsiBTableDef,
+  cleanupItems,
+  declareTables,
+} from '../../../src/helpers.js'
+
+// The index-bearing transact cases, kept out of transactWriteItems.test.ts so
+// that file declares no indexed table. Each request writes a real index key, so
+// the rejection is the message under test rather than an unknown-attribute pass.
+declareTables(compositeIndexedTableDef, gsiBTableDef)
+
+// Defensive: the invalid-key-value cases below fail validation and write
+// nothing; clean up anyway in case a too-lenient target persists them.
+const compositeKeysToCleanup = [
+  { pk: { S: 'em-twi-idx-type' }, sk: { S: 'a' } },
+  { pk: { S: 'em-twi-idx-nonscalar' }, sk: { S: 'b' } },
+  { pk: { S: 'em-twi-idx-empty' }, sk: { S: 'c' } },
+  { pk: { S: 'em-twi-idx-upd-type' }, sk: { S: 'a' } },
+  { pk: { S: 'em-twi-idx-upd-nonscalar' }, sk: { S: 'b' } },
+  { pk: { S: 'em-twi-idx-upd-empty' }, sk: { S: 'c' } },
+]
+
+afterAll(async () => {
+  await cleanupItems(compositeIndexedTableDef.name, compositeKeysToCleanup)
+})
+
+describe('TransactWriteItems — index key error messages', { tags: ['transactions', 'data-plane', 'negative-path', 'gsi'] }, () => {
+  // An empty TransactItems is rejected by any target that implements the
+  // operation, so this separates "not implemented" from "implemented".
+  skipUnlessSupported(() => ddb.send(new TransactWriteItemsCommand({ TransactItems: [] })))
+
+  // Invalid index key value inside a transact Put/Update. The error shape splits
+  // by fault, captured from real AWS eu-west-2:
+  //   - wrong type / non-scalar: TransactionCanceledException, reason code
+  //     'ValidationError', reason Message carrying the PutItem-style string;
+  //   - empty string: top-level ValidationException (up-front input validation).
+  // Index-key messages name gsi1, the alphabetically-first index lsi1sk keys.
+  const expectCancelledReason = async (
+    command: TransactWriteItemsCommand,
+    reasonMessage: string,
+  ) => {
+    try {
+      await ddb.send(command)
+      expect.unreachable('should have thrown')
+    } catch (err) {
+      expect(err).toBeInstanceOf(TransactionCanceledException)
+      const txErr = err as TransactionCanceledException
+      const expectedReasons = ['ValidationError'] as const
+      expect(txErr.message).toBe(
+        `Transaction cancelled, please refer cancellation reasons for specific reasons [${expectedReasons.join(', ')}]`,
+      )
+      expect(txErr.CancellationReasons?.map((r) => r.Code)).toEqual([
+        ...expectedReasons,
+      ])
+      expect(txErr.CancellationReasons?.[0]?.Message).toBe(reasonMessage)
+    }
+  }
+
+  const expectTopLevelValidation = async (
+    command: TransactWriteItemsCommand,
+    message: string,
+  ) => {
+    try {
+      await ddb.send(command)
+      expect.unreachable('should have thrown')
+    } catch (err) {
+      expect(err).toBeInstanceOf(DynamoDBServiceException)
+      expect((err as DynamoDBServiceException).name).toBe('ValidationException')
+      expect((err as DynamoDBServiceException).message).toBe(message)
+    }
+  }
+
+  it('Put wrong-typed index key: cancelled with full ValidationError reason', async () => {
+    await expectCancelledReason(
+      new TransactWriteItemsCommand({
+        TransactItems: [
+          {
+            Put: {
+              TableName: compositeIndexedTableDef.name,
+              Item: { pk: { S: 'em-twi-idx-type' }, sk: { S: 'a' }, lsi1sk: { N: '5' } },
+            },
+          },
+        ],
+      }),
+      'One or more parameter values were invalid: Type mismatch for Index Key lsi1sk Expected: S Actual: N IndexName: gsi1',
+    )
+  })
+
+  it('Put non-scalar index key: cancelled with full ValidationError reason', async () => {
+    await expectCancelledReason(
+      new TransactWriteItemsCommand({
+        TransactItems: [
+          {
+            Put: {
+              TableName: compositeIndexedTableDef.name,
+              Item: { pk: { S: 'em-twi-idx-nonscalar' }, sk: { S: 'b' }, lsi1sk: { L: [{ S: 'x' }] } },
+            },
+          },
+        ],
+      }),
+      'One or more parameter values were invalid: Type mismatch for Index Key lsi1sk Expected: S Actual: L IndexName: gsi1',
+    )
+  })
+
+  it('Update wrong-typed index key: cancelled with full ValidationError reason', async () => {
+    await expectCancelledReason(
+      new TransactWriteItemsCommand({
+        TransactItems: [
+          {
+            Update: {
+              TableName: compositeIndexedTableDef.name,
+              Key: { pk: { S: 'em-twi-idx-upd-type' }, sk: { S: 'a' } },
+              UpdateExpression: 'SET lsi1sk = :v',
+              ExpressionAttributeValues: { ':v': { N: '5' } },
+            },
+          },
+        ],
+      }),
+      'One or more parameter values were invalid: Type mismatch for Index Key lsi1sk Expected: S Actual: N IndexName: gsi1',
+    )
+  })
+
+  it('Update non-scalar index key: cancelled with full ValidationError reason', async () => {
+    await expectCancelledReason(
+      new TransactWriteItemsCommand({
+        TransactItems: [
+          {
+            Update: {
+              TableName: compositeIndexedTableDef.name,
+              Key: { pk: { S: 'em-twi-idx-upd-nonscalar' }, sk: { S: 'b' } },
+              UpdateExpression: 'SET lsi1sk = :v',
+              ExpressionAttributeValues: { ':v': { L: [{ S: 'x' }] } },
+            },
+          },
+        ],
+      }),
+      'One or more parameter values were invalid: Type mismatch for Index Key lsi1sk Expected: S Actual: L IndexName: gsi1',
+    )
+  })
+
+  it('Put empty-string index key: top-level ValidationException', async () => {
+    await expectTopLevelValidation(
+      new TransactWriteItemsCommand({
+        TransactItems: [
+          {
+            Put: {
+              TableName: compositeIndexedTableDef.name,
+              Item: { pk: { S: 'em-twi-idx-empty' }, sk: { S: 'c' }, lsi1sk: { S: '' } },
+            },
+          },
+        ],
+      }),
+      'One or more parameter values are not valid. A value specified for a secondary index key is not supported. The AttributeValue for a key attribute cannot contain an empty string value. IndexName: gsi1, IndexKey: lsi1sk',
+    )
+  })
+
+  it('Update empty-string index key: top-level ValidationException', async () => {
+    await expectTopLevelValidation(
+      new TransactWriteItemsCommand({
+        TransactItems: [
+          {
+            Update: {
+              TableName: compositeIndexedTableDef.name,
+              Key: { pk: { S: 'em-twi-idx-upd-empty' }, sk: { S: 'c' } },
+              UpdateExpression: 'SET lsi1sk = :v',
+              ExpressionAttributeValues: { ':v': { S: '' } },
+            },
+          },
+        ],
+      }),
+      'One or more parameter values are not valid. The update expression attempted to update a secondary index key to a value that is not supported. The AttributeValue for a key attribute cannot contain an empty string value.',
+    )
+  })
+
+  // Empty-binary index key values mirror the empty-string cases: a top-level
+  // ValidationException that hoists out of the transaction, never a cancellation
+  // reason. Real AWS names the same message with 'binary' for 'string'. They need
+  // a table whose index key attribute is declared type B, hence gsiBTableDef.
+  it('Put empty-binary index key: top-level ValidationException', async () => {
+    await expectTopLevelValidation(
+      new TransactWriteItemsCommand({
+        TransactItems: [
+          { Put: { TableName: gsiBTableDef.name, Item: { pk: { S: 'eb-twi-idx' }, bidx: { B: new Uint8Array([]) } } } },
+        ],
+      }),
+      'One or more parameter values are not valid. A value specified for a secondary index key is not supported. The AttributeValue for a key attribute cannot contain an empty binary value. IndexName: gsib, IndexKey: bidx',
+    )
+  })
+
+  it('Update empty-binary index key: top-level ValidationException', async () => {
+    await expectTopLevelValidation(
+      new TransactWriteItemsCommand({
+        TransactItems: [
+          {
+            Update: {
+              TableName: gsiBTableDef.name,
+              Key: { pk: { S: 'eb-twi-idx-upd' } },
+              UpdateExpression: 'SET bidx = :v',
+              ExpressionAttributeValues: { ':v': { B: new Uint8Array([]) } },
+            },
+          },
+        ],
+      }),
+      'One or more parameter values are not valid. The update expression attempted to update a secondary index key to a value that is not supported. The AttributeValue for a key attribute cannot contain an empty binary value.',
+    )
+  })
+})

--- a/tests/tier3/error-messages/transactWriteItems.test.ts
+++ b/tests/tier3/error-messages/transactWriteItems.test.ts
@@ -4,6 +4,7 @@ import {
   DynamoDBServiceException,
   ResourceNotFoundException,
   TransactionCanceledException,
+  type TransactWriteItem,
 } from '@aws-sdk/client-dynamodb'
 import { ddb } from '../../../src/client.js'
 import { skipUnlessSupported } from '../../../src/infra.js'
@@ -311,7 +312,7 @@ describe('TransactWriteItems — exact error messages', { tags: ['transactions',
   // the Put 'Type mismatch for key' form.
   const emptyKeyMsg = 'One or more parameter values are not valid. The AttributeValue for a key attribute cannot contain an empty string value. Key: pk'
   const schemaMismatchMsg = 'The provided key element does not match the schema'
-  const cmd = (item: unknown) => new TransactWriteItemsCommand({ TransactItems: [item] as never })
+  const cmd = (item: unknown) => new TransactWriteItemsCommand({ TransactItems: [item] as TransactWriteItem[] })
   const updKey = (key: unknown) => ({ Update: { TableName: hashTableDef.name, Key: { pk: key }, UpdateExpression: 'SET attr1 = :v', ExpressionAttributeValues: { ':v': { S: 'x' } } } })
   const delKey = (key: unknown) => ({ Delete: { TableName: hashTableDef.name, Key: { pk: key } } })
   const ccKey = (key: unknown) => ({ ConditionCheck: { TableName: hashTableDef.name, Key: { pk: key }, ConditionExpression: 'attribute_not_exists(pk)' } })

--- a/tests/tier3/error-messages/transactWriteItems.test.ts
+++ b/tests/tier3/error-messages/transactWriteItems.test.ts
@@ -10,13 +10,11 @@ import { skipUnlessSupported } from '../../../src/infra.js'
 import {
   hashTableDef,
   hashBTableDef,
-  gsiBTableDef,
-  compositeTableDef,
   cleanupItems,
   declareTables,
 } from '../../../src/helpers.js'
 
-declareTables(hashTableDef, hashBTableDef, gsiBTableDef, compositeTableDef)
+declareTables(hashTableDef, hashBTableDef)
 
 const keysToCleanup = [
   { pk: { S: 'em-twi-dup' } },
@@ -26,20 +24,8 @@ const keysToCleanup = [
   { pk: { S: 'em-twi-pos-new' } },
 ]
 
-// Defensive: the invalid-key-value cases below fail validation and write
-// nothing; clean up anyway in case a too-lenient target persists them.
-const compositeKeysToCleanup = [
-  { pk: { S: 'em-twi-idx-type' }, sk: { S: 'a' } },
-  { pk: { S: 'em-twi-idx-nonscalar' }, sk: { S: 'b' } },
-  { pk: { S: 'em-twi-idx-empty' }, sk: { S: 'c' } },
-  { pk: { S: 'em-twi-idx-upd-type' }, sk: { S: 'a' } },
-  { pk: { S: 'em-twi-idx-upd-nonscalar' }, sk: { S: 'b' } },
-  { pk: { S: 'em-twi-idx-upd-empty' }, sk: { S: 'c' } },
-]
-
 afterAll(async () => {
   await cleanupItems(hashTableDef.name, keysToCleanup)
-  await cleanupItems(compositeTableDef.name, compositeKeysToCleanup)
 })
 
 describe('TransactWriteItems — exact error messages', { tags: ['transactions', 'data-plane', 'negative-path'] }, () => {
@@ -250,12 +236,12 @@ describe('TransactWriteItems — exact error messages', { tags: ['transactions',
     }
   })
 
-  // Invalid key value (table or index) inside a transact Put/Update. The error
-  // shape splits by fault, captured from real AWS eu-west-2:
+  // Invalid table key value inside a transact Put/Update. The error shape
+  // splits by fault, captured from real AWS eu-west-2:
   //   - wrong type / non-scalar: TransactionCanceledException, reason code
   //     'ValidationError', reason Message carrying the PutItem-style string;
   //   - empty string: top-level ValidationException (up-front input validation).
-  // Index-key messages name gsi1, the alphabetically-first index lsi1sk keys.
+  // The secondary-index equivalents live in transactIndexKeys.test.ts.
   const expectCancelledReason = async (
     command: TransactWriteItemsCommand,
     reasonMessage: string,
@@ -309,114 +295,12 @@ describe('TransactWriteItems — exact error messages', { tags: ['transactions',
     )
   })
 
-  it('Put wrong-typed index key: cancelled with full ValidationError reason', async () => {
-    await expectCancelledReason(
-      new TransactWriteItemsCommand({
-        TransactItems: [
-          {
-            Put: {
-              TableName: compositeTableDef.name,
-              Item: { pk: { S: 'em-twi-idx-type' }, sk: { S: 'a' }, lsi1sk: { N: '5' } },
-            },
-          },
-        ],
-      }),
-      'One or more parameter values were invalid: Type mismatch for Index Key lsi1sk Expected: S Actual: N IndexName: gsi1',
-    )
-  })
-
-  it('Put non-scalar index key: cancelled with full ValidationError reason', async () => {
-    await expectCancelledReason(
-      new TransactWriteItemsCommand({
-        TransactItems: [
-          {
-            Put: {
-              TableName: compositeTableDef.name,
-              Item: { pk: { S: 'em-twi-idx-nonscalar' }, sk: { S: 'b' }, lsi1sk: { L: [{ S: 'x' }] } },
-            },
-          },
-        ],
-      }),
-      'One or more parameter values were invalid: Type mismatch for Index Key lsi1sk Expected: S Actual: L IndexName: gsi1',
-    )
-  })
-
-  it('Update wrong-typed index key: cancelled with full ValidationError reason', async () => {
-    await expectCancelledReason(
-      new TransactWriteItemsCommand({
-        TransactItems: [
-          {
-            Update: {
-              TableName: compositeTableDef.name,
-              Key: { pk: { S: 'em-twi-idx-upd-type' }, sk: { S: 'a' } },
-              UpdateExpression: 'SET lsi1sk = :v',
-              ExpressionAttributeValues: { ':v': { N: '5' } },
-            },
-          },
-        ],
-      }),
-      'One or more parameter values were invalid: Type mismatch for Index Key lsi1sk Expected: S Actual: N IndexName: gsi1',
-    )
-  })
-
-  it('Update non-scalar index key: cancelled with full ValidationError reason', async () => {
-    await expectCancelledReason(
-      new TransactWriteItemsCommand({
-        TransactItems: [
-          {
-            Update: {
-              TableName: compositeTableDef.name,
-              Key: { pk: { S: 'em-twi-idx-upd-nonscalar' }, sk: { S: 'b' } },
-              UpdateExpression: 'SET lsi1sk = :v',
-              ExpressionAttributeValues: { ':v': { L: [{ S: 'x' }] } },
-            },
-          },
-        ],
-      }),
-      'One or more parameter values were invalid: Type mismatch for Index Key lsi1sk Expected: S Actual: L IndexName: gsi1',
-    )
-  })
-
   it('Put empty-string table key: top-level ValidationException', async () => {
     await expectTopLevelValidation(
       new TransactWriteItemsCommand({
         TransactItems: [{ Put: { TableName: hashTableDef.name, Item: { pk: { S: '' } } } }],
       }),
       'One or more parameter values are not valid. The AttributeValue for a key attribute cannot contain an empty string value. Key: pk',
-    )
-  })
-
-  it('Put empty-string index key: top-level ValidationException', async () => {
-    await expectTopLevelValidation(
-      new TransactWriteItemsCommand({
-        TransactItems: [
-          {
-            Put: {
-              TableName: compositeTableDef.name,
-              Item: { pk: { S: 'em-twi-idx-empty' }, sk: { S: 'c' }, lsi1sk: { S: '' } },
-            },
-          },
-        ],
-      }),
-      'One or more parameter values are not valid. A value specified for a secondary index key is not supported. The AttributeValue for a key attribute cannot contain an empty string value. IndexName: gsi1, IndexKey: lsi1sk',
-    )
-  })
-
-  it('Update empty-string index key: top-level ValidationException', async () => {
-    await expectTopLevelValidation(
-      new TransactWriteItemsCommand({
-        TransactItems: [
-          {
-            Update: {
-              TableName: compositeTableDef.name,
-              Key: { pk: { S: 'em-twi-idx-upd-empty' }, sk: { S: 'c' } },
-              UpdateExpression: 'SET lsi1sk = :v',
-              ExpressionAttributeValues: { ':v': { S: '' } },
-            },
-          },
-        ],
-      }),
-      'One or more parameter values are not valid. The update expression attempted to update a secondary index key to a value that is not supported. The AttributeValue for a key attribute cannot contain an empty string value.',
     )
   })
 
@@ -469,33 +353,4 @@ describe('TransactWriteItems — exact error messages', { tags: ['transactions',
     expectTopLevelValidation(cmd(delKeyB(emptyBin)), emptyBinKeyMsg))
   it('ConditionCheck empty-binary Key: top-level empty-value message', () =>
     expectTopLevelValidation(cmd(ccKeyB(emptyBin)), emptyBinKeyMsg))
-
-  it('Put empty-binary index key: top-level ValidationException', async () => {
-    await expectTopLevelValidation(
-      new TransactWriteItemsCommand({
-        TransactItems: [
-          { Put: { TableName: gsiBTableDef.name, Item: { pk: { S: 'eb-twi-idx' }, bidx: { B: new Uint8Array([]) } } } },
-        ],
-      }),
-      'One or more parameter values are not valid. A value specified for a secondary index key is not supported. The AttributeValue for a key attribute cannot contain an empty binary value. IndexName: gsib, IndexKey: bidx',
-    )
-  })
-
-  it('Update empty-binary index key: top-level ValidationException', async () => {
-    await expectTopLevelValidation(
-      new TransactWriteItemsCommand({
-        TransactItems: [
-          {
-            Update: {
-              TableName: gsiBTableDef.name,
-              Key: { pk: { S: 'eb-twi-idx-upd' } },
-              UpdateExpression: 'SET bidx = :v',
-              ExpressionAttributeValues: { ':v': { B: new Uint8Array([]) } },
-            },
-          },
-        ],
-      }),
-      'One or more parameter values are not valid. The update expression attempted to update a secondary index key to a value that is not supported. The AttributeValue for a key attribute cannot contain an empty binary value.',
-    )
-  })
 })

--- a/tests/tier3/error-messages/transactWriteItems.test.ts
+++ b/tests/tier3/error-messages/transactWriteItems.test.ts
@@ -13,7 +13,10 @@ import {
   gsiBTableDef,
   compositeTableDef,
   cleanupItems,
+  declareTables,
 } from '../../../src/helpers.js'
+
+declareTables(hashTableDef, hashBTableDef, gsiBTableDef, compositeTableDef)
 
 const keysToCleanup = [
   { pk: { S: 'em-twi-dup' } },

--- a/tests/tier3/error-messages/updateItem.test.ts
+++ b/tests/tier3/error-messages/updateItem.test.ts
@@ -9,7 +9,10 @@ import {
   gsiBTableDef,
   compositeTableDef,
   cleanupItems,
+  declareTables,
 } from '../../../src/helpers.js'
+
+declareTables(hashTableDef, hashBTableDef, gsiBTableDef, compositeTableDef)
 
 const hashKeys = [
   { pk: { S: 'em-upd-key-mod' } },

--- a/tests/tier3/error-messages/updateItem.test.ts
+++ b/tests/tier3/error-messages/updateItem.test.ts
@@ -6,13 +6,12 @@ import { ddb } from '../../../src/client.js'
 import {
   hashTableDef,
   hashBTableDef,
-  gsiBTableDef,
   compositeTableDef,
   cleanupItems,
   declareTables,
 } from '../../../src/helpers.js'
 
-declareTables(hashTableDef, hashBTableDef, gsiBTableDef, compositeTableDef)
+declareTables(hashTableDef, hashBTableDef, compositeTableDef)
 
 const hashKeys = [
   { pk: { S: 'em-upd-key-mod' } },
@@ -212,28 +211,6 @@ describe('UpdateItem — exact error messages', { tags: ['update-item', 'data-pl
       expect((err as DynamoDBServiceException).name).toBe('ValidationException')
       expect((err as DynamoDBServiceException).message).toBe(
         'One or more parameter values are not valid. The AttributeValue for a key attribute cannot contain an empty binary value. Key: pk',
-      )
-    }
-  })
-
-  it('empty-binary index key value: full secondary-index-key message', async () => {
-    // Real AWS rejects a SET of a zero-length binary value on a secondary index
-    // key with the update-form message (no IndexName/IndexKey suffix).
-    try {
-      await ddb.send(
-        new UpdateItemCommand({
-          TableName: gsiBTableDef.name,
-          Key: { pk: { S: 'eb-idx-upd' } },
-          UpdateExpression: 'SET bidx = :v',
-          ExpressionAttributeValues: { ':v': { B: new Uint8Array([]) } },
-        }),
-      )
-      expect.unreachable('should have thrown')
-    } catch (err) {
-      expect(err).toBeInstanceOf(DynamoDBServiceException)
-      expect((err as DynamoDBServiceException).name).toBe('ValidationException')
-      expect((err as DynamoDBServiceException).message).toBe(
-        'One or more parameter values are not valid. The update expression attempted to update a secondary index key to a value that is not supported. The AttributeValue for a key attribute cannot contain an empty binary value.',
       )
     }
   })

--- a/tests/tier3/legacy-api/attributeUpdates.test.ts
+++ b/tests/tier3/legacy-api/attributeUpdates.test.ts
@@ -4,7 +4,9 @@ import {
   GetItemCommand,
 } from '@aws-sdk/client-dynamodb'
 import { ddb } from '../../../src/client.js'
-import { hashTableDef, cleanupItems, expectDynamoError } from '../../../src/helpers.js'
+import { declareTables, hashTableDef, cleanupItems, expectDynamoError } from '../../../src/helpers.js'
+
+declareTables(hashTableDef)
 
 // no negative-path: acceptance-mixed (asserts accepted and rejected cases)
 describe('Legacy API — AttributeUpdates (legacy UpdateExpression)', { tags: ['update-item', 'legacy', 'data-plane'] }, () => {

--- a/tests/tier3/legacy-api/attributesToGet.test.ts
+++ b/tests/tier3/legacy-api/attributesToGet.test.ts
@@ -11,7 +11,10 @@ import {
   compositeTableDef,
   cleanupItems,
   expectDynamoError,
+  declareTables,
 } from '../../../src/helpers.js'
+
+declareTables(hashTableDef, compositeTableDef)
 
 // no negative-path: acceptance-mixed (asserts accepted and rejected cases)
 describe('Legacy API — AttributesToGet (legacy ProjectionExpression)', { tags: ['get-item', 'query', 'scan', 'legacy', 'data-plane'] }, () => {

--- a/tests/tier3/legacy-api/expected.test.ts
+++ b/tests/tier3/legacy-api/expected.test.ts
@@ -4,7 +4,9 @@ import {
   DeleteItemCommand,
 } from '@aws-sdk/client-dynamodb'
 import { ddb } from '../../../src/client.js'
-import { hashTableDef, cleanupItems, expectDynamoError } from '../../../src/helpers.js'
+import { declareTables, hashTableDef, cleanupItems, expectDynamoError } from '../../../src/helpers.js'
+
+declareTables(hashTableDef)
 
 // no negative-path: acceptance-mixed (asserts accepted and rejected cases)
 describe('Legacy API — Expected (legacy ConditionExpression)', { tags: ['put-item', 'delete-item', 'legacy', 'data-plane'] }, () => {

--- a/tests/tier3/legacy-api/expected.test.ts
+++ b/tests/tier3/legacy-api/expected.test.ts
@@ -27,7 +27,7 @@ describe('Legacy API — Expected (legacy ConditionExpression)', { tags: ['put-i
   })
 
   it('PutItem with Expected Exists:false succeeds when item does not exist', async () => {
-    const result = await ddb.send(
+    await ddb.send(
       new PutItemCommand({
         TableName: hashTableDef.name,
         Item: { pk: { S: 'expected-1' }, data: { S: 'created' } },

--- a/tests/tier3/legacy-api/queryFilter.test.ts
+++ b/tests/tier3/legacy-api/queryFilter.test.ts
@@ -3,7 +3,9 @@ import {
   QueryCommand,
 } from '@aws-sdk/client-dynamodb'
 import { ddb } from '../../../src/client.js'
-import { compositeTableDef, cleanupItems, expectDynamoError } from '../../../src/helpers.js'
+import { declareTables, compositeTableDef, cleanupItems, expectDynamoError } from '../../../src/helpers.js'
+
+declareTables(compositeTableDef)
 
 // no negative-path: acceptance-mixed (asserts accepted and rejected cases)
 describe('Legacy API — KeyConditions and QueryFilter', { tags: ['query', 'legacy', 'data-plane'] }, () => {

--- a/tests/tier3/legacy-api/scanFilter.test.ts
+++ b/tests/tier3/legacy-api/scanFilter.test.ts
@@ -3,7 +3,9 @@ import {
   ScanCommand,
 } from '@aws-sdk/client-dynamodb'
 import { ddb } from '../../../src/client.js'
-import { hashTableDef, cleanupItems, expectDynamoError } from '../../../src/helpers.js'
+import { declareTables, hashTableDef, cleanupItems, expectDynamoError } from '../../../src/helpers.js'
+
+declareTables(hashTableDef)
 
 // no negative-path: acceptance-mixed (asserts accepted and rejected cases)
 describe('Legacy API — ScanFilter (legacy FilterExpression)', { tags: ['scan', 'legacy', 'data-plane'] }, () => {

--- a/tests/tier3/limits/batchLimits.test.ts
+++ b/tests/tier3/limits/batchLimits.test.ts
@@ -1,7 +1,6 @@
 import {
   BatchWriteItemCommand,
   BatchGetItemCommand,
-  PutItemCommand,
 } from '@aws-sdk/client-dynamodb'
 import { ddb } from '../../../src/client.js'
 import {

--- a/tests/tier3/limits/emptyValues.test.ts
+++ b/tests/tier3/limits/emptyValues.test.ts
@@ -8,7 +8,10 @@ import {
   compositeTableDef,
   cleanupItems,
   expectDynamoError,
+  declareTables,
 } from '../../../src/helpers.js'
+
+declareTables(hashTableDef, compositeTableDef)
 
 // no negative-path: acceptance-mixed (asserts accepted and rejected cases)
 describe('Empty values — strings, binary, and sets', { tags: ['put-item', 'get-item', 'data-plane'] }, () => {

--- a/tests/tier3/limits/expressionSize.test.ts
+++ b/tests/tier3/limits/expressionSize.test.ts
@@ -6,7 +6,9 @@ import {
   UpdateItemCommand,
 } from '@aws-sdk/client-dynamodb'
 import { ddb } from '../../../src/client.js'
-import { hashTableDef, expectDynamoError, cleanupItems } from '../../../src/helpers.js'
+import { declareTables, hashTableDef, expectDynamoError, cleanupItems } from '../../../src/helpers.js'
+
+declareTables(hashTableDef)
 
 // Real DynamoDB caps every expression parameter at 4096 bytes, measured on the
 // raw expression string as sent: aliases are not substituted before counting,

--- a/tests/tier3/limits/itemSize.test.ts
+++ b/tests/tier3/limits/itemSize.test.ts
@@ -7,7 +7,10 @@ import {
   hashTableDef,
   hashNTableDef,
   cleanupItems,
+  declareTables,
 } from '../../../src/helpers.js'
+
+declareTables(hashTableDef, hashNTableDef)
 
 const PREFIX = 'lim-is-'
 const keysToClean: { pk: { S: string } }[] = []

--- a/tests/tier3/limits/keyLength.test.ts
+++ b/tests/tier3/limits/keyLength.test.ts
@@ -1,6 +1,8 @@
 import { PutItemCommand, GetItemCommand } from '@aws-sdk/client-dynamodb'
 import { ddb } from '../../../src/client.js'
-import { hashTableDef, expectDynamoError, cleanupItems } from '../../../src/helpers.js'
+import { declareTables, hashTableDef, expectDynamoError, cleanupItems } from '../../../src/helpers.js'
+
+declareTables(hashTableDef)
 
 // Real DynamoDB caps a partition key at 2048 bytes. The ceiling is enforced on
 // the read/lookup path as well as on writes.

--- a/tests/tier3/limits/nestingDepth.test.ts
+++ b/tests/tier3/limits/nestingDepth.test.ts
@@ -4,8 +4,10 @@ import {
   type AttributeValue,
 } from '@aws-sdk/client-dynamodb'
 import { ddb } from '../../../src/client.js'
-import { hashTableDef, cleanupItems, expectDynamoError } from '../../../src/helpers.js'
+import { declareTables, hashTableDef, cleanupItems, expectDynamoError } from '../../../src/helpers.js'
 import { observeSplit } from '../../../src/observation-sink.js'
+
+declareTables(hashTableDef)
 
 // Wrap a scalar leaf in `depth` single-key maps: depth=1 -> { M: { n: { S: 'leaf' } } }.
 // Real DynamoDB caps document nesting at 32 levels, counting the attribute itself as

--- a/tests/tier3/limits/numberPrecision.test.ts
+++ b/tests/tier3/limits/numberPrecision.test.ts
@@ -10,7 +10,10 @@ import {
   compositeNTableDef,
   cleanupItems,
   expectDynamoError,
+  declareTables,
 } from '../../../src/helpers.js'
+
+declareTables(hashTableDef, compositeNTableDef)
 
 // no negative-path: acceptance-mixed (asserts accepted and rejected cases)
 describe('Number precision — DynamoDB number limits and edge cases', { tags: ['put-item', 'get-item', 'update-item', 'query', 'data-plane'] }, () => {

--- a/tests/tier3/limits/reservedWords.test.ts
+++ b/tests/tier3/limits/reservedWords.test.ts
@@ -2,7 +2,6 @@ import {
   PutItemCommand,
   GetItemCommand,
   UpdateItemCommand,
-  QueryCommand,
   ScanCommand,
 } from '@aws-sdk/client-dynamodb'
 import { ddb } from '../../../src/client.js'

--- a/tests/tier3/limits/reservedWords.test.ts
+++ b/tests/tier3/limits/reservedWords.test.ts
@@ -10,7 +10,10 @@ import {
   hashTableDef,
   cleanupItems,
   expectDynamoError,
+  declareTables,
 } from '../../../src/helpers.js'
+
+declareTables(hashTableDef)
 
 // no negative-path: acceptance-mixed (asserts accepted and rejected cases)
 describe('Reserved words — ExpressionAttributeNames handling', { tags: ['put-item', 'get-item', 'update-item', 'query', 'scan', 'data-plane'] }, () => {

--- a/tests/tier3/limits/transactionLimits.test.ts
+++ b/tests/tier3/limits/transactionLimits.test.ts
@@ -2,7 +2,6 @@ import {
   TransactWriteItemsCommand,
   TransactGetItemsCommand,
   BatchWriteItemCommand,
-  PutItemCommand,
 } from '@aws-sdk/client-dynamodb'
 import { ddb } from '../../../src/client.js'
 import { skipUnlessSupported } from '../../../src/infra.js'

--- a/tests/tier3/validation-ordering/batchOperations.test.ts
+++ b/tests/tier3/validation-ordering/batchOperations.test.ts
@@ -4,7 +4,9 @@ import {
   DynamoDBServiceException,
 } from '@aws-sdk/client-dynamodb'
 import { ddb } from '../../../src/client.js'
-import { hashTableDef } from '../../../src/helpers.js'
+import { declareTables, hashTableDef } from '../../../src/helpers.js'
+
+declareTables(hashTableDef)
 
 describe('Batch operations — validation ordering', { tags: ['batch', 'data-plane', 'negative-path'] }, () => {
   it('BatchWriteItem rejects empty RequestItems', async () => {

--- a/tests/tier3/validation-ordering/index.test.ts
+++ b/tests/tier3/validation-ordering/index.test.ts
@@ -5,7 +5,9 @@ import {
   DynamoDBServiceException,
 } from '@aws-sdk/client-dynamodb'
 import { ddb } from '../../../src/client.js'
-import { hashTableDef } from '../../../src/helpers.js'
+import { declareTables, hashTableDef } from '../../../src/helpers.js'
+
+declareTables(hashTableDef)
 
 // The non-existent-index error surface. Real AWS does NOT return
 // IndexNotFoundException here (characterised in the U2 gap map): Query/Scan

--- a/tests/tier3/validation-ordering/index.test.ts
+++ b/tests/tier3/validation-ordering/index.test.ts
@@ -10,7 +10,7 @@ import { declareTables, hashTableDef } from '../../../src/helpers.js'
 declareTables(hashTableDef)
 
 // The non-existent-index error surface. Real AWS does NOT return
-// IndexNotFoundException here (characterised in the U2 gap map): Query/Scan
+// IndexNotFoundException here: Query/Scan
 // report ValidationException, and an UpdateTable GSI delete reports
 // ResourceNotFoundException. A too-lenient target that invents its own code or
 // silently succeeds fails these.

--- a/tests/tier3/validation-ordering/query.test.ts
+++ b/tests/tier3/validation-ordering/query.test.ts
@@ -3,7 +3,9 @@ import {
   DynamoDBServiceException,
 } from '@aws-sdk/client-dynamodb'
 import { ddb } from '../../../src/client.js'
-import { hashTableDef } from '../../../src/helpers.js'
+import { declareTables, hashTableDef } from '../../../src/helpers.js'
+
+declareTables(hashTableDef)
 
 describe('Query — validation ordering', { tags: ['query', 'data-plane', 'negative-path'] }, () => {
   it('reports invalid TableName pattern', async () => {

--- a/tests/tier3/validation-ordering/scan.test.ts
+++ b/tests/tier3/validation-ordering/scan.test.ts
@@ -3,7 +3,9 @@ import {
   DynamoDBServiceException,
 } from '@aws-sdk/client-dynamodb'
 import { ddb } from '../../../src/client.js'
-import { hashTableDef } from '../../../src/helpers.js'
+import { declareTables, hashTableDef } from '../../../src/helpers.js'
+
+declareTables(hashTableDef)
 
 describe('Scan — validation ordering', { tags: ['scan', 'data-plane', 'negative-path'] }, () => {
   it('rejects Segment without TotalSegments', async () => {


### PR DESCRIPTION
## What this changes

`--tags-filter='!gsi and !lsi'` deselected the index tests, but the shared tables were created before any filter applied and two of them carried indexes, so an engine without index support still died in setup. Follow-up to #115, which fixed the same directory-assignment problem for `legacy` and left the index axes needing this. Part of #26.

Three things had to move together:

- **Tables are created on demand.** A file declares what it needs at module scope and setup creates only that file's tables. `--tags-filter` skips tests but still imports every file, so scoping by declaring file is what does the work here: an excluded file's setup hook never runs, and nothing has to parse the filter.
- **The shared composite table split.** `compositeTableDef` now carries no index; `compositeIndexedTableDef` carries the same ones under their existing names, since a number of tests pin messages naming them. Tests depending on an index moved into files of their own, so a file's declaration says whether it needs one.
- **Tagged by dependency rather than by filename**, including the tests that never name an index and are only rejected because the attribute they write is an index key.

Two guards go with it: a file must declare the shared tables it uses, and a test that writes an index-key attribute or builds a table with an index collection must carry an index tag.

Verified by polling table creation during a run:

```
!gsi and !lsi  ->  0 indexed tables
!gsi           ->  0 GSI-bearing (LSI tables still built, which is correct)
!lsi           ->  0 LSI-bearing
```

998 tests before and after. Each of the 124 files now also passes when run on its own, which it did not before.

## Checklist

- [x] New or modified tests run against real AWS DynamoDB and pass - 981/981 in `eu-west-2`, no failures and no skips
- [x] New or modified tests run against at least one emulator target and behave as expected
- [x] Linked issue or a short note explaining the motivation
- [x] I agree my contribution is licensed under the project's terms (Apache License, Version 2.0)

## Tier and scope

Touches the results pipeline. `results/tag-manifest.json` is regenerated; no schema change. The generator now writes the site's committed copy as well, which had drifted nine files behind while being kept in step by hand.

No conformance percentage moves - tags never fed the score. The `gsi` and `lsi` columns grow, which is the tagging being corrected.

One thing this does not settle: whether the real-AWS gating run got slower. Tables are now created as files ask for them rather than all at once up front, so a cold run pays each table's activation in turn.
