### PR TITLE
ci: run the WebAssembly engine as a scored target

### DIFF
--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -31,6 +31,10 @@ on:
         description: "ExtendDB git ref to build (blank = latest release)"
         required: false
         default: ""
+      dynoxide_wasm_ref:
+        description: "Dynoxide git ref to build the wasm engine from (blank = latest release)"
+        required: false
+        default: ""
   # No repository_dispatch. A `[dynoxide-release, extenddb-release]` trigger
   # sat here and nothing ever fired it - the sending repo dispatches to its own
   # docs site, not to this one - so it read as a live path and was not one, and
@@ -596,6 +600,87 @@ jobs:
         uses: actions/upload-artifact@v7
         with:
           name: results-dynoxide
+          path: results/
+
+  test-dynoxide-wasm:
+    name: Dynoxide (wasm)
+    # A separate engine from the native build above, scored as its own row.
+    # It is the only target reachable by neither a container image nor an npm
+    # binary: the wasm engine answers a postMessage RPC in a browser, and the
+    # shim that puts a DynamoDB endpoint in front of it is unpublished. So this
+    # builds it from a Dynoxide checkout, which makes it as heavy as ExtendDB
+    # and it skips PRs for the same reason.
+    #
+    # Until this job existed the row was refreshed by hand, and it went three
+    # weeks without a run while tests moved between files underneath it. Its
+    # count still matched the suite, so nothing noticed.
+    if: github.event_name != 'pull_request'
+    continue-on-error: true
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Resolve Dynoxide ref (latest release unless overridden)
+        id: ref
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          REF='${{ github.event.inputs.dynoxide_wasm_ref }}'
+          if [ -z "$REF" ]; then
+            REF=$(gh release view -R nubo-db/dynoxide --json tagName --jq .tagName)
+          fi
+          echo "ref=$REF" >> "$GITHUB_OUTPUT"
+          echo "Building the Dynoxide wasm engine at $REF"
+
+      - name: Checkout Dynoxide
+        uses: actions/checkout@v7
+        with:
+          repository: nubo-db/dynoxide
+          ref: ${{ steps.ref.outputs.ref }}
+          path: dynoxide
+
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: wasm32-unknown-unknown
+      - uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: dynoxide
+
+      - uses: actions/setup-node@v7
+        with:
+          node-version: 24
+          cache: npm
+
+      - run: npm ci
+
+      # From npm rather than the upstream shell installer, so the version is
+      # pinned by a lockfile-shaped thing and nothing pipes curl into sh.
+      - name: Install wasm-pack
+        run: npm install -g wasm-pack@0.15.0
+
+      - name: Build and start the wasm engine
+        env:
+          DYNOXIDE_DIR: ${{ github.workspace }}/dynoxide
+        run: ./scripts/run-dynoxide-wasm.sh
+
+      - name: Run conformance suite
+        continue-on-error: true # a preview: PartiQL, transactions, tags and TTL skip
+        env:
+          CONFORMANCE_TARGET: dynoxide-wasm
+        run: npm test
+
+      - name: Record target version
+        continue-on-error: true
+        env:
+          DYNOXIDE_WASM_REF: ${{ steps.ref.outputs.ref }}
+        run: scripts/record-version.sh dynoxide-wasm
+
+      - name: Upload results
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: results-dynoxide-wasm
           path: results/
 
   test-floci:

--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -621,22 +621,32 @@ jobs:
     steps:
       - uses: actions/checkout@v7
 
-      - name: Resolve Dynoxide ref (latest release unless overridden)
+      - name: Resolve the engine's repository and ref
         id: ref
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
+          # The organisation comes from the target registry, where a target's
+          # project URL is data. Writing it here would have the workflow name a
+          # vendor, which scripts/public-tree.test.mjs refuses and which is the
+          # difference between a neutral board and somebody's marketing. The
+          # registry module has no imports, so this runs before npm ci.
+          REPO=$(node --input-type=module -e "
+            import { repoUrl } from './scripts/lib/targets.mjs'
+            process.stdout.write(new URL(repoUrl('dynoxide')).pathname.slice(1))
+          ")
           REF='${{ github.event.inputs.dynoxide_wasm_ref }}'
           if [ -z "$REF" ]; then
-            REF=$(gh release view -R nubo-db/dynoxide --json tagName --jq .tagName)
+            REF=$(gh release view -R "$REPO" --json tagName --jq .tagName)
           fi
+          echo "repo=$REPO" >> "$GITHUB_OUTPUT"
           echo "ref=$REF" >> "$GITHUB_OUTPUT"
-          echo "Building the Dynoxide wasm engine at $REF"
+          echo "Building the wasm engine from $REPO at $REF"
 
-      - name: Checkout Dynoxide
+      - name: Checkout the engine
         uses: actions/checkout@v7
         with:
-          repository: nubo-db/dynoxide
+          repository: ${{ steps.ref.outputs.repo }}
           ref: ${{ steps.ref.outputs.ref }}
           path: dynoxide
 

--- a/README.md
+++ b/README.md
@@ -261,6 +261,17 @@ so the suite sees a port like every other target. The script is test-only and
 deliberately undistributed - it is not a way to run dynoxide, and getting it
 means cloning the repo.
 
+`scripts/run-dynoxide-wasm.sh` automates the whole bring-up (build the bundle,
+install the browser, start the shim, wait for the engine to answer) against a
+Dynoxide checkout, and the CI job uses it:
+
+```bash
+DYNOXIDE_DIR=/path/to/dynoxide eval "$(./scripts/run-dynoxide-wasm.sh)"
+CONFORMANCE_TARGET=dynoxide-wasm npm test
+```
+
+To wire it up by hand instead:
+
 ```bash
 # in a dynoxide checkout: build the bundle, then serve it
 npm ci && npm run build:wasm

--- a/scripts/record-version.sh
+++ b/scripts/record-version.sh
@@ -31,7 +31,11 @@ case "$target" in
   extenddb)   ver="${EXTENDDB_REF:-}" ;;
   dynoxide)   ver=$(npm view dynoxide version 2>/dev/null) ;;
   dynoxide-wasm)
+    # The ref is a release tag (v0.13.0) while the native row reads its version
+    # from npm (0.13.0). They are the same release on two adjacent rows, so the
+    # prefix goes rather than having the board render it two ways.
     ver="${DYNOXIDE_WASM_REF:-}"
+    ver="${ver#v}"
     [ -z "$ver" ] && ver=$(npm view dynoxide version 2>/dev/null)
     ;;
   dynalite)   ver=$(npm view dynalite version 2>/dev/null) ;;

--- a/scripts/run-dynoxide-wasm.sh
+++ b/scripts/run-dynoxide-wasm.sh
@@ -1,0 +1,87 @@
+#!/usr/bin/env bash
+#
+# Build the Dynoxide WebAssembly engine and stand it up on an HTTP port.
+#
+# The wasm build is the only target the suite cannot reach with a container
+# image or an npm binary. It has no server of its own: it answers a postMessage
+# RPC inside a browser. Dynoxide ships a shim that speaks the DynamoDB HTTP API
+# and forwards each request into a headless Chromium running the built dist/,
+# so the suite sees a port like every other target. The shim is not published,
+# which is why this needs a Dynoxide checkout rather than an install.
+#
+# Used by the Dynoxide (wasm) CI job and runnable locally.
+#
+# Required:
+#   DYNOXIDE_DIR                path to a Dynoxide checkout
+#
+# Optional (defaults shown):
+#   DYNOXIDE_WASM_PORT=8003     the DynamoDB endpoint the suite drives
+#   DYNOXIDE_WASM_ASSET_PORT=8004  the shim's internal static server
+#   BUILD=1                     set 0 to reuse an existing dist/
+#
+# On success it emits the suite env (DYNAMODB_ENDPOINT and placeholder AWS
+# credentials). In CI ($GITHUB_ENV set) it appends them there; otherwise it
+# prints `export` lines suitable for
+# `eval "$(DYNOXIDE_DIR=... ./scripts/run-dynoxide-wasm.sh)"`.
+set -euo pipefail
+
+: "${DYNOXIDE_DIR:?set DYNOXIDE_DIR to a Dynoxide checkout}"
+PORT=${DYNOXIDE_WASM_PORT:-8003}
+ASSET_PORT=${DYNOXIDE_WASM_ASSET_PORT:-8004}
+LOG=${DYNOXIDE_WASM_LOG:-/tmp/dynoxide-wasm-bridge.log}
+
+cd "$DYNOXIDE_DIR"
+
+if [ "${BUILD:-1}" = "1" ]; then
+  echo "==> npm ci (dynoxide)" >&2
+  npm ci >&2
+
+  # The shim drives Chromium through Playwright and will install it on first
+  # run, but doing it here keeps a browser-download failure attributable to its
+  # own step, and --with-deps pulls the system libraries a bare CI image lacks.
+  echo "==> install chromium" >&2
+  npx playwright install --with-deps chromium >&2
+
+  echo "==> build the wasm bundle" >&2
+  scripts/build-wasm.sh >&2
+fi
+
+echo "==> start the wasm engine on :${PORT}" >&2
+# Detached, because the conformance run is a later step and the runner would
+# otherwise reap the shim with this shell.
+nohup npm run wasm:serve -- --port "$PORT" --asset-port "$ASSET_PORT" >"$LOG" 2>&1 &
+
+# Ready means answering the DynamoDB API, not merely holding the port: the shim
+# binds only after Chromium has loaded the bundle and the engine has reported
+# its contract version. An unauthenticated ListTables is rejected rather than
+# served, and that rejection is proof enough that the whole chain is up.
+ready=0
+for _ in $(seq 1 120); do
+  code=$(curl -s -o /dev/null -w '%{http_code}' \
+    -X POST "http://127.0.0.1:${PORT}/" \
+    -H 'X-Amz-Target: DynamoDB_20120810.ListTables' \
+    -H 'Content-Type: application/x-amz-json-1.0' \
+    -d '{}' 2>/dev/null || true)
+  if [ -n "$code" ] && [ "$code" != "000" ]; then ready=1; break; fi
+  sleep 2
+done
+if [ "$ready" -ne 1 ]; then
+  echo "ERROR: the wasm engine did not answer on :${PORT}" >&2
+  echo "--- bridge log ---" >&2
+  cat "$LOG" >&2 || true
+  exit 1
+fi
+
+emit() { # name value
+  if [ -n "${GITHUB_ENV:-}" ]; then
+    printf '%s=%s\n' "$1" "$2" >>"$GITHUB_ENV"
+  else
+    printf "export %s='%s'\n" "$1" "$2"
+  fi
+}
+emit DYNAMODB_ENDPOINT "http://127.0.0.1:${PORT}"
+emit AWS_ACCESS_KEY_ID "fakeAccessKeyId"
+emit AWS_SECRET_ACCESS_KEY "fakeSecretAccessKey"
+emit AWS_REGION "us-east-1"
+
+echo "==> Dynoxide wasm ready at http://127.0.0.1:${PORT}" >&2


### PR DESCRIPTION
The wasm engine was the only target with no CI job. Its row was refreshed by hand, and it sat three weeks stale while tests moved between files underneath it, which nothing noticed because its count still matched the suite.

It is the only target reachable by neither a container image nor an npm binary: the engine answers a `postMessage` RPC in a browser, and the shim that puts a DynamoDB endpoint in front of it is unpublished. So the job builds it from a Dynoxide release, the same way `test-extenddb` builds ExtendDB from source, and skips pull requests for the same reason.

`scripts/run-dynoxide-wasm.sh` does the bring-up (build the bundle, install Chromium, start the shim, wait for the engine to answer) and is runnable locally against any Dynoxide checkout.

Two pieces were already in place for a job that never arrived: `record-version.sh` had a `dynoxide-wasm` case documenting a `DYNOXIDE_WASM_REF` input, and `results-table.yml` downloads with `--pattern 'results-*'`, so the new artifact reaches the board without a change there. The version case now drops the `v` from the release tag, because the native row reads `0.13.0` from npm and the two sit adjacent on the board.

`wasm-pack` comes from npm pinned at 0.15.0 rather than the upstream shell installer.

### Rehearsed before committing

The whole job was run locally against a fresh `git clone --branch v0.13.0`, so nothing reused a working checkout:

| step | result |
|---|---|
| wasm-pack build from the clean clone | `pkg/` and `dist/` produced |
| Chromium install, shim start | `engine ready: contract 1, persistence memory, 17 ops` |
| conformance suite | 998 tests, 865 passed, 133 skipped, 0 failed |
| `record-version.sh dynoxide-wasm` | `0.13.0` |

Those are the same numbers the hand-run produced, which is the point: the machine now reproduces what previously only happened by hand.

### What it does not change

The row still refreshes on pushes to `release/3.0.0` and main, the weekly schedule, and manual dispatch, but not on pull requests. That matches ExtendDB and keeps the Rust build off the PR path.

Worth knowing for afterwards: with the suite manifest gate in, a wasm row whose population has drifted stops the board regenerating for every target rather than publishing a wrong row. Loud rather than wrong, and the recovery is now re-running this job instead of building wasm by hand.