### PR TITLE
ci: stop dependency merges measuring against real AWS

### DIFF
--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -38,13 +38,68 @@ permissions:
   contents: read
 
 jobs:
+  # Whether this push changed anything that could move a measurement against
+  # real DynamoDB. Real DynamoDB's behaviour is AWS's, so what makes the
+  # ground-truth run worth repeating is a change to the tests driving it or the
+  # harness running them, not a dependency bump, a workflow edit or the docs.
+  #
+  # Without this, merging any dependency update started a live AWS run. Those
+  # hold the shared conformance account for their whole duration, and the
+  # account is also what a maintainer probes by hand, so a routine merge could
+  # block someone mid-investigation with no warning. Every dependency PR the
+  # repo has seen touched lockfiles, manifests or workflows and none touched
+  # tests/ or src/, so keying on those two keeps the same-day refresh for real
+  # suite changes and drops it for the rest.
+  changes:
+    name: What changed
+    runs-on: ubuntu-latest
+    outputs:
+      suite: ${{ steps.filter.outputs.suite }}
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+      - id: filter
+        env:
+          BEFORE: ${{ github.event.before }}
+          AFTER: ${{ github.sha }}
+          EVENT: ${{ github.event_name }}
+        run: |
+          decide() { echo "suite=$1" >>"$GITHUB_OUTPUT"; echo "suite=$1 ($2)"; exit 0; }
+
+          # A schedule or a dispatch is an explicit request to measure.
+          [ "$EVENT" = "push" ] || decide true "$EVENT is not a push"
+
+          # A first push, a force-push, or a parent this checkout cannot see
+          # leaves nothing to diff. Measure rather than guess.
+          if [ -z "$BEFORE" ] || [ "$BEFORE" = "0000000000000000000000000000000000000000" ] \
+            || ! git cat-file -e "${BEFORE}^{commit}" 2>/dev/null; then
+            decide true "no comparable parent"
+          fi
+
+          # tests/ is the assertions, src/ is the harness that drives them, and
+          # vitest.config.ts sets the timeouts, retries and include glob a run
+          # is made under. An SDK bump is deliberately not here: it would match
+          # every dependency PR and so undo this, and the weekly run picks the
+          # new client up within seven days.
+          if git diff --name-only "$BEFORE" "$AFTER" \
+            | grep -qE '^(tests|src)/|^vitest\.config\.ts$'; then
+            decide true "the suite or the harness changed"
+          fi
+          decide false "nothing outside the suite changed"
+
   test-dynamodb:
     name: DynamoDB (ground truth)
     runs-on: ubuntu-latest
-    # Runs on a merge to main, the weekly schedule, and a manual dispatch (on any
-    # ref) - never on a pull request, so PRs stay on the emulator jobs and never
-    # spend real-AWS time. Verify a branch on demand with a dispatch on its ref.
-    if: github.event_name == 'push' || github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+    needs: changes
+    # The weekly schedule and a manual dispatch (on any ref) always measure. A
+    # merge to main measures only when it touched the suite - see the `changes`
+    # job for why. Never on a pull request, so PRs stay on the emulator jobs and
+    # never spend real-AWS time. Verify a branch on demand with a dispatch on
+    # its ref, which is also how to force a refresh after a merge that skipped.
+    if: >-
+      github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' ||
+      (github.event_name == 'push' && needs.changes.outputs.suite == 'true')
     # Serialise AWS runs: the suite shares one account and cleanup deletes every
     # _conformance_ table by prefix, so overlapping runs delete each other's
     # tables. Queue rather than cancel — a cancelled run leaves orphan tables.


### PR DESCRIPTION
Merging a dependency update started a live AWS run. `test-dynamodb` fires on every push to main, assumes the OIDC role, and holds the `conformance-aws` concurrency group for the duration. That account is also what a maintainer probes by hand, so a routine merge could block an investigation with no warning and nothing to point at.

Real DynamoDB's behaviour is AWS's. Nothing in this repo changes it. What makes the ground-truth run worth repeating is a change to the assertions, the harness driving them, or the config a run happens under, so a `changes` job now decides that and `test-dynamodb` gates on it.

- the weekly schedule and a manual dispatch always measure
- a merge to main measures only when it touched `tests/`, `src/` or `vitest.config.ts`
- a force push, or any parent the checkout cannot see, measures rather than guesses
- pull requests are unaffected: the real-AWS jobs already skipped on them

An SDK bump is deliberately not in the filter. Matching `package.json` would catch every dependency PR and undo the change, and the weekly run picks up a new client within seven days. The emulator jobs still run on dependency merges, which is where a bad SDK bump would show.

### Checked against real refs

The filter script was extracted from the workflow and run as a shell against actual commits, so the test covers the text that ships rather than a paraphrase.

| input | outcome |
|---|---|
| #132, the aws-sdk group | no AWS |
| #133, markdown-it 14 to 15 | no AWS |
| #130, the six batched updates | no AWS |
| #117 | no AWS: it changes the scorer, not the measurement |
| `c21fe9b`, a real test-file refactor | measures |
| a real commit touching `vitest.config.ts` | measures |
| weekly schedule, manual dispatch | measures |
| force push with no comparable parent | measures |

`vitest.tooling.config.ts` correctly does not match. It configures the tooling tests, not an AWS run.

### Ordering

A push evaluates the workflow file at the pushed commit, so this only takes effect once it is on main. It covers its own merge: the change touches only `.github/workflows/`, which the new filter reads as no measurement needed. #132 and #133 can then merge without touching AWS.