### PR TITLE
fix: enumerate results/ through the shared predicate everywhere

### DIFF
--- a/scripts/badges.test.mjs
+++ b/scripts/badges.test.mjs
@@ -3,7 +3,7 @@ import { existsSync, readdirSync, readFileSync } from 'node:fs'
 import { join } from 'node:path'
 import { buildBadge, colour, gradeFor } from './badges.mjs'
 import { BASELINE_GRADE } from './lib/grade.mjs'
-import { loadScoringContext } from './lib/score.mjs'
+import { isTargetResultFile, loadScoringContext } from './lib/score.mjs'
 
 const RESULTS_DIR = 'results'
 
@@ -183,10 +183,12 @@ describe('committed badges are fresh', () => {
   // The same committed inputs the CLI writer uses: the split registry and the
   // observed region set, plus each run's indeterminate sidecar if present.
   const context = loadScoringContext()
-  const resultFiles = readdirSync(RESULTS_DIR).filter(
-    (f) =>
-      f.endsWith('.json') && !f.endsWith('.badge.json') && !f.endsWith('.indeterminate.json'),
-  )
+  // The shared predicate, not a hand-rolled filter. Spelling it out here caught
+  // summary.json and tag-manifest.json, which are companions rather than runs
+  // and only ever asserted that they had no badge, and results/local.json,
+  // which is the gitignored scratch slug - so the case count moved depending on
+  // whether the person running the tests had run the suite locally.
+  const resultFiles = readdirSync(RESULTS_DIR).filter(isTargetResultFile)
 
   it.each(resultFiles)('%s matches a fresh build', (file) => {
     const slug = file.replace(/\.json$/, '')

--- a/scripts/lib/score.test.mjs
+++ b/scripts/lib/score.test.mjs
@@ -1,6 +1,12 @@
 import { describe, it, expect } from 'vitest'
 import { readdirSync, readFileSync } from 'node:fs'
-import { basename } from 'node:path'
+import { basename, join } from 'node:path'
+
+/** Every file under a directory, recursively. */
+const walk = (dir) =>
+  readdirSync(dir, { withFileTypes: true }).flatMap((e) =>
+    e.isDirectory() ? walk(join(dir, e.name)) : [join(dir, e.name)],
+  )
 import {
   cohortOf,
   GROUND_TRUTH_LANES,
@@ -527,12 +533,22 @@ describe('targetResultSlug', () => {
   it('nothing enumerates results/ without going through the predicate', () => {
     // A grep, deliberately. The failure mode is a new caller writing its own
     // extension filter, which no unit test of this module can see.
-    const sources = ['scripts/summarise.mjs', 'scripts/badges.mjs', 'scripts/lineage.mjs']
+    //
+    // The list is discovered rather than written down. It used to name three
+    // files, so a caller that was not one of them was invisible - which is how
+    // badges.test.mjs came to walk results/ with its own filter, pick up the
+    // summary, the tag manifest and the gitignored scratch slug, and change its
+    // own case count depending on whether the suite had been run locally. A
+    // hand-maintained list of callers is the same bug this guard exists to
+    // catch, one level up.
+    const sources = walk('scripts').filter((f) => f.endsWith('.mjs'))
     for (const file of sources) {
       // Imports stripped first. Checking the whole file only proves the name
       // was imported, which stays true when a caller stops calling it.
       const body = readFileSync(file, 'utf8').replace(/^import[\s\S]*?from\s+'[^']+'$/gm, '')
-      if (!/readdirSync\((?:'results'|resultsDir)\)/.test(body)) continue
+      // The constant form too: badges.test.mjs walked `readdirSync(RESULTS_DIR)`
+      // and the pattern did not know the name.
+      if (!/readdirSync\((?:'results'|resultsDir|RESULTS_DIR)\)/.test(body)) continue
       expect(
         /targetResultSlug|isTargetResultFile/.test(body),
         `${file} walks results/ without the shared predicate`,

--- a/scripts/lib/targets.test.mjs
+++ b/scripts/lib/targets.test.mjs
@@ -12,7 +12,7 @@ import {
   projectOf,
   repoUrl,
 } from './targets.mjs'
-import { GROUND_TRUTH_SLUG, isPublishedTarget } from './score.mjs'
+import { GROUND_TRUTH_SLUG, isPublishedTarget, isTargetResultFile } from './score.mjs'
 
 // The registry is hand-maintained, unlike every figure the board publishes, so
 // what can be checked about it is checked here: that its relationships are
@@ -71,17 +71,12 @@ describe('the target registry', () => {
   it('has a row for every target the results directory publishes', () => {
     // A results file with no registry entry renders under a hyphen-stripped
     // slug with no link, which is how a new target reaches the board unnamed.
-    // Filtered on being a Vitest run rather than on a filename denylist, which
-    // is the same criterion the pipeline applies: results/ also holds derived
-    // artefacts (the tag manifest, the summary) that are not targets.
+    // Through the shared predicate, which is the criterion the pipeline
+    // applies: results/ also holds derived artefacts (the tag manifest, the
+    // summary) and the gitignored scratch slug, none of which are targets.
     const published = readdirSync('results')
-      .filter((f) => f.endsWith('.json'))
-      .filter((f) => !f.endsWith('.badge.json') && !f.endsWith('.indeterminate.json'))
-      .filter((f) =>
-        Array.isArray(JSON.parse(readFileSync(join('results', f), 'utf8')).testResults),
-      )
+      .filter(isTargetResultFile)
       .map((f) => f.replace(/\.json$/, ''))
-      .filter((slug) => isPublishedTarget(slug))
     const missing = published.filter((slug) => !TARGETS[slug])
     expect(missing, `results files with no registry entry: ${missing}`).toEqual([])
   })

--- a/scripts/summarise.test.mjs
+++ b/scripts/summarise.test.mjs
@@ -5,7 +5,7 @@ import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { buildBadge, writeBadges } from './badges.mjs'
 import { testIdentities } from './ground-truth-coverage.mjs'
-import { GROUND_TRUTH_SLUG, axesOf, loadScoringContext, scoreTarget, verdictsForRegion } from './lib/score.mjs'
+import { GROUND_TRUTH_SLUG, axesOf, isTargetResultFile, loadScoringContext, scoreTarget, verdictsForRegion } from './lib/score.mjs'
 import { classifyResults } from './lib/classify.mjs'
 import { splitFor } from './lib/registry.mjs'
 import { BASELINE_LABEL, gradeOf } from './lib/grade.mjs'
@@ -271,7 +271,7 @@ describe('buildSummary', () => {
       const summary = buildSummary(
         readTargets(
           readdirSync('results')
-            .filter((f) => f.endsWith('.json'))
+            .filter(isTargetResultFile)
             .map((f) => join('results', f)),
         ),
         context,
@@ -759,7 +759,7 @@ describe('renderTable variant nesting', () => {
 describe('committed results pipeline', () => {
   const context = loadScoringContext()
   const files = readdirSync('results')
-    .filter((f) => f.endsWith('.json'))
+    .filter(isTargetResultFile)
     .map((f) => join('results', f))
   const targets = readTargets(files)
   const fresh = buildSummary(targets, context)


### PR DESCRIPTION
`badges.test.mjs` walked `results/` with its own extension filter, which enumerated 12 files where 9 are target runs. `summary.json` and `tag-manifest.json` are companions rather than runs, so they only ever asserted that they had no badge, and `local.json` is the gitignored scratch slug, so a case appeared or vanished depending on whether the person running the tests had run the suite locally. That is the whole of the 493-versus-492 count difference between a clean checkout and a working one.

Benign in what it asserted, but it meant local and CI disagreed about the test inventory.

### The guard was the actual bug

`score.test.mjs` already had a check for this, and it did not fire, because its list of callers was three filenames written by hand:

```js
const sources = ['scripts/summarise.mjs', 'scripts/badges.mjs', 'scripts/lineage.mjs']
```

A caller that was not one of the three was invisible to it. A hand-maintained list of callers is the same bug the guard exists to catch, one level up, so it now discovers its sources by walking `scripts/`. The pattern also learned the constant form, `readdirSync(RESULTS_DIR)`, which is exactly what `badges.test.mjs` used and what the old pattern could not see.

Widening it found two more callers, so all four now go through `isTargetResultFile`:

- `badges.test.mjs`, the original
- `targets.test.mjs`, which reimplemented the predicate's logic by hand; its own comment said it was applying "the same criterion the pipeline applies"
- `summarise.test.mjs`, ad-hoc in two places

### Checked by sabotage

Reverting `badges.test.mjs` to the old filter makes the guard fail with `scripts/badges.test.mjs walks results/ without the shared predicate`. Restoring it passes. A guard that has already been slipped past once is worth proving rather than assuming.

Gate: 490 tooling tests (three phantom cases gone), typecheck clean, suite manifest matches, 249 site tests, all build checks pass. The badge test is 29 cases with or without `results/local.json` present, checked both ways.