### PR TITLE
fix(ci): sanitise results before the leak check, not only in the AWS lanes

### DIFF
--- a/.github/workflows/results-table.yml
+++ b/.github/workflows/results-table.yml
@@ -170,10 +170,19 @@ jobs:
           node scripts/strip-lane-detail.mjs \
             results/dynamodb.integrations.json results/dynamodb.gsi.json
 
-      # The sanitiser rewrites account IDs inside ARNs and IAM principals; this
-      # is the check that it worked. It was written for exactly this path and
-      # had never been wired to anything, so nothing verified the sanitising
-      # before these files were committed.
+      # Only the real-AWS lanes sanitise before upload, because only they can
+      # carry an account ID. Vitest absolutises every test path against the
+      # checkout it ran in regardless, so every emulator artefact arrives
+      # carrying the runner's `/home/runner/work/...` prefix. Sanitising here
+      # covers all of them on the one path that commits, whatever each lane
+      # uploaded.
+      - name: Sanitize account IDs and machine paths
+        run: node scripts/sanitize-arns.mjs
+
+      # The check that the step above did its job, on the exact files about to
+      # be committed. It was written for this path and had never been wired to
+      # anything, so nothing verified the sanitising before these files were
+      # committed.
       - name: Refuse to commit a leaked account ID
         run: node scripts/check-account-ids.mjs
 


### PR DESCRIPTION
## What this changes

The results-table job overlays each lane's artefacts and then refuses to commit
anything carrying an account ID or a machine path. Only the real-AWS lanes
sanitise before upload, because only they can carry an account ID, so every
emulator artefact arrives with the runner's checkout prefix on each of its test
paths and the job dies at the guard. This adds the sanitising step to the one
path that commits, so it covers every lane whatever shape that lane uploaded in.

The guard was wired up for the first time in 3.0.0, alongside the machine-path
rule in both the sanitiser and the checker, so the first results-table run after
that release was the first to meet it. It failed with eight files flagged, one
per emulator target, which is why 3.0.0's results have not published. The
committed results are clean because the release's captures were sanitised before
they were committed; nothing on the CI path did the same.

Verified by replaying the failing run's own artefacts through both scripts: the
checker fails on the raw download and passes across all 110 files after one
sanitise pass, including the account ID flagged in `extenddb.json`. The
sanitiser and the checker match on the same two account-ID patterns, so a file
that satisfies one cannot trip the other.

## Checklist

- ~~New or modified tests run against real AWS DynamoDB and pass~~ - CI-only
  change, no suite tests touched.
- ~~New or modified tests run against at least one emulator target and behave as
  expected~~ - as above. Verified instead by replaying the failing run's
  artefacts through the sanitiser and the guard.
- [x] Linked issue or a short note explaining the motivation
- [x] I agree my contribution is licensed under the project's terms
  (Apache License, Version 2.0)
