### PR TITLE
feat(cleanup): sweep the _capture_ prefix on its own daily run

### DIFF
--- a/.github/workflows/sweep.yml
+++ b/.github/workflows/sweep.yml
@@ -9,9 +9,15 @@ name: Ground Truth Sweep
 # Output goes to ground-truth/, never results/: any results/<slug>.json is
 # automatically scored, badged and published as a target row, so a per-region
 # file landing there would fabricate phantom targets and redden the PR gate.
+#
+# It also carries the two daily orphan cleanups, one per table namespace: the
+# `_conformance_` sweep the runs here strand tables in, and the `_capture_`
+# sweep backstopping ad-hoc local capture sessions. Separate crons and separate
+# jobs, so each namespace's failure is its own alarm.
 on:
   schedule:
     - cron: '0 3 * * 6' # sweep: 3am UTC Saturday, clear of Sunday's gating run
+    - cron: '0 4 * * *' # cleanup: daily, the _capture_ namespace's backstop
     - cron: '30 5 * * *' # cleanup: daily, catching tables a dead run stranded
   workflow_dispatch:
     inputs:
@@ -291,12 +297,15 @@ jobs:
 
   cleanup:
     name: Clean up orphaned tables
-    # Runs after every sweep (skipped or not - the daily cron skips the matrix
+    # Runs after every sweep (skipped or not - the 5.30 cron skips the matrix
     # and comes straight here) so tables stranded by a dead run never sit for
     # more than a day. The age gate inside the cleanup is what keeps runs still
     # in flight safe; see scripts/cleanup-orphans.mjs.
+    #
+    # The 4am cron belongs to the capture job below, so it is excluded here:
+    # this run stays exactly as narrow as the by-prefix teardown it backstops.
     needs: sweep
-    if: always()
+    if: always() && github.event.schedule != '0 4 * * *'
     runs-on: ubuntu-latest
     timeout-minutes: 30
     permissions:
@@ -322,3 +331,44 @@ jobs:
 
       - name: Clean up orphans across all regions
         run: node scripts/cleanup-orphans.mjs
+
+  capture-cleanup:
+    name: Clean up orphaned capture tables
+    # The backstop for the `_capture_` namespace. A local capture session tears
+    # its own tables down by exact name when it ends; this catches what a
+    # session that died mid-flight left behind. Its own cron and its own job
+    # rather than a second prefix on the run above, so a capture-side failure
+    # reddens a run of its own and stays legible as a capture problem.
+    #
+    # No `needs`: the matrix never runs on this cron, and the two namespaces
+    # have nothing to sequence between them.
+    #
+    # Seven hours gates this the same as the conformance sweep, but as a
+    # convention rather than the derived credential bound it is there - nothing
+    # stops a local session running longer. See scripts/cleanup-orphans.mjs.
+    if: github.event.schedule == '0 4 * * *'
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      id-token: write
+      contents: read
+    environment: conformance-testing
+
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v7
+        with:
+          node-version: 24
+          cache: npm
+
+      - run: npm ci
+
+      - name: Configure AWS credentials via OIDC
+        uses: aws-actions/configure-aws-credentials@v6
+        with:
+          role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
+          aws-region: eu-west-2
+          role-duration-seconds: 3600
+
+      - name: Clean up capture orphans across all regions
+        run: node scripts/cleanup-orphans.mjs --prefix _capture_

--- a/scripts/cleanup-orphans.mjs
+++ b/scripts/cleanup-orphans.mjs
@@ -1,30 +1,50 @@
 #!/usr/bin/env node
 
 /**
- * Delete orphaned `_conformance_` tables, per region, across the commercial
- * region set. A sweep that dies mid-flight strands tables in every region it
- * touched; this cleanup finishes the job the dead run could not.
+ * Delete orphaned test tables, per region, across the commercial region set. A
+ * sweep that dies mid-flight strands tables in every region it touched; this
+ * cleanup finishes the job the dead run could not.
  *
  * Idempotent and resumable: it selects from a fresh listing every time, so
  * running it twice is harmless and running it after a partial failure finishes
  * the job. Per region, so one unreachable region never blocks the others.
  *
- * The one thing it must never do is delete tables out from under a run still
- * in flight, so selection is age-based: a live run cannot outlive the OIDC
- * credentials it holds, so no legitimate `_conformance_` table can be older
- * than its run's credential ceiling. That ceiling is the largest
- * role-duration-seconds across the workflows - six hours, set by the GSI
- * lifecycle lane, whose backfills need it. The seven-hour default adds slack
- * on top of that hard bound; do not lower it below the credential ceiling,
- * and raise it whenever a lane raises role-duration-seconds past six hours.
+ * Two prefixes exist, one per identity, and each is swept on its own schedule.
+ * `_conformance_` is the CI role's namespace, torn down by prefix at the end
+ * of every run. `_capture_` is the local capture identity's, named
+ * `_capture_<yyyymmdd>_<short-code>_<name>` with the code unique per session
+ * and torn down by exact name when the session ends. That split is the whole
+ * point: a run's by-prefix cleanup can no longer delete an ad-hoc capture
+ * session's tables out from under it. So this script sweeps only the prefixes
+ * it is asked for, defaulting to `_conformance_` alone - widening the default
+ * would hand back the race the split just removed.
  *
- * Tables without the `_conformance_` prefix are never touched, in any region,
- * under any condition - the same contract the IAM role enforces.
+ * The one thing it must never do is delete tables out from under work still in
+ * flight, so selection is age-based. On the `_conformance_` side that age is a
+ * hard bound: a live run cannot outlive the OIDC credentials it holds, so no
+ * legitimate table can be older than its run's credential ceiling. That
+ * ceiling is the largest role-duration-seconds across the workflows - six
+ * hours, set by the GSI lifecycle lane, whose backfills need it. The
+ * seven-hour default adds slack on top; do not lower it below the credential
+ * ceiling, and raise it whenever a lane raises role-duration-seconds past six
+ * hours.
+ *
+ * Nothing binds a local capture session that way - it holds no OIDC
+ * credentials and can in principle run all day. Seven hours stays the gate for
+ * `_capture_` as a convention (no capture session should run that long), not
+ * as a derived bound, and the exact-name teardown at session end is the real
+ * cleanup. This sweep is only the backstop for a session that died first.
+ *
+ * A table carrying neither prefix is never touched, in any region, under any
+ * condition - the same contract the IAM roles enforce.
  *
  * Usage:
- *   node scripts/cleanup-orphans.mjs [--dry-run] [--max-age-hours N] [region ...]
+ *   node scripts/cleanup-orphans.mjs [--dry-run] [--max-age-hours N]
+ *                                    [--prefix P] [region ...]
  *
- * With no regions named it walks the full commercial set (src/regions.ts).
+ * `--prefix` repeats, or takes a comma-separated list, and accepts only the
+ * known prefixes. With no regions named it walks the full commercial set
+ * (src/regions.ts).
  */
 
 import {
@@ -35,19 +55,28 @@ import {
 } from '@aws-sdk/client-dynamodb'
 import { COMMERCIAL_REGIONS } from '../src/regions.ts'
 
-const TABLE_PREFIX = '_conformance_'
+/**
+ * Every prefix this cleanup may ever delete under. An allowlist rather than a
+ * free-text option: the script holds DeleteTable in every commercial region,
+ * so a typo'd or over-broad prefix is the one input that could turn it into an
+ * outage. A new prefix is a deliberate edit here, reviewed alongside the IAM
+ * grant that makes it deletable.
+ */
+export const KNOWN_PREFIXES = ['_conformance_', '_capture_']
+
+export const DEFAULT_PREFIXES = ['_conformance_']
 
 export const DEFAULT_MAX_AGE_HOURS = 7
 
 /**
  * Pure selection: the table names safe to delete. A table qualifies only when
- * it carries the `_conformance_` prefix AND is provably older than the
+ * it carries one of the prefixes being swept AND is provably older than the
  * threshold. A table whose age cannot be established is left alone - deleting
  * on missing evidence is how a cleanup becomes an outage.
  */
-export function selectOrphans(tables, { now = Date.now(), maxAgeMs }) {
+export function selectOrphans(tables, { now = Date.now(), maxAgeMs, prefixes = DEFAULT_PREFIXES }) {
   return tables
-    .filter((t) => typeof t.name === 'string' && t.name.startsWith(TABLE_PREFIX))
+    .filter((t) => typeof t.name === 'string' && prefixes.some((p) => t.name.startsWith(p)))
     .filter((t) => {
       const created = t.creationDateTime ? new Date(t.creationDateTime).getTime() : NaN
       return Number.isFinite(created) && now - created > maxAgeMs
@@ -73,7 +102,7 @@ export async function cleanupAll(regions, { cleanup }) {
   return { cleaned, failures }
 }
 
-async function cleanupRegion(region, { maxAgeMs, dryRun }) {
+async function cleanupRegion(region, { maxAgeMs, dryRun, prefixes }) {
   const client = new DynamoDBClient({ region })
   try {
     const names = []
@@ -82,7 +111,7 @@ async function cleanupRegion(region, { maxAgeMs, dryRun }) {
       const res = await client.send(
         new ListTablesCommand({ ExclusiveStartTableName: start }),
       )
-      names.push(...(res.TableNames ?? []).filter((n) => n.startsWith(TABLE_PREFIX)))
+      names.push(...(res.TableNames ?? []).filter((n) => prefixes.some((p) => n.startsWith(p))))
       start = res.LastEvaluatedTableName
     } while (start)
 
@@ -97,7 +126,7 @@ async function cleanupRegion(region, { maxAgeMs, dryRun }) {
       }
     }
 
-    const orphans = selectOrphans(tables, { maxAgeMs })
+    const orphans = selectOrphans(tables, { maxAgeMs, prefixes })
     const deleted = []
     const failed = []
     for (const name of orphans) {
@@ -122,7 +151,7 @@ async function cleanupRegion(region, { maxAgeMs, dryRun }) {
 }
 
 export function parseArgs(argv) {
-  const args = { regions: [], maxAgeHours: DEFAULT_MAX_AGE_HOURS, dryRun: false }
+  const args = { regions: [], prefixes: [], maxAgeHours: DEFAULT_MAX_AGE_HOURS, dryRun: false }
   for (let i = 0; i < argv.length; i++) {
     const a = argv[i]
     if (a === '--dry-run') args.dryRun = true
@@ -131,10 +160,23 @@ export function parseArgs(argv) {
       if (!Number.isFinite(args.maxAgeHours) || args.maxAgeHours <= 0) {
         throw new Error('--max-age-hours needs a positive number')
       }
+    } else if (a === '--prefix') {
+      const named = (argv[++i] ?? '')
+        .split(',')
+        .map((p) => p.trim())
+        .filter(Boolean)
+      if (named.length === 0) throw new Error('--prefix needs at least one prefix')
+      for (const prefix of named) {
+        if (!KNOWN_PREFIXES.includes(prefix)) {
+          throw new Error(`unknown prefix ${prefix}; expected one of ${KNOWN_PREFIXES.join(', ')}`)
+        }
+        if (!args.prefixes.includes(prefix)) args.prefixes.push(prefix)
+      }
     } else if (a.startsWith('--')) throw new Error(`unknown option ${a}`)
     else args.regions.push(a)
   }
   if (args.regions.length === 0) args.regions = [...COMMERCIAL_REGIONS]
+  if (args.prefixes.length === 0) args.prefixes = [...DEFAULT_PREFIXES]
   return args
 }
 
@@ -169,7 +211,8 @@ async function main() {
   const args = parseArgs(process.argv.slice(2))
   const maxAgeMs = args.maxAgeHours * 60 * 60 * 1000
   const { cleaned, failures } = await cleanupAll(args.regions, {
-    cleanup: (region) => cleanupRegion(region, { maxAgeMs, dryRun: args.dryRun }),
+    cleanup: (region) =>
+      cleanupRegion(region, { maxAgeMs, dryRun: args.dryRun, prefixes: args.prefixes }),
   })
 
   let strays = 0
@@ -187,8 +230,12 @@ async function main() {
   for (const { region, message } of failures) {
     console.error(`${region}: unreachable, skipped: ${message}`)
   }
+  // The prefixes are named in the summary because two cleanup runs a day now
+  // land in the same workflow's history, and the count alone cannot tell you
+  // which namespace a given run walked.
   console.log(
-    `${args.regions.length} region(s): ${strays} orphan(s) ${args.dryRun ? 'found' : 'deleted'}, ` +
+    `${args.prefixes.join(', ')} in ${args.regions.length} region(s): ` +
+      `${strays} orphan(s) ${args.dryRun ? 'found' : 'deleted'}, ` +
       `${stuck} undeletable, ${failures.length} region(s) unreachable`,
   )
   const verdict = exitVerdict({

--- a/scripts/cleanup-orphans.test.mjs
+++ b/scripts/cleanup-orphans.test.mjs
@@ -1,6 +1,8 @@
 import { describe, expect, it } from 'vitest'
 import {
   DEFAULT_MAX_AGE_HOURS,
+  DEFAULT_PREFIXES,
+  KNOWN_PREFIXES,
   exitVerdict,
   parseArgs,
   cleanupAll,
@@ -59,6 +61,46 @@ describe('selectOrphans', () => {
     ])
   })
 
+  it('sweeps only the prefixes it is asked for: a capture table survives a conformance sweep', () => {
+    // The whole point of the prefix split: the run's cleanup must not reach
+    // into the capture identity's namespace, however old the table looks.
+    const tables = [
+      table('_capture_20260812_wk1_dup', 100),
+      table('_conformance_stray_170000_5', 100),
+    ]
+    expect(selectOrphans(tables, { now: NOW, maxAgeMs })).toEqual([
+      '_conformance_stray_170000_5',
+    ])
+    expect(selectOrphans(tables, { now: NOW, maxAgeMs, prefixes: ['_capture_'] })).toEqual([
+      '_capture_20260812_wk1_dup',
+    ])
+  })
+
+  it('sweeps both namespaces when asked for both, and neither owns a foreign table', () => {
+    const tables = [
+      table('_capture_20260812_wk2_vidx', 100),
+      table('_conformance_stray_170000_5', 100),
+      table('production-users', 24 * 365),
+      table('capture_missing_underscore', 100),
+    ]
+    expect(selectOrphans(tables, { now: NOW, maxAgeMs, prefixes: KNOWN_PREFIXES })).toEqual([
+      '_capture_20260812_wk2_vidx',
+      '_conformance_stray_170000_5',
+    ])
+  })
+
+  it('age-gates the capture prefix on the same threshold, convention or not', () => {
+    // Seven hours is a hard bound for _conformance_ (the OIDC credential
+    // ceiling) and a convention for _capture_ (nothing stops a local session
+    // running longer). Selection does not care which: both are gated.
+    const young = [table('_capture_20260812_wk1_live', DEFAULT_MAX_AGE_HOURS - 1)]
+    expect(selectOrphans(young, { now: NOW, maxAgeMs, prefixes: ['_capture_'] })).toEqual([])
+    const old = [table('_capture_20260812_wk1_dead', DEFAULT_MAX_AGE_HOURS + 1)]
+    expect(selectOrphans(old, { now: NOW, maxAgeMs, prefixes: ['_capture_'] })).toEqual([
+      '_capture_20260812_wk1_dead',
+    ])
+  })
+
   it('leaves a table whose age cannot be established alone: no deletion on missing evidence', () => {
     const tables = [
       { name: '_conformance_undated_170000_6' },
@@ -89,16 +131,50 @@ describe('cleanupAll', () => {
 })
 
 describe('parseArgs', () => {
-  it('defaults to every commercial region and the default age threshold', () => {
+  it('defaults to every commercial region, the default age threshold, and _conformance_ alone', () => {
     const args = parseArgs([])
     expect(args.regions).toEqual([...COMMERCIAL_REGIONS])
     expect(args.maxAgeHours).toBe(DEFAULT_MAX_AGE_HOURS)
     expect(args.dryRun).toBe(false)
+    // A silently widening default would hand back the race the prefix split
+    // removed: an unasked-for sweep of the capture namespace.
+    expect(args.prefixes).toEqual(['_conformance_'])
+    expect(DEFAULT_PREFIXES).toEqual(['_conformance_'])
   })
 
   it('accepts a region subset, a threshold override, and dry-run', () => {
     const args = parseArgs(['--dry-run', '--max-age-hours', '6', 'eu-west-2', 'us-east-1'])
-    expect(args).toEqual({ regions: ['eu-west-2', 'us-east-1'], maxAgeHours: 6, dryRun: true })
+    expect(args).toEqual({
+      regions: ['eu-west-2', 'us-east-1'],
+      prefixes: ['_conformance_'],
+      maxAgeHours: 6,
+      dryRun: true,
+    })
+  })
+
+  it('takes a prefix repeated, comma-separated, or on its own', () => {
+    expect(parseArgs(['--prefix', '_capture_']).prefixes).toEqual(['_capture_'])
+    expect(parseArgs(['--prefix', '_capture_,_conformance_']).prefixes).toEqual([
+      '_capture_',
+      '_conformance_',
+    ])
+    expect(
+      parseArgs(['--prefix', '_conformance_', '--prefix', ' _capture_ ']).prefixes,
+    ).toEqual(['_conformance_', '_capture_'])
+  })
+
+  it('names a prefix once however often it is repeated', () => {
+    expect(parseArgs(['--prefix', '_capture_,_capture_', '--prefix', '_capture_']).prefixes)
+      .toEqual(['_capture_'])
+  })
+
+  it('rejects a prefix outside the allowlist rather than sweeping under it', () => {
+    // The script holds DeleteTable in every commercial region, so a typo must
+    // not become the prefix it deletes by.
+    expect(() => parseArgs(['--prefix', '_conformance'])).toThrow(/unknown prefix/)
+    expect(() => parseArgs(['--prefix', '_'])).toThrow(/unknown prefix/)
+    expect(() => parseArgs(['--prefix', ''])).toThrow(/at least one prefix/)
+    expect(() => parseArgs(['--prefix'])).toThrow(/at least one prefix/)
   })
 
   it('rejects a threshold that is not a positive number', () => {


### PR DESCRIPTION
## What this changes

The orphan sweep only ever selected `_conformance_` tables, so a local capture
session that died mid-flight stranded its tables indefinitely.
`scripts/cleanup-orphans.mjs` now takes a prefix list, and a new 4am cron sweeps
`_capture_` in a job of its own.

The prefix list comes from a small allowlist rather than free text. The script
holds DeleteTable in every commercial region, so a mistyped prefix is the one
input that could turn it into an outage. The default stays `_conformance_`
alone: widening it would reintroduce the race the prefix split exists to remove,
where a run's by-prefix cleanup deletes an ad-hoc capture session's tables
underneath it.

The capture sweep gets its own cron and its own job rather than a second prefix
on the existing 5.30 run, so a capture-side failure stays legible as one instead
of reddening the conformance cleanup.

The seven-hour age gate is unchanged and applies to both. On the conformance
side it derives from the OIDC credential ceiling, which is a hard bound. Nothing
binds a local capture session that way, so there it is a convention (no capture
session should run that long) rather than a derived limit, and the exact-name
teardown at session end is the real cleanup. That caveat is recorded in the
script header, along with the `_capture_<yyyymmdd>_<short-code>_<name>` naming.

The CI role's policy has been extended with DescribeTable and DeleteTable on the
capture prefix. ListTables was already account-level, and nothing else was
needed.

Verified: the tooling suite passes (528 tests, nine of them new, covering prefix
selection and the argument parsing), typecheck is clean, and actionlint reports
no new findings on the workflow. Both prefixes were dry-run against real
DynamoDB in eu-west-2, walked cleanly and deleted nothing.

## Checklist

- ~~New or modified tests run against real AWS DynamoDB and pass~~ - no suite
  tests changed. The cleanup script itself was dry-run against real DynamoDB in
  eu-west-2 on both prefixes.
- ~~New or modified tests run against at least one emulator target and behave as
  expected~~ - tooling change, no emulator involved.
- [x] Linked issue or a short note explaining the motivation
- [x] I agree my contribution is licensed under the project's terms
  (Apache License, Version 2.0)

Closes #140
