### PR TITLE
docs: reshape the results table and an editorial pass over the README

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,365 +5,141 @@ broadened, and targets brought into the run. Newest first.
 
 ## 2026-08-12 (3.0.0)
 
-**Read this first if you consume the JSON.** The data endpoints go from schema
-2 to schema 4 in this one release. Schema 3 was never published on its own, so
-there is no intermediate version to have been running: everything on 2 crosses
-both steps at once. Schema 3 is breaking in four ways and they are listed under
-"Everything else that was a percentage follows the headline down" below. Schema
-4 is additive on top of it. The one that fails silently is `movement.state`,
-whose values changed from `up`/`down` to `improved`/`regressed` - the old names
-still parse and now mean the opposite direction. `movement.delta` inverts the
-same way without changing shape: it was computed from correctness and is now
-computed from divergence, so the sign of a delta means the opposite of what it
-did and nothing in the data says so.
+**Read this first if you consume the JSON.** The data endpoints go from schema 2
+to schema 4 in one step. Schema 3 was never published on its own, so everything
+on 2 crosses both steps at once. Schema 3 breaks in four ways:
 
-Every target now wears a letter grade, read from the two published figures.
-Divergence sets the letter - A under 5%, B under 15%, C under 25%, D under 35%,
-F beyond - and coverage can only lower it, never raise it: a third of whatever
-a target leaves unimplemented is added to its divergence before the bands are
-read, so a target implementing the whole suite is graded on divergence alone.
-A+ is exactly zero divergence at full coverage, and nothing on the board holds
-it. No measurement changed. The 5% and 25% boundaries carry over the numbers of
-the colour bands the board has always published, though those sat on
-correctness and these sit on divergence, so the same numbers cut a different
-line at anything below full coverage; 15%, 35% and the coverage weight are new.
-The criteria are versioned (v1) and dated in the methodology, because where a
-threshold sits is a hand-picked input to a letter and moving one regrades
-targets whose results never changed.
+- `movement.state` values changed from `up`/`down` to `improved`/`regressed`.
+  **This is the one that fails silently:** the old names still parse, and now
+  mean the opposite direction.
+- `movement.delta` keeps its shape but is computed from divergence rather than
+  correctness, so the sign of a delta means the opposite of what it did.
+- A tier no longer carries `pct` and `value`. It carries `divergence`,
+  `coverage` and `correctness`, each with a `pct` and a `value` of its own.
+- The whole-suite correctness percentage is `correctness`, not `total`. `total`
+  also names the raw test count inside `counts`, so the same word meant a count
+  in one place and a percentage in another.
 
-The coverage weight rolls rather than stepping. An earlier draft of these
-criteria capped in three jumps, at 90%, 70% and 50% covered, and between two
-steps a target could decline the operations it failed, cross a band, and never
-come near the step that would have held it. Pricing every withdrawal instead of
-three of them removes that cliff. It does not make withdrawal unprofitable: the
-effective figure still falls by two thirds of whatever is withdrawn, so a
-target that declines what it fails still gains, it just pays more. Only
-weighting a declined test exactly as heavily as a failed one would remove the
-gain, and that distinction is what the board is built on. Rank on the two
-figures rather than the letter if it matters to you.
+Schema 4 is additive on top: each target carries its grade and the full criteria
+in `metrics.grade`, every envelope gains `baseline.observation` (how much of the
+suite the live-AWS row stands on, which passes reported, and what is carried),
+`latest.json` and `runs.json` gain `divergence`, `project`, `configuration` and
+`isVariant`, `results/summary.json` gains `regionFailures`, and `/data/index.json`
+lists the split registry.
 
-- Dynoxide reads `A` where it read `0.0% diverges, 98.6% covered` - both
-  figures stay printed beside the letter. It diverges nowhere, and the
-  1.4-point coverage gap is what denies it A+. Its WebAssembly build reads `A`
-  on the same zero divergence over 86.7% coverage, so neither reaches A+
-  without running everything. Two rows sit lower than the
-  stepped draft would have put them: Dynoxide, which is the board author's own,
-  and Dynalite, which is not.
-- Real DynamoDB reads `baseline`, not a letter. A grade measures how far a
-  target sits from real DynamoDB, so grading the yardstick against itself would
-  seat it in a band an engine had to earn its way into. Its two figures still
-  publish.
-- A row says where coverage is holding its letter, whether or not it had to
-  lower one. Dynalite diverges 12.3%, which is the B band on its own, over
-  80.0% coverage, and the third of that shortfall reads it up to an effective
-  19.0 and grades it `C`. Without the clause a capped row looks identical to
-  one with room above it, and a reader comparing Dynalite's **C** with
-  LocalStack's **C** could not see that only one of the two is boxed in.
-- `maintainedByAuthor` now reads `true` for `dynoxide-wasm`. It is keyed on the
-  project rather than the exact slug, because a build of a self-maintained
-  engine is the same conflict of interest as the engine. The flag was
-  understating the disclosure, so this widens it.
-- The per-target badges show the grade under a `parity` label. They had still
-  been publishing the correctness percentage the board retired, under a
-  `conformance` label, so a badge could disagree with the table it cited. The
-  endpoint URL is unchanged and is now documented on the agent guide, which is
-  where a badge's only version channel lives: shields pins its own
-  `schemaVersion` to 1, so the path is all there is.
-- The README table gains a Grade column, and the data endpoints (schema 4)
-  carry each target's grade plus the full criteria in `metrics.grade`. Each
-  grade carries `capAt`, the ceiling a letter is sitting at, alongside the
-  `capped` flag that says whether reaching it moved the letter. `capAt` is that
-  letter whenever `capped` is true and null otherwise: test one, read the other.
-- Every endpoint's envelope gains `baseline.observation`: how much of the suite
-  the live-AWS row is actually standing on, which of the three real-AWS passes
-  have reported and when, and how many tests are carried rather than
-  re-observed. The pages have always disclosed this; without it in the JSON a
-  consumer could not tell a fully measured baseline from a pinned one.
-- `/data/index.json` lists the split registry alongside the other endpoints.
-  It is what a zero-divergence row's out-of-region failures are checked
-  against, so anyone recomputing a grade needs it to check the same premise the
-  build does.
-- The board leads with the highest-graded engine, because the baseline moved
-  out of the standings and into a panel above them. Today that puts the
-  board author's own engine in the top card, with the conflict-of-interest
-  disclosure on the card itself.
-- `results/summary.json` gains `regionFailures`: for a target that diverges
-  nowhere in its headline region, the tests it fails elsewhere, by name. The
-  site build reads them against the split registry to check the top grade's
-  premise by identity rather than by count. Additive, and `schemaVersion` stays
-  1, so an existing reader is unaffected.
-- The baseline row is measured rather than pinned once real AWS has been
-  observed across the whole suite. It runs in three passes and only the main
-  one reached the published artefact, so the row claimed 998 of 998 on a run
-  that recorded 981. The passes are merged before scoring now, each with its own
+### A score is two figures, never one
+
+Divergence is the share of the whole suite a target answers differently from real
+DynamoDB. Coverage is the share it implements at all. They are reported apart and
+never summed, because a declined operation is discoverable in minutes and a wrong
+one in production. No target was re-run for the change and no pass, fail or skip
+moved: what changed is how the same counts are expressed.
+
+Everything else that was a percentage followed the headline down - tier figures,
+the per-region drilldown, the per-operation table, and the colour bands, which
+inverted with them. A target's history is two plots rather than one, because
+divergence falls when a target stops attempting something it used to get wrong,
+so a divergence line alone can render a withdrawal as an improvement.
+
+### Every target wears a letter
+
+Divergence sets it - A under 5%, B under 15%, C under 25%, D under 35%, F beyond
+- and coverage can only lower it, never raise it: a third of whatever a target
+leaves unimplemented is added to its divergence before the bands are read. A+ is
+exactly zero divergence at full coverage. A row says when coverage is holding its
+letter down, so a capped row is not mistaken for one with room above it. Real
+DynamoDB reads `baseline` rather than a letter, because grading the yardstick
+against itself would seat it in a band an engine had to earn its way into.
+
+These are grading criteria version 1, dated in the
+[methodology](https://paritysuite.org/methodology#grading), which carries the
+derivation. Where a threshold sits is a hand-picked input to a published letter,
+and moving one regrades targets whose results never changed, so any change to a
+band, the coverage weight or the A+ gate bumps the version.
+
+### The suite grows from 998 tests to 1054
+
+**Vector search (#125).** 42 tests over the deterministic surface DynamoDB
+shipped in August 2026: the index lifecycle on both creation paths, request
+validation on each plane, rejection wording, write-path validation, search on a
+fixture where the nearest neighbour is unambiguous, the two new capacity shapes,
+and PartiQL's inability to reach a vector index. Every pinned value was
+characterised against real DynamoDB in eu-west-2 before it was asserted. Two
+findings worth naming: searching during a backfill is an error whatever AWS's own
+documentation says, and an overwrite leaving the stored vector unchanged reports
+no vector write capacity at all, because index replication is delta-based. No
+emulator implements the family yet, so every target skips it and every coverage
+figure drops with this release while divergence is untouched. Sending the new
+operations needs `@aws-sdk/client-dynamodb` 3.1103.0 or later.
+
+**Index write costs (#124).** 14 tests. The suite's only per-index capacity
+assertion was on a Query, so the write side - the half you get billed extra for -
+went unmeasured. A sub-1KB write costs one unit for the table and one for each
+index it lands in, and LSI units fold into the total exactly as GSI units do.
+Moving an item to a new GSI key costs two on that index, a delete and an insert;
+touching a projected attribute costs one; touching a non-projected attribute
+costs nothing, and the response carries no arm for that index rather than a zero.
+An overwrite that leaves the item unchanged reports no index cost whatsoever.
+
+**The index exclusions create no indexed table (#116).** `!gsi and !lsi` used to
+select the right tests and then build the tables anyway, so an engine with no
+secondary-index support died in setup whatever it had asked for. Shared tables
+are created on demand from what the running file declared, the composite table
+split into indexed and plain variants, and three guards keep the declarations and
+the tags honest.
+
+### Corrections
+
+- **The suite counts its own tests.** "The whole suite" had meant whichever
+  target ran the most tests, so one of the measured things was setting the
+  denominator every figure divided by. `registry/suite-manifest.json` lists every
+  test by file and full name, generated from the suite rather than inferred from
+  a run, and CI fails if it drifts. Publishing now refuses a row whose test
+  population disagrees with it, which catches a results file carried across a
+  rename that keeps its old total while naming tests that no longer exist.
+- **Every figure on a row comes from one region.** A headline came from the
+  target's best-matching region while its tier split and raw counts stayed on the
+  baseline region's basis. Correctness never had to reconcile, because each tier
+  had its own denominator; divergence is additive, so it does.
+- **The per-region overlay is matched to the run it describes**, rather than
+  keyed on the date real AWS was last swept, which had put a later run's figures
+  on an earlier run's page.
+- **A methodology claim was wrong.** The page said that measuring divergence over
+  the whole suite stops an engine implementing a sliver from posting a perfect
+  score. It doesn't: zero fails is 0.0% divergence at any coverage. What does hold
+  is the identity the page now states - a test going from failing to skipped
+  leaves both numerators together over the same denominator, so withdrawal costs
+  exactly as much coverage as it gains divergence, and is disclosed rather than
+  silent.
+- **The baseline row is measured rather than pinned** once real AWS has been
+  observed across the whole suite. It runs in three passes and only the main one
+  reached the published artefact, so the row had claimed a full suite on a run
+  that recorded less. The passes are merged before scoring, each with its own
   capture date, and the row stays pinned and says so until all three report.
-- The A+ premise is checked in the site build rather than beside it. It lived
-  in a test suite no publishing path depended on, while the methodology called
-  it a build-time guard.
-- The grading criteria's effective date comes from one constant. Five surfaces
-  stated it in prose, and the feed reads it to decide which runs may carry a
-  letter, so a page disagreeing with it would date history differently from the
-  way the feed treats it.
-- A movement reads `4.9pp less` where it read `-4.9pp`. A down arrow beside a
-  negative number said the direction twice and whether it was good not at all,
-  which on an inverted metric is the wrong way round.
-- Every heading on the prose pages carries an id, so any section can be linked
-  to directly. The two anchors that were already hand-written keep their
-  published slugs.
-- A badge whose target is still on the board but has no results this run reads
-  `no data` rather than disappearing. The URL sits in other people's READMEs,
-  where a 404 reads as the project having vanished.
-- The Atom feed carries no letter on any run measured before criteria version 1
-  took effect, which today is every run in it. The feed had been rewriting each
-  entry's summary with a grade the run never had, while leaving `<updated>`
-  alone so no subscriber re-notified: the one artefact built to be archived by
-  other people was restating its own history quietly. Expect the letters to
-  start appearing from the first run measured after the criteria date. An
-  ungraded entry says so in its summary and carries
-  `<category term="ungraded"/>`, because a feed is read one entry at a time and
-  a missing clause is otherwise indistinguishable from a field that failed to
-  populate.
-
-The board publishes two figures now instead of one, and the index exclusions
-started meaning what they said. No target was re-run for this and no
-pass, fail or skip changed: what moved is how the same counts are expressed, so
-a figure that looks different here is the same measurement described more
-honestly. Divergence puts skips in the denominator where correctness left them out, so
-the two metrics can order the board differently where one target declines much
-more than another. On this run they do not: every row sits where correctness
-would have put it.
-
-**A score is now divergence and coverage, never one number.** Divergence is
-the share of the whole suite a target answers differently from real DynamoDB.
-Coverage is the share it implements at all. They are reported apart because a
-skip and a fail are different problems: an operation a target declines is
-something you find in minutes and plan around, and one it gets quietly wrong is
-something you find in production. Summing them would price them the same.
-
-- The standings are ordered by divergence. That ranks how much a target gets
-  wrong; it is not a verdict on which emulator to pick, which depends on the
-  operations you need. A target with no divergences over a narrow surface sits
-  high, and its coverage figure says how narrow.
-- Dynoxide reads `0.0% diverges, 98.6% covered` where it used to read `100%`.
-  Ministack reads `11.2% diverges, 100.0% covered` where it used to read
-  `88.8%`. Neither engine changed.
-- The Region column is gone. It named the cohort a target matched at its best
-  rate, which read as breadth: a target equally wrong in every region showed
-  `all regions` while one perfect in 6 showed `6 regions`, even though the
-  second diverges less in its worst region than the first does in its best.
-  Regional disagreement moves a figure by at most 0.3 points, across three
-  tests of about a thousand, so the detail sits in `results/summary.json` and
-  on each target's page instead.
-- Movement follows divergence, where lower is better. The states are
-  `improved` and `regressed` rather than `up` and `down`, because a rise is now
-  the bad direction and the old names would have coloured a regression green.
-  **Anything reading `movement.state` from the JSON needs updating.**
-- `latest.json` and `runs.json` gain `divergence`, and `project`,
-  `configuration` and `isVariant` so a consumer can tell a build of an engine
-  from a rival without parsing display names. The raw counts stay beside every
-  figure, so anyone preferring their own arithmetic has it.
-- A build of an engine nests under it rather than taking a row beside it. You
-  choose between projects; which build you want follows from where your code
-  runs. Dynoxide (wasm) keeps its own figures, its own page and its own link.
-- Each target lists how it is actually distributed - Docker, npx, cargo, a JAR
-  and so on - with the project's own page for each. These are the only claims
-  on the board the suite does not measure, so each one carries the link that
-  backs it.
-
-**Everything else that was a percentage follows the headline down.** The
-headline changed first and the rest of the page did not, so a target's page ran
-in two directions at once: a falling divergence figure above a rising
-correctness chart, with nothing saying they were different measurements.
-
-- Tier figures are divergence within each tier - that tier's fails over its
-  whole size - with coverage beside them. Dynalite's Tier 2 reads `14.1%
-  diverges, 20.1% covered` where it read `30.0%`; the engine is unchanged, and
-  the second pair says the thing the single figure hid, which is that Dynalite
-  attempts a fifth of Tier 2. Correctness is still there under its own name.
-- The colour bands inverted with the figures. A tier bar was green at 95% and
-  above; left alone, a target diverging on 2% of a tier would have rendered
-  red. Bar length is that tier's coverage and its colour is that tier's
-  divergence, the same encoding the standings row already used.
-- A target's history is two plots now, divergence and coverage, where it was
-  one chart headed "Conformance over time". Both are needed because divergence
-  falls when a target stops attempting an operation it used to get wrong, so a
-  divergence line alone can show an improvement that is really a withdrawal.
-  Dynalite is the live case: 88 failing tests became skips on 24 July, dropping
-  its divergence 8.8 points and its coverage 8.8 points in the same run, and the
-  single plot rendered that as the engine getting markedly better. This is the same reason the board
-  publishes two figures instead of summing them, applied to the time axis.
-- Each plot keeps its own orientation, so a regression always moves away from
-  the pinned edge: divergence pins zero to the bottom axis and rises for a
-  regression, coverage pins 100 to the top and falls for one. Neither is
-  squashed onto a shared axis with the other, and each names its own sense
-  down the side of the plot, because a reader can't be expected to assume which
-  way is good for either. The caption reads off the worst run for that metric -
-  the highest divergence, the lowest coverage - which stopped being the same
-  run once the headline changed.
-- The old heading was wrong as well as incomplete. A line sitting at 0% under
-  "Conformance over time" invites reading as no conformance at all, when 0%
-  divergence is the best result there is.
-- The per-region drilldown is divergence too, ordered best first. Best first
-  means lowest first now, so a descending sort would have put a target's worst
-  regions at the top under a heading that reads as its best.
-- Each tier states its coverage as a figure, not only as the length of its bar.
-  Divergence is paired with a number everywhere else it is published, and a
-  tier whose coverage lived solely in a bar was the one place a thin surface
-  stopped being stated: Dynalite's Tier 2 diverges on 14.1%, which reads
-  unremarkable until you know it attempts a fifth of the tier.
-- The per-operation table on a target page is divergence and coverage too, with
-  the counts as fails over each operation's whole size. It was a pass rate over
-  what the operation attempted, which left the most detailed table on the page
-  running opposite to every figure above it.
-- **These are schema 3's four breaking changes, and every consumer was on
-  schema 2, so all four land at once.** A tier no
-  longer carries `pct` and `value`; it carries `divergence`, `coverage` and
-  `correctness`, each with a `pct` and a `value` of its own. The whole-suite
-  correctness percentage is `correctness`, not `total`: `total` also names the
-  raw test count inside `counts`, so the same word meant a count in one place
-  and a percentage in another. Anything reading a tier's `pct`, or `total` as a
-  percentage, has to be updated - read as-is, both now invert or vanish. The
-  last two are `movement.state` and `movement.delta`, whose values are named
-  above; they are listed here too so a consumer counting the breaks against the
-  version gets all of them in one place. They are the dangerous ones, because
-  `up` and `down` still parse and a delta keeps its shape, and both now mean the
-  opposite thing.
-
-**A headline says how many regions it came from.** Each target is scored
-against every observed region and headlines its best-matching cohort, and the
-size of that cohort only appeared on the target's own page. A figure earned
-across six regions and one earned across every region rendered identically.
-
-- The board and the targets index show the count beside the figure - `6 of 32
-  regions` - for the same reason coverage sits beside divergence: the number
-  that qualifies a headline belongs with it, not a click away. The full cohort
-  listing stays on the target page, where a reader has asked for that detail.
-
-**A methodology claim was wrong, and is corrected.** The page said that
-measuring divergence over the whole suite stops an emulator implementing a
-sliver from posting a perfect score on a thin surface. It doesn't: zero fails
-is 0.0% at any coverage, and the Dynoxide WebAssembly build is a live
-counterexample at 0.0% over 86.7%. A second formulation - that whole-suite
-measurement stops a target lowering its divergence by attempting less - was
-false too, so the page now states the identity that does hold rather than
-claiming an immunity the arithmetic never gave. A test going from failing to
-skipped leaves the divergence numerator and the coverage numerator together over
-the same unchanged denominator, so both figures fall by exactly the same amount.
-Withdrawal is disclosed rather than silent: it costs precisely as much coverage
-as it gains divergence. Dynalite is the live case. On 24 July, 88 of its failing
-tests became skips, nothing was fixed, and its divergence and coverage each fell
-8.8 points - both of them exactly 88/998. The correctness figure this replaced
-rose 8.4 points on that same act, because those 88 tests left its denominator as
-well as its numerator and no second figure remained to record it.
-
-**Every figure on a row now comes from one region.** A target's headline is its
-best-matching region, but only the headline was taken from that region: the tier
-split and the raw counts stayed on the baseline region's basis. Under correctness
-that never had to reconcile, because each tier had its own denominator.
-Divergence is additive, so it does: the tiers stopped decomposing the headline,
-`failed / total` from a row's own published counts stopped equalling its
-published divergence, and this table disagreed with the board about three
-targets' Tier 3 figures. The whole region entry is applied now, and the region is
-named on the row and in the JSON.
-
-- The overlay is also matched to the run it describes. It was keyed on the date
-  real AWS was last swept, while each target entry inside carries its own run
-  date, so a summary committed after a later run put that later run's figures on
-  an earlier run's page. Four rows on the 22 July run published a divergence from
-  the 24 July run: Dynalite read 12.3% beside its own count of 213 fails in 998.
-  Those four rows now read what that run measured - Dynalite 21.3%, ExtendDB
-  15.3%, Dynoxide 5.2%, DynamoDB Local 16.8% - and 22 other rows' fail counts
-  move by one or two, to the headline region's count. No target was re-run for
-  any of it.
-- Coverage is unaffected, and can't be affected: scoring a target against a
-  region only ever turns a pass into a fail or back, so what a target implements
-  is the same in every region. Divergence is the figure a region decides, which
-  is why it is the one the headline region governs.
-
-**The suite counts its own tests.** Divergence and coverage both divide by the
-whole suite, and until now "the whole suite" meant whichever target had run the
-most tests. One of the measured things was setting the denominator every other
-figure used. `registry/suite-manifest.json` lists all 1054 by file and full
-name, generated from the suite rather than inferred from a run, and CI fails if
-it drifts from the tests. Publishing now refuses a row whose count or whose test
-population disagrees with it, which is a stronger check than the count alone: a
-results file carried across a rename keeps its old total while naming tests that
-no longer exist. Dynoxide's WebAssembly row was doing exactly that, 35 tests out
-of date at the right total, and is re-measured.
-
-- The WebAssembly engine runs in CI like every other target. It was the only one
-  reachable by neither a container image nor an npm binary, so its row was
-  refreshed by hand and had sat three weeks stale. It builds from a Dynoxide
-  release the way ExtendDB builds from source.
+- **The Atom feed carries no letter on any run measured before criteria version 1
+  took effect.** It had been rewriting each entry's summary with a grade the run
+  never had, while leaving `<updated>` alone so no subscriber re-notified.
+- **Badges publish the grade** under a `parity` label, having still been
+  publishing the correctness percentage the board retired under a `conformance`
+  label. The endpoint URL is unchanged; a badge whose target has no results this
+  run reads `no data` rather than disappearing, because the URL sits in other
+  people's READMEs.
 - Two more regional splits are admitted, both `BatchGetItem` with an empty
-  `RequestItems` map. Five regions answer with the validation framework's
-  generic constraint message where 27 keep the bespoke sentence. The
-  nesting-depth row was rewritten from a full 32-region capture: it had been
-  written from four regions, so seven strict regions were recorded as one, and
-  the pinned wording had drifted without moving a verdict.
-
-**Vector search coverage lands with the release (#125).** DynamoDB shipped
-vector search in August 2026 and the suite now covers its deterministic
-surface: 42 new tests taking the suite from 998 to 1040. The family spans the
-index lifecycle on both creation paths, request validation on the control and
-data planes, exact rejection wording, write-path validation (including the
-write that silently misses the index when its SearchSchema HASH attribute is
-absent), search itself on a fixture where the nearest neighbour is
-unambiguous, the two new capacity shapes, and PartiQL's inability to reach a
-vector index. Every pinned value was characterised against real DynamoDB in
-eu-west-2 before it was asserted. Two findings worth naming: AWS's own
-documentation disagrees with itself on what happens when you search during
-backfill - the answer is an error (`Cannot search backfilling vector index`),
-and DescribeTable can report the index ready a beat before the search plane
-agrees - and an overwrite that leaves the stored vector unchanged reports no
-vector write capacity at all, because index replication is delta-based.
-
-**No emulator implements vector search yet, and the columns say so.** Every
-target skips the family through its support probes, so every emulator's
-coverage figure drops with this release while divergence is untouched. The
-probes are split per plane, so a target that adopts half the surface is
-scored on the half it actually does; DynamoDB Local today accepts
-`VectorIndexes` on CreateTable and silently drops them, which the
-control-plane probe's DescribeTable reflection check records as scope rather
-than divergence. The UpdateTable half of the lifecycle backfills on GSI
-timescales (~17 minutes observed for 25 items) and rides in the GSI lane.
-Sending the new operations needs `@aws-sdk/client-dynamodb` 3.1103.0 or
-later.
-
-**Writes into indexed tables now have their capacity pinned (#124).** Until
-now the suite's only per-index capacity assertion was on a Query, so the
-write side - the half you actually get billed extra for - went unmeasured.
-Fourteen new tier1 tests fix that, taking the suite from 1040 to 1054, with
-every number measured in eu-west-2 rather than lifted from the docs. A
-sub-1KB write costs one unit for the table and one for each index it lands
-in, and LSI units fold into the total just like GSI units do. Moving an item
-to a new GSI key costs two on that index (a delete and an insert), touching
-a projected attribute costs one, and touching a non-projected attribute
-costs nothing - in which case the response has no arm for that index at all,
-rather than a zero. The oddest finding: an overwrite that leaves the item
-unchanged reports no index cost whatsoever. Index replication is delta-based,
-just as the vector indexes above turned out to be.
-
-**The index exclusions create no indexed table (#116).** `!gsi and !lsi` used
-to select the right tests and then build the tables anyway, because
-provisioning ran over a fixed list before any filter applied. An engine with no
-secondary-index support died in setup whatever it had asked for.
-
-- Shared tables are created on demand: a test file declares what it needs, and
-  setup creates only what the running file declared. A tag filter skips tests
-  but still imports the file, so scoping declarations to the file is what makes
-  the exclusion real.
-- The shared composite table split. The plain name carries no index; a second
-  variant carries the same LSIs and GSIs under their existing names. Tests
-  depending on an index moved into files of their own, so a file's declaration
-  says whether it needs one.
-- The `gsi` and `lsi` tags now mark index dependency wherever it occurs,
-  including the tests that never name an index and are only rejected because
-  the attribute they write is an index key. Both columns grow. No score moves;
-  tags never fed it.
-- Three guards: a file must declare the shared tables it uses, a test writing
-  an index-key attribute must carry an index tag, and a file using the
-  index-bearing table must carry both.
+  `RequestItems` map. The nesting-depth row was rewritten from a full 32-region
+  capture, having been written from four.
+- A build of an engine nests under it rather than taking a row beside it, and
+  `maintainedByAuthor` is keyed on the project, so it now reads `true` for the
+  WebAssembly build. That build runs in CI like every other target, where its row
+  had been refreshed by hand.
+- The board leads with the highest-graded engine, since the baseline moved into a
+  panel above the standings. Where that is the board author's own engine, the
+  conflict-of-interest disclosure sits on the card.
+- The Region column is gone. It named the cohort a target matched at its best
+  rate, which read as breadth. The count sits beside the figure instead, and the
+  cohort listing stays on the target page.
+- Each target lists how it is actually distributed, with the project's own page
+  for each. These are the only claims on the board the suite does not measure, so
+  each carries the link that backs it.
 
 ## 2026-07-21 (2.1.0)
 

--- a/README.md
+++ b/README.md
@@ -94,11 +94,34 @@ from the Actions tab. It fills each row's Version from the run (npm version,
 container image digest, release tag, or `live` for real AWS). Run
 `npm run results:table` to preview it locally.
 
+## Independence
+
+This suite is maintained by the same person who maintains Dynoxide, one of the
+engines it scores. Dynoxide runs through the same automated matrix as every
+other target, against the same live-AWS ground truth, and the tests and the
+results are both in this repo.
+
+Two inputs are hand-picked rather than measured. The grade bands and the
+coverage weight decide a published letter, and moving either regrades targets
+whose results never changed, so they carry a version: these are grading criteria
+version 1, and any change to a band, the coverage weight or the A+ gate bumps
+the version and is dated in the
+[methodology](https://paritysuite.org/methodology#grading).
+
+`registry/splits.json` is the other, and it is written by hand by design. It
+records the behaviours where real DynamoDB's own regions disagree, with the
+evidence each region returned, and a target matching any recorded answer is
+scored as conformant rather than wrong. Admitting a row turns a fail into a pass
+with no re-run and no results file changing, which is the one thing "a score
+can't be tuned without changing the published results first" does not cover. So
+the registry is in this repo, every row carries its captured evidence and the
+date it was refreshed, and a behaviour enters only once confirmed across regions.
+
 ## Tiers
 
 **Tier 1 - Core.** The operations and behaviours that 90% of DynamoDB users rely on. CRUD, queries, scans, batch operations, GSIs, UpdateTable. If an emulator fails Tier 1, it's not usable.
 
-**Tier 2 - Complete.** Less common but documented features. Transactions, PartiQL, LSIs, TTL, streams, tags. An emulator that passes Tier 1 but fails some Tier 2 is usable with caveats.
+**Tier 2 - Complete.** Less common but documented features. Transactions, PartiQL, LSIs, TTL, streams, tags, vector search. An emulator that passes Tier 1 but fails some Tier 2 is usable with caveats.
 
 **Tier 3 - Strict.** Validation ordering, error behaviour at a range of strictness (exact where DynamoDB's wording is stable, structural where its rendering is non-deterministic), edge cases around limits, legacy API compatibility (ScanFilter, QueryFilter). An emulator that passes Tier 1 and Tier 2 but fails some Tier 3 is production-quality for local dev.
 
@@ -114,6 +137,76 @@ Tier 3 splits into four sub-directories by what each test asserts:
 - `legacy-api/` - the older request shapes (`AttributeUpdates`, `QueryFilter`, `ScanFilter`, `Expected`, `AttributesToGet`) for backwards compatibility.
 
 A new test goes in whichever sub-directory matches what it asserts. If you care about the message the service returns, that's `error-messages/`. If you only care which error fires, that's `validation-ordering/`.
+
+## Operations covered
+
+| Operation | Tier 1 | Tier 2 | Tier 3 |
+|-----------|--------|--------|--------|
+| PutItem | basic, conditions (incl. parens), validation, expressions, dataTypes, consumedCapacity, indexConsumedCapacity (GSI/LSI write cost) | vector write validation, vector write capacity | error messages |
+| GetItem | basic, validation, projection, consumedCapacity | | error messages |
+| UpdateItem | basic, conditions (incl. parens, non-existent key branch), validation, paths, index write-capacity ladder | | error messages |
+| DeleteItem | basic, conditions (incl. parens), validation, index write capacity | | error messages |
+| Query | basic, GSI, LSI, expressions (incl. KeyCondition + Filter parens), select, numericKeys, binaryKeys, pagination | | error messages, validation ordering |
+| Scan | basic, validation, GSI (incl. pagination), LSI (incl. pagination), parallel, select, filterOperators, filterExpression parens | | error messages, validation ordering |
+| BatchWriteItem | basic, validation, index write capacity | | error messages |
+| BatchGetItem | basic, validation | | error messages |
+| CreateTable | basic, GSI, LSI | vector indexes (lifecycle, SearchSchema, validation) | error messages, validation ordering |
+| DeleteTable | basic | | |
+| DescribeTable | basic | | |
+| ListTables | basic | | |
+| UpdateTable | basic (throughput, billing mode) | GSI lifecycle, vector index lifecycle | |
+| SearchVectors | | scores per distance function, projection, capacity shape, request validation | error messages |
+| TransactWriteItems | | basic, conditions (incl. parens, non-existent key branch), idempotency, cancellation | error messages |
+| TransactGetItems | | basic, validation | error messages |
+| ExecuteStatement | | INSERT, SELECT, UPDATE, DELETE, parameterised, RETURNING, vector index non-reach | error messages (RETURNING) |
+| BatchExecuteStatement | | batch, partial failure, RETURNING honoured | |
+| ExecuteTransaction | | atomic, rollback, RETURNING rejected | error messages (RETURNING) |
+| UpdateTimeToLive | | enable, validation | |
+| DescribeTimeToLive | | describe | |
+| TagResource | | add, list, remove, validation | |
+| DynamoDB Streams | | ListStreams, DescribeStream, GetRecords, view types | |
+| Backups | | on-demand, continuous (PITR) | |
+| ExportTableToPointInTime / ImportTable | | S3 export and import | |
+| Kinesis streaming destination | | enable, describe, disable | |
+| UpdateContributorInsights | | enable, describe, list | |
+| Resource policies | | put, get, delete | |
+| DescribeLimits / DescribeEndpoints | | account reads | |
+
+### Operations every emulator skips
+
+A handful of operations only exist on real AWS or reach into another AWS
+service, so no emulator implements them and each one skips on every target. The
+suite still exercises them against real DynamoDB - characterising AWS's own
+behaviour has value - and they all carry the `cloud-only` tag, so
+`--tags-filter='!cloud-only'` drops the lot:
+
+- Import/Export to S3
+- Kinesis Data Streams integration (streaming destinations)
+- On-demand backups and Point-in-Time Recovery
+- Contributor Insights
+- Resource-based policies
+- Account reads (DescribeLimits, DescribeEndpoints)
+
+Import/Export and Kinesis lean on slow async control-plane calls that make poor
+gate material, so they run in a separate non-gating job via
+`npm run test:integrations` rather than on the gating run. They still run
+against real AWS every scheduled run, and the ground-truth coverage check
+fails if they don't.
+
+Vector search (SearchVectors and the vector index lifecycle) is in the same
+position today for a different reason: the surface shipped on AWS in August
+2026 and no emulator implements it yet, so every current target skips the
+whole family through its support probes. Unlike the list above it is not
+`cloud-only` - it is ordinary DynamoDB surface any emulator can adopt, and the
+skips (and the coverage they cost) should shrink as targets catch up. The
+family carries the `vector` tag, so `--tags-filter='!vector'` drops it. The
+UpdateTable half of the lifecycle backfills on GSI timescales and rides in the
+same slow lane as the GSI lifecycle (`npm run test:gsi`).
+
+Genuinely not covered, with no tests yet:
+
+- Global Tables
+- DynamoDB Accelerator (DAX)
 
 ## Filtering by feature
 
@@ -337,7 +430,7 @@ npm test
 
 The full suite includes slow online-index lifecycle tests: 14 UpdateTable GSI tests that add and remove Global Secondary Indexes from existing tables, plus the UpdateTable vector index lifecycle test, which backfills on the same machinery. On real DynamoDB, each index creation triggers a backfill that usually takes 5-15 minutes even on small tables, and has been observed taking 25+ on a slow night (a 25-item vector index took ~17). These tests are important for conformance but they dominate runtime against real AWS.
 
-`test:quick` excludes the online-index lifecycle tests (GSI and vector) for faster local iteration. CI's gating real-DynamoDB job runs `test:gating`, which drops those *and* the S3 and Kinesis integration suites (see "Operations no emulator implements" below), so a slow async import can't redden the build. Emulator targets run the full `npm test` since index creation is instant locally.
+`test:quick` excludes the online-index lifecycle tests (GSI and vector) for faster local iteration. CI's gating real-DynamoDB job runs `test:gating`, which drops those *and* the S3 and Kinesis integration suites (see "Operations every emulator skips" above), so a slow async import can't redden the build. Emulator targets run the full `npm test` since index creation is instant locally.
 
 Nothing is dropped from real AWS by being off the gate, only moved. Real-AWS
 coverage runs in three lanes, split by runtime rather than by importance:
@@ -414,7 +507,7 @@ tests/
 
 ## The site
 
-[paritysuite.org](https://paritysuite.org) is built from `site/`, an npm workspace in this repository. It renders the files in `results/` as current standings, a page per target with its score over time, and a browsable archive of every recorded run. It imports the suite's own target maps and pass-rate arithmetic, so the board and the table above can't disagree about a target's name, its link, or its score.
+[paritysuite.org](https://paritysuite.org) is built from `site/`, an npm workspace in this repository. It renders the files in `results/` as current standings, a page per target with its score over time, and a browsable archive of every recorded run. It imports the suite's own target maps and the same divergence, coverage and grading arithmetic, so the board and the table above can't disagree about a target's name, its link, or its score.
 
 ```bash
 npm run site:dev     # http://localhost:8080
@@ -478,7 +571,9 @@ the first such target), two extra steps apply: trust its certificate with
 `NODE_EXTRA_CA_CERTS=/path/to/cert.pem` (the JS SDK does **not** read
 `AWS_CA_BUNDLE`), and pass a real `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY`
 whose policy allows the operations the suite exercises. Before committing the
-results JSON, grep it for your key to be sure no credential leaked into it.
+results JSON, grep it for your key to be sure no credential leaked into it, and
+run `npm run results:check-leaks`, which catches account IDs and the machine
+paths Vitest records.
 
 If the engine doesn't speak DynamoDB HTTP at all - a browser or embedded engine
 reached over its own RPC - it can still be tracked, provided the vendor fronts
@@ -496,83 +591,13 @@ operation is scored as a failure instead of a skip.
 
 All test data must be synthetic. Don't use real names, emails, addresses, or any personally identifiable information in test fixtures.
 
-## Operations covered
-
-| Operation | Tier 1 | Tier 2 | Tier 3 |
-|-----------|--------|--------|--------|
-| PutItem | basic, conditions (incl. parens), validation, expressions, dataTypes, consumedCapacity, indexConsumedCapacity (GSI/LSI write cost) | vector write validation, vector write capacity | error messages |
-| GetItem | basic, validation, projection, consumedCapacity | | error messages |
-| UpdateItem | basic, conditions (incl. parens, non-existent key branch), validation, paths, index write-capacity ladder | | error messages |
-| DeleteItem | basic, conditions (incl. parens), validation, index write capacity | | error messages |
-| Query | basic, GSI, LSI, expressions (incl. KeyCondition + Filter parens), select, numericKeys, binaryKeys, pagination | | error messages, validation ordering |
-| Scan | basic, validation, GSI (incl. pagination), LSI (incl. pagination), parallel, select, filterOperators, filterExpression parens | | error messages, validation ordering |
-| BatchWriteItem | basic, validation, index write capacity | | error messages |
-| BatchGetItem | basic, validation | | error messages |
-| CreateTable | basic, GSI, LSI | vector indexes (lifecycle, SearchSchema, validation) | error messages, validation ordering |
-| DeleteTable | basic | | |
-| DescribeTable | basic | | |
-| ListTables | basic | | |
-| UpdateTable | basic (throughput, billing mode) | GSI lifecycle, vector index lifecycle | |
-| SearchVectors | | scores per distance function, projection, capacity shape, request validation | error messages |
-| TransactWriteItems | | basic, conditions (incl. parens, non-existent key branch), idempotency, cancellation | error messages |
-| TransactGetItems | | basic, validation | error messages |
-| ExecuteStatement | | INSERT, SELECT, UPDATE, DELETE, parameterised, RETURNING, vector index non-reach | error messages (RETURNING) |
-| BatchExecuteStatement | | batch, partial failure, RETURNING honoured | |
-| ExecuteTransaction | | atomic, rollback, RETURNING rejected | error messages (RETURNING) |
-| UpdateTimeToLive | | enable, validation | |
-| DescribeTimeToLive | | describe | |
-| TagResource | | add, list, remove, validation | |
-| DynamoDB Streams | | ListStreams, DescribeStream, GetRecords, view types | |
-| Backups | | on-demand, continuous (PITR) | |
-| ExportTableToPointInTime / ImportTable | | S3 export and import | |
-| Kinesis streaming destination | | enable, describe, disable | |
-| UpdateContributorInsights | | enable, describe, list | |
-| Resource policies | | put, get, delete | |
-| DescribeLimits / DescribeEndpoints | | account reads | |
-
-### Operations every emulator skips
-
-A handful of operations only exist on real AWS or reach into another AWS
-service, so no emulator implements them and each one skips on every target. The
-suite still exercises them against real DynamoDB - characterising AWS's own
-behaviour has value - and they all carry the `cloud-only` tag, so
-`--tags-filter='!cloud-only'` drops the lot:
-
-- Import/Export to S3
-- Kinesis Data Streams integration (streaming destinations)
-- On-demand backups and Point-in-Time Recovery
-- Contributor Insights
-- Resource-based policies
-- Account reads (DescribeLimits, DescribeEndpoints)
-
-Import/Export and Kinesis lean on slow async control-plane calls that make poor
-gate material, so they run in a separate non-gating job via
-`npm run test:integrations` rather than on the gating run. They still run
-against real AWS every scheduled run, and the ground-truth coverage check
-fails if they don't.
-
-Vector search (SearchVectors and the vector index lifecycle) is in the same
-position today for a different reason: the surface shipped on AWS in August
-2026 and no emulator implements it yet, so every current target skips the
-whole family through its support probes. Unlike the list above it is not
-`cloud-only` - it is ordinary DynamoDB surface any emulator can adopt, and the
-skips (and the coverage they cost) should shrink as targets catch up. The
-family carries the `vector` tag, so `--tags-filter='!vector'` drops it. The
-UpdateTable half of the lifecycle backfills on GSI timescales and rides in the
-same slow lane as the GSI lifecycle (`npm run test:gsi`).
-
-Genuinely not covered, with no tests yet:
-
-- Global Tables
-- DynamoDB Accelerator (DAX)
-
 ## Citing a finding
 
-When the suite surfaces a divergence in a target and you want to reference it from that target's own issue tracker, cite the suite as the independent source it is. The reference carries weight precisely because the suite is not the engine's own test harness: it scores every target against the same live-AWS baseline, so "the conformance suite flags this" says more than a self-written test can.
-
-**Disclosure.** This suite is maintained by the same person who maintains Dynoxide, one of the engines it scores. Dynoxide runs through the same automated matrix as every other target, against the same live-AWS ground truth. The tests and the results are in this repo. The grade bands and the coverage weight are hand-picked inputs to a published letter, and moving one regrades targets whose results never changed. So they carry a version. These are grading criteria version 1, and any change to a band, the coverage weight or the A+ gate bumps the version and is dated in the [methodology](https://paritysuite.org/methodology#grading), which is where the effective date lives.
-
-They are not the only hand-picked input. `registry/splits.json` is written by hand by design: it records the behaviours where real DynamoDB's own regions disagree, with the evidence each region returned, and a target matching any recorded answer is scored as conformant rather than wrong. Admitting a row there turns a fail into a pass with no re-run and no results file changing, which is the one thing "a score can't be tuned without changing the published results first" does not cover. So the registry is in this repo, every row carries its captured evidence and the date it was refreshed, and a behaviour enters only once confirmed across regions.
+When the suite surfaces a divergence in a target and you want to raise it on that
+target's own issue tracker, the reference carries weight because the suite is not
+the engine's own test harness: every target is scored against the same live-AWS
+baseline, so "the conformance suite flags this" says more than a self-written
+test can.
 
 Fill in the bracketed parts. The block is the same whichever engine the finding concerns:
 
@@ -586,7 +611,7 @@ Fill in the bracketed parts. The block is the same whichever engine the finding 
 Two details keep the citation honest:
 
 - **Link the specific test, and pin it.** Use a commit SHA or tag (`.../blob/<sha>/...`), never `.../blob/main/...`: a `main` link rots the moment the file is reformatted or the lines shift, while a pinned link points at the exact assertion for good. Link the test itself, not a bare in-repo path, so it resolves for anyone reading the issue.
-- **Pinned test for a specific finding; site row only for a general claim.** The pinned test is durable evidence that this exact case diverged. The row on [Parity Suite, the DynamoDB conformance suite](https://paritysuite.org) (paritysuite.org) is a live score that moves with every run, so it answers "how does this engine do overall", not "what broke here". Don't cite a moving score as evidence for a fixed bug.
+- **Pinned test for a specific finding; site row only for a general claim.** The pinned test is durable evidence that this exact case diverged. A row on [the board](https://paritysuite.org) is a live score that moves with every run, so it answers "how does this engine do overall", not "what broke here". Don't cite a moving score as evidence for a fixed bug.
 
 Real AWS DynamoDB is the ground truth here as everywhere: the "expected" line is what AWS does, captured against a named region, not what any emulator does. If the behaviour is one where regions disagree, say so and name the regions on each side - the admitted cases are in `registry/splits.json`.
 

--- a/README.md
+++ b/README.md
@@ -30,75 +30,49 @@ DYNAMODB_ENDPOINT=http://localhost:8000 npm run test:tier1
 ## Results
 
 <!-- results:start -->
-_Scored against real DynamoDB's recorded behaviour in each observed region (`af-south-1`, `ap-east-1`, `ap-east-2`, `ap-northeast-1`, `ap-northeast-2`, `ap-northeast-3`, `ap-south-1`, `ap-south-2`, `ap-southeast-1`, `ap-southeast-2`, `ap-southeast-3`, `ap-southeast-4`, `ap-southeast-5`, `ap-southeast-6`, `ap-southeast-7`, `ca-central-1`, `ca-west-1`, `eu-central-1`, `eu-central-2`, `eu-north-1`, `eu-south-1`, `eu-south-2`, `eu-west-1`, `eu-west-2`, `eu-west-3`, `il-central-1`, `mx-central-1`, `sa-east-1`, `us-east-1`, `us-east-2`, `us-west-1`, `us-west-2`), at each target's best-matching region. **Divergence** is the share of the whole suite a target answers differently from real DynamoDB - the operations it implements and gets wrong. **Coverage** is the share it implements at all. They are reported apart because they carry opposite risks: a declined operation is discoverable in minutes, a wrong one in production. **Grade** is a reading of the pair: divergence sets the letter and coverage can only lower it, never raise it, under the versioned criteria in the [methodology](https://paritysuite.org/methodology). Sorted by divergence, so the order ranks risk rather than declaring a winner - a target with no divergences over a narrow surface is exactly what its two figures say it is. Regions is how many of the observed regions the headline was measured against. The tier columns are divergence too, within each tier, so lower is better in every column but Coverage. Real DynamoDB does not behave identically in every region, so each target is measured in every region above and scored against its best match; the per-region detail is in `results/summary.json`. Behaviour varies by region and over time, so these are point-in-time figures. `me-central-1`, `me-south-1` have been dropped from the observed set and are not scored against._
+_Scored against real DynamoDB in each of the 32 observed regions, at each target's best-matching region. **Coverage** is how much of DynamoDB's behaviour a target implements. **Divergence** is how much of it the target answers differently from real DynamoDB. Both are shares of the whole suite, and they are never added together: an operation a target declines is discoverable in minutes, one it answers wrongly is discoverable in production. **Grade** reads the pair, with divergence setting the letter and coverage only ever lowering it, under the versioned criteria in the [methodology](https://paritysuite.org/methodology). Rows are sorted by divergence. The tier columns are divergence within that tier, so lower is better in every column but Coverage. **Regions** counts the observed regions a target's headline matched, as evidence rather than a score: it currently over-credits a target whose assertion matches a region's answer loosely ([#138](https://github.com/paritysuite/dynamodb-conformance/issues/138)). Real DynamoDB does not answer identically everywhere, and the per-region detail is in `results/summary.json`. Behaviour varies by region and over time, so these are point-in-time figures. `me-central-1`, `me-south-1` have been dropped from the observed set and are not scored against. Measured 2026-08-12, except where a row carries its own date._
 
-| Target | Grade | Divergence | Coverage | Regions | Tier 1 | Tier 2 | Tier 3 | Fail | Skip | Version | Date |
-|--------|-------|-----------|----------|---------|--------|--------|--------|------|------|---------|------|
-| [DynamoDB](https://aws.amazon.com/dynamodb/) | baseline | 0.0% | 100.0% | 32 of 32 | 0.0% | 0.0% | 0.0% | 0 | 0 | live (AWS) | 2026-08-12 |
-| [Dynoxide](https://github.com/nubo-db/dynoxide) · native | A | 0.9% | 94.7% | 4 of 32 | 2.0% | 0.0% | 0.0% | 10 | 56 | 0.13.0 | 2026-08-12 |
-| ↳ WebAssembly / OPFS | B | 0.9% | 83.4% | 4 of 32 | 2.0% | 0.0% | 0.0% | 10 | 175 | 0.13.0 | 2026-08-12 |
-| [ExtendDB](https://github.com/ExtendDB/extenddb) · PostgreSQL | B | 2.0% | 87.8% | 27 of 32 | 0.8% | 2.7% | 3.2% | 21 | 129 | v0.1.3 | 2026-08-12 |
-| [Ministack](https://github.com/ministackorg/ministack) | B | 11.9% | 96.0% | 27 of 32 | 5.7% | 15.1% | 18.5% | 125 | 42 | 63621de32116 | 2026-08-12 |
-| [Dynalite](https://github.com/architect/dynalite) | C | 12.8% | 77.0% | 23 of 32 | 10.8% | 12.4% | 15.9% | 135 | 242 | 4.0.0 | 2026-08-12 |
-| [LocalStack](https://github.com/localstack/localstack) | C | 14.8% | 95.3% | 25 of 32 | 6.3% | 16.0% | 26.2% | 156 | 50 | 2026.7.3 | 2026-08-12 |
-| [DynamoDB Local](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/DynamoDBLocal.html) | C | 15.1% | 94.0% | 25 of 32 | 7.6% | 14.2% | 26.5% | 159 | 63 | ff89bd48ff32 | 2026-08-12 |
-| [Floci](https://github.com/floci-io/floci) | C | 21.0% | 95.2% | 27 of 32 | 10.8% | 32.4% | 27.9% | 221 | 51 | eab36252ea43 | 2026-08-12 |
+| Target | Grade | Version | Divergence | Coverage | Fail | Skip | Tier 1 | Tier 2 | Tier 3 | Regions | Measured |
+|--------|-------|---------|-----------|----------|------|------|--------|--------|--------|---------|----------|
+| [DynamoDB](https://aws.amazon.com/dynamodb/) | baseline | live (AWS) | 0.0% | 100.0% | 0 | 0 | 0.0% | 0.0% | 0.0% | 32 of 32 |  |
+| [Dynoxide](https://github.com/nubo-db/dynoxide) · native | A | 0.13.0 | 0.9% | 94.7% | 10 | 56 | 2.0% | 0.0% | 0.0% | 4 of 32 |  |
+| ↳ WebAssembly / OPFS | B | 0.13.0 | 0.9% | 83.4% | 10 | 175 | 2.0% | 0.0% | 0.0% | 4 of 32 |  |
+| [ExtendDB](https://github.com/ExtendDB/extenddb) · PostgreSQL | B | v0.1.3 | 2.0% | 87.8% | 21 | 129 | 0.8% | 2.7% | 3.2% | 27 of 32 |  |
+| [Ministack](https://github.com/ministackorg/ministack) | B | 63621de32116 | 11.9% | 96.0% | 125 | 42 | 5.7% | 15.1% | 18.5% | 27 of 32 |  |
+| [Dynalite](https://github.com/architect/dynalite) | C | 4.0.0 | 12.8% | 77.0% | 135 | 242 | 10.8% | 12.4% | 15.9% | 23 of 32 |  |
+| [LocalStack](https://github.com/localstack/localstack) | C | 2026.7.3 | 14.8% | 95.3% | 156 | 50 | 6.3% | 16.0% | 26.2% | 25 of 32 |  |
+| [DynamoDB Local](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/DynamoDBLocal.html) | C | ff89bd48ff32 | 15.1% | 94.0% | 159 | 63 | 7.6% | 14.2% | 26.5% | 25 of 32 |  |
+| [Floci](https://github.com/floci-io/floci) | C | eab36252ea43 | 21.0% | 95.2% | 221 | 51 | 10.8% | 32.4% | 27.9% | 27 of 32 |  |
 <!-- results:end -->
 
 **Live results:** [the Parity Suite board](https://paritysuite.org) - the full table for every target, tracked run over run.
 
-Two figures, and they are never added together. **Divergence** is `Fail / Total`:
-the share of the whole suite a target answers differently from real DynamoDB.
-**Coverage** is `(Pass + Fail) / Total`: the share it implements at all. They
-stay apart because a skip and a fail are not the same kind of problem. An
-operation a target declines is something you find in minutes and plan around;
-one it gets quietly wrong is something you find in production.
+**Divergence** is `Fail / Total` and **Coverage** is `(Pass + Fail) / Total`,
+and they are never added together: an operation a target declines is one you
+plan around, one it gets quietly wrong is one you find in production.
 
 The **Grade** leads because a row carries several figures and a reader
-comparing eight targets needs somewhere to start. Divergence sets the letter (A
-under 5%, B under 15%, C under 25%, D under 35%, F beyond) and coverage can
+comparing a column of them needs somewhere to start. Divergence sets the letter
+(A under 5%, B under 15%, C under 25%, D under 35%, F beyond) and coverage can
 only lower it, never raise it: a third of whatever a target leaves
 unimplemented is added to its divergence before the bands are read, so a target
 implementing the whole suite is graded on divergence alone. A+ is exactly zero
-divergence at full coverage, and nothing holds it today. Both figures print
-beside the letter in this table and on every page of the board, so the grade is
-always recomputable; the criteria are versioned and dated in the
-[methodology](https://paritysuite.org/methodology#grading). The per-target
-badges are the exception: a shields endpoint has room for a label and a message
-and nothing else, so a badge carries the letter alone. A grade is an
-observation against this suite's tests on a date, not a certification.
+divergence at full coverage, and nothing holds it today. Real DynamoDB reads
+`baseline` rather than a letter, because grading the yardstick against itself
+would put it in a band an engine had to earn its way into.
 
-Where coverage is holding a letter down the site says so on the row. On the 9
-August 2026 run, Dynalite diverged on 12.3% of the suite, which is the B band
-on its own, but implemented 80.0% of it, and the third of that shortfall reads
-it up to an effective 19.0 and grades it C. Dynoxide diverged nowhere and
-implemented 98.6%, and that 1.4-point gap is enough to deny it A+ and settle it
-at A.
+Both figures print beside the letter, so any grade here is recomputable, and the
+percentage points are the finer instrument: **rank on the two figures rather
+than the letter** if a close call matters to you. A grade is an observation
+against this suite's tests on a date, not a certification. The criteria are
+versioned and dated in the
+[methodology](https://paritysuite.org/methodology#grading), which carries the
+derivation of the bands, the worked examples, and what withdrawing a test costs.
 
-Real DynamoDB reads `baseline` rather than a letter. A grade measures how far a
-target sits from real DynamoDB, so grading the yardstick against itself would
-put it in a band an engine had to earn its way into. Its two figures still
-publish: they are the definition every other row is read against.
-
-Withdrawing a failing test lowers divergence and coverage by exactly the same
-amount, which is what makes the pair hard to game. The letter does not fully
-inherit that. A third of the withdrawal comes back, so the effective figure
-still falls by two thirds of whatever left: withdrawal costs more than it used
-to rather than costing everything. Closing it completely would mean weighting a
-declined test exactly as heavily as a failed one, and the distinction between
-those two is what the board is built on. **Rank on the two figures, not the
-letter, if that matters to you.** On the 9 August 2026 run the cheapest letter
-anyone could buy this way was LocalStack's, at 14 withdrawn tests, which is a
-measurement of that board rather than a property of the criteria.
-
-The 5% and 25% boundaries are the numbers this board has published as its
-colour bands since it began, though those bands sat on correctness over the
-operations a target implements and these sit on divergence over the whole
-suite. Same numbers, different denominator, and the two only coincide at full
-coverage. The coverage weight is what answers that: a target diverging 4.9%
-over 92% coverage is 94.7% correct, which the old sub-95% amber band caught,
-and reads an effective 7.6 here, which grades B. The splits at 15% and 35% are
-new, and so is the weight.
+Rows are ordered by divergence. That ranks how much a target gets wrong rather
+than telling you which one to pick, because that depends on the operations you
+need: a target with no divergences over a narrow surface sits high, and its
+coverage figure says how narrow.
 
 A skipped test is deliberate: each test file probes for feature support in
 `beforeAll` and skips itself when the target doesn't implement that operation,
@@ -107,23 +81,17 @@ is a failed observation - a timeout, an exhausted throttle, a transport fault -
 and counts neither for nor against a target, because nobody knows what the
 answer was.
 
-Rows are ordered by divergence. That ranks how much a target gets wrong; it
-isn't a verdict on which emulator to pick, because that depends on which
-operations you need. A target with no divergences over a narrow surface sits
-high and its coverage figure says how narrow.
-
 DynamoDB is the ground truth, recorded per region. Real DynamoDB disagrees with
 itself in a handful of places (the admitted cases are in `registry/splits.json`),
 so each target is measured in every observed region and scored against its
-best-matching one. A target fails a behaviour only when no observed region does
-what it does. The spread is small - three tests out of about a thousand - so the
-per-region detail lives in `results/summary.json` rather than in the table.
+best-matching one, and fails a behaviour only when no observed region does what
+it does. The spread is three tests in about a thousand, so the per-region detail
+lives in `results/summary.json` rather than in the table.
 
 This table is regenerated by the **Update Results Table** workflow -
 automatically when a Conformance Tests run finishes on `main`, and on demand
-from the Actions tab. It pulls each target's result artifact, fills the Version
-(npm version, container image digest, release tag, or `live` for real AWS) and
-Run date columns from the run, and commits the refreshed table. Run
+from the Actions tab. It fills each row's Version from the run (npm version,
+container image digest, release tag, or `live` for real AWS). Run
 `npm run results:table` to preview it locally.
 
 ## Tiers

--- a/README.md
+++ b/README.md
@@ -119,9 +119,9 @@ date it was refreshed, and a behaviour enters only once confirmed across regions
 
 ## Tiers
 
-**Tier 1 - Core.** The operations and behaviours that 90% of DynamoDB users rely on. CRUD, queries, scans, batch operations, GSIs, UpdateTable. If an emulator fails Tier 1, it's not usable.
+**Tier 1 - Core.** The operations and behaviours that 90% of DynamoDB users rely on. CRUD, queries, scans, batch operations, secondary indexes (GSI and LSI), UpdateTable. If an emulator fails Tier 1, it's not usable.
 
-**Tier 2 - Complete.** Less common but documented features. Transactions, PartiQL, LSIs, TTL, streams, tags, vector search. An emulator that passes Tier 1 but fails some Tier 2 is usable with caveats.
+**Tier 2 - Complete.** Less common but documented features. Transactions, PartiQL, TTL, streams, tags, vector search, the online index lifecycle (adding and removing a GSI or a vector index on a live table), and the `cloud-only` surfaces below: backups and PITR, S3 export and import, Kinesis, Contributor Insights, resource policies, account reads. An emulator that passes Tier 1 but fails some Tier 2 is usable with caveats.
 
 **Tier 3 - Strict.** Validation ordering, error behaviour at a range of strictness (exact where DynamoDB's wording is stable, structural where its rendering is non-deterministic), edge cases around limits, legacy API compatibility (ScanFilter, QueryFilter). An emulator that passes Tier 1 and Tier 2 but fails some Tier 3 is production-quality for local dev.
 

--- a/scripts/summarise.mjs
+++ b/scripts/summarise.mjs
@@ -751,27 +751,35 @@ export function tableRows(summary) {
  * able to mistake an unresolved region for an agreeing one, so absence is
  * spelled out rather than implied.
  */
-export function tableCaption(regions, groundTruth = null) {
+export function tableCaption(regions, groundTruth = null, tableDate = null) {
   const list = (rs) => rs.map((r) => `\`${r}\``).join(', ')
+  // Two figures, said plainly. The long form spent a paragraph on what they
+  // measure before a reader reached a number, when the pair is simple:
+  // coverage is how much of DynamoDB a target implements, divergence is how
+  // much of it the target gets wrong. What genuinely needs saying is why they
+  // are never added together, and everything the table cannot show on its own -
+  // which regions dropped out, which lanes were carried, which column is known
+  // to be wrong. Naming all 32 observed regions inline was the bulk of it and
+  // the least of it: the count carries the same weight and the set is in
+  // `registry/regions.json`. The exceptions are still named, because that is
+  // where naming earns its space.
   const sentences = [
-    `Scored against real DynamoDB's recorded behaviour in each observed region ` +
-      `(${list(regions.observed)}), at each target's best-matching region. ` +
-      `**Divergence** is the share of the whole suite a target answers differently ` +
-      `from real DynamoDB - the operations it implements and gets wrong. ` +
-      `**Coverage** is the share it implements at all. They are reported apart ` +
-      `because they carry opposite risks: a declined operation is discoverable in ` +
-      `minutes, a wrong one in production. **Grade** is a reading of the pair: ` +
-      `divergence sets the letter and coverage can only lower it, never raise it, ` +
-      `under the versioned criteria in the ` +
-      `[methodology](https://paritysuite.org/methodology). Sorted by divergence, so the order ranks ` +
-      `risk rather than declaring a winner - a target with no divergences over a ` +
-      `narrow surface is exactly what its two figures say it is. Regions is how many ` +
-      `of the observed regions the headline was measured against. The tier columns ` +
-      `are divergence too, within each tier, so lower is better in every column ` +
-      `but Coverage. Real DynamoDB does ` +
-      `not behave identically in every region, so each target is measured in every ` +
-      `region above and scored against its best match; the per-region detail is in ` +
-      `\`results/summary.json\`. Behaviour varies by region and over time, so these ` +
+    `Scored against real DynamoDB in each of the ${regions.observed.length} observed ` +
+      `regions, at each target's best-matching region. **Coverage** is how much of ` +
+      `DynamoDB's behaviour a target implements. **Divergence** is how much of it the ` +
+      `target answers differently from real DynamoDB. Both are shares of the whole ` +
+      `suite, and they are never added together: an operation a target declines is ` +
+      `discoverable in minutes, one it answers wrongly is discoverable in production. ` +
+      `**Grade** reads the pair, with divergence setting the letter and coverage only ` +
+      `ever lowering it, under the versioned criteria in the ` +
+      `[methodology](https://paritysuite.org/methodology). Rows are sorted by ` +
+      `divergence. The tier columns are divergence within that tier, so lower is ` +
+      `better in every column but Coverage. **Regions** counts the observed regions a ` +
+      `target's headline matched, as evidence rather than a score: it currently ` +
+      `over-credits a target whose assertion matches a region's answer loosely ` +
+      `([#138](https://github.com/paritysuite/dynamodb-conformance/issues/138)). Real ` +
+      `DynamoDB does not answer identically everywhere, and the per-region detail is ` +
+      `in \`results/summary.json\`. Behaviour varies by region and over time, so these ` +
       `are point-in-time figures.`,
   ]
   if (regions.unresolved.length > 0) {
@@ -804,6 +812,10 @@ export function tableCaption(regions, groundTruth = null) {
         `${unobserved === 1 ? 'is' : 'are'} carried.`,
     )
   }
+  // Last, because it closes the table rather than qualifying any one column.
+  if (tableDate) {
+    sentences.push(`Measured ${tableDate}, except where a row carries its own date.`)
+  }
   return `_${sentences.join(' ')}_`
 }
 
@@ -815,17 +827,33 @@ export function tableCaption(regions, groundTruth = null) {
 // as a rival. This replaces a footnote keyed off a bracket in the display name.
 const VARIANT_PREFIX = '↳ '
 
+/**
+ * The date the table as a whole was measured: the newest date any row carries.
+ * Rows older than it are carried from an earlier run, and only those state a
+ * date of their own.
+ */
+export const tableDateOf = (rows) =>
+  rows.map((r) => r.runDate).filter((d) => d && d !== '-').sort().pop() ?? null
+
 export function renderTable(summary) {
   const rows = tableRows(summary)
+  const tableDate = tableDateOf(rows)
+  // Identity first (what was measured), then the two headline figures, then the
+  // counts behind them, then the tier breakdown, and the evidence columns last.
+  // Regions sat fourth, where a reader met `4 of 32` beside `27 of 32` and read
+  // it as quality: it counts the regions whose recorded wording a target
+  // matched, and the target on 4 diverges least of any of them.
+  //
+  // Measured is an exception column, not a date column. It carried the same
+  // date on every row on a re-measure of everything and a mix of two or three
+  // otherwise, so a column of repeats hid the only rows worth spotting. A row
+  // with a date in it is carried from an earlier run; the caption states the
+  // date the rest were measured on.
   const fmt = (r, name) =>
-    `| ${name} | ${r.grade} | ${r.divergence} | ${r.coverage} | ${r.cohort ?? '-'} | ${r.tier1} | ${r.tier2} | ${r.tier3} | ${r.failed} | ${r.skipped} | ${r.version} | ${r.runDate} |`
+    `| ${name} | ${r.grade} | ${r.version} | ${r.divergence} | ${r.coverage} | ${r.failed} | ${r.skipped} | ${r.tier1} | ${r.tier2} | ${r.tier3} | ${r.cohort ?? '-'} | ${r.runDate === tableDate ? '' : r.runDate} |`
   const body = [
-    // Regions is the cohort the headline was measured against, as a count. The
-    // Region column this replaces named the cohort, which read as breadth: a
-    // target equally wrong in all 33 showed "all regions" while one perfect in 6
-    // showed "6 regions". A count out of the observed total cannot.
-    '| Target | Grade | Divergence | Coverage | Regions | Tier 1 | Tier 2 | Tier 3 | Fail | Skip | Version | Date |',
-    '|--------|-------|-----------|----------|---------|--------|--------|--------|------|------|---------|------|',
+    '| Target | Grade | Version | Divergence | Coverage | Fail | Skip | Tier 1 | Tier 2 | Tier 3 | Regions | Measured |',
+    '|--------|-------|---------|-----------|----------|------|------|--------|--------|--------|---------|----------|',
     ...rows.flatMap((r) => [
       // The parent's figures are its reference configuration's, so name that
       // configuration inline when the project has more than one shape. Without
@@ -837,7 +865,7 @@ export function renderTable(summary) {
       ),
     ]),
   ].join('\n')
-  return `${tableCaption(summary.regions, summary.groundTruth)}\n\n${body}`
+  return `${tableCaption(summary.regions, summary.groundTruth, tableDate)}\n\n${body}`
 }
 
 // ── CLI ──────────────────────────────────────────────────────────────────────

--- a/scripts/summarise.test.mjs
+++ b/scripts/summarise.test.mjs
@@ -27,6 +27,7 @@ import {
   renderTable,
   repoUrl,
   tableCaption,
+  tableDateOf,
   tableRows,
   writeSummaryFile,
 } from './summarise.mjs'
@@ -554,8 +555,40 @@ describe('tableRows / renderTable', () => {
     expect(order.indexOf('alpha')).toBeLessThan(order.indexOf('beta'))
   })
 
-  it('names the observed regions in the caption', () => {
-    expect(tableCaption(summary.regions)).toContain('`eu-west-2`, `us-east-1`')
+  it('counts the observed regions in the caption rather than naming every one', () => {
+    // Naming all of them was most of the caption's length, and the set is in
+    // registry/regions.json. The exceptions are still named - the unresolved
+    // and dropped cases above assert exactly that - because a name earns its
+    // space where it marks something out.
+    const caption = tableCaption(summary.regions)
+    expect(caption).toContain('each of the 2 observed regions')
+    expect(caption).not.toContain('`eu-west-2`, `us-east-1`')
+  })
+
+  it('states the known defect in the Regions column rather than publishing it bare', () => {
+    expect(tableCaption(summary.regions)).toMatch(/over-credits.*issues\/138/s)
+  })
+
+  it('dates the table from the newest row, and only carried rows carry a date', () => {
+    // Repeating one date down every row hid the rows worth spotting. The
+    // caption states the run's date; a row that shows one is carried from an
+    // earlier run.
+    const carried = [{ runDate: '2026-08-12' }, { runDate: '2026-07-24' }, { runDate: '-' }]
+    expect(tableDateOf(carried)).toBe('2026-08-12')
+    expect(tableDateOf([{ runDate: '-' }])).toBe(null)
+
+    const table = renderTable(summary)
+    expect(table).toContain('Measured 2026-07-06, except where a row carries its own date.')
+    // Every row here was measured in the same run, so no row restates it.
+    for (const line of table.split('\n').filter((l) => l.startsWith('| ') && !l.startsWith('| Target'))) {
+      expect(line.endsWith('|  |') || line.endsWith('| - |')).toBe(true)
+    }
+  })
+
+  it('orders the columns identity, headline, counts, tiers, then evidence', () => {
+    expect(renderTable(summary)).toContain(
+      '| Target | Grade | Version | Divergence | Coverage | Fail | Skip | Tier 1 | Tier 2 | Tier 3 | Regions | Measured |',
+    )
   })
 
   it('badge and table cannot disagree: every grade equals the badge letter', () => {

--- a/site/lib/dataset.mjs
+++ b/site/lib/dataset.mjs
@@ -76,8 +76,8 @@ export const DATA_SCHEMA_VERSION = 4;
 
 // Tier metadata, surfaced so a consumer doesn't have to hard-code the names.
 export const TIERS = [
-  { key: "tier1", name: "Core", description: "The operations roughly 90% of DynamoDB users rely on: CRUD, queries, scans, batch operations, GSIs, UpdateTable." },
-  { key: "tier2", name: "Complete", description: "Documented but less common features: transactions, PartiQL, LSIs, TTL, streams, tags, vector search." },
+  { key: "tier1", name: "Core", description: "The operations roughly 90% of DynamoDB users rely on: CRUD, queries, scans, batch operations, secondary indexes (GSI and LSI), UpdateTable." },
+  { key: "tier2", name: "Complete", description: "Documented but less common features: transactions, PartiQL, TTL, streams, tags, vector search, the online index lifecycle, and the surfaces only real AWS implements (backups, S3 export and import, Kinesis, Contributor Insights, resource policies, account reads)." },
   { key: "tier3", name: "Strict", description: "Validation ordering, error behaviour, limits, and legacy API shapes." },
 ];
 


### PR DESCRIPTION
## What this changes

Three passes over the results table and the copy around it.

**The table.** Identity first (target, grade, version), then divergence and
coverage, then the counts behind them, then the tiers, with Regions last.
Regions sat fourth, where `4 of 32` beside `27 of 32` reads as quality: it
counts the regions whose recorded wording a target matched, and the target on 4
diverges least of any of them. The caption now calls it evidence rather than a
score and says it over-credits while #138 is open.

The Date column becomes Measured, and only a row carried from an earlier run
states one, with the caption dating the rest. 17 of the last 25 revisions of
this table carried two or three distinct dates, so hoisting a single date to the
caption would have stamped today's on rows measured weeks earlier.

The caption named all 32 observed regions before it reached a number. It states
the count instead, says plainly that coverage is how much of DynamoDB a target
implements and divergence is how much of it the target gets wrong, and leaves
the derivation to the methodology page that already carries it. 245 words to
191, with the dropped-region and carried-lane disclosures untouched.

**The prose below the table** ran a second copy of the methodology page, worked
examples and all, and those examples had gone stale. It now keeps what a reader
needs in order to read the table and links the rest.

**The disclosure** was buried inside "Citing a finding", which was doing two
jobs at once. It has its own Independence section directly under the results,
where a reader has just read a table the maintainer's own engine sits in. The
citation guide keeps the template and the two rules that keep a citation honest.

Fixed along the way:

- Tier 2 was described with LSIs, which have been in Tier 1 since the first
  commit, and without vector search, which shipped into the tier months ago.
  Tier 2 also named seven of its thirteen areas, omitting the online index
  lifecycle and the cloud-only family - 28 tests it was silent about. Both tier
  descriptions now match the directories, in the README and in `dataset.mjs`,
  which publishes them through the data endpoints.
- The site section described importing "pass-rate arithmetic" that 3.0.0
  retired.
- "Operations covered" sat between the contributor guide and the citation
  block, so it moves up beside Tiers. That flipped a cross-reference pointing
  "below" at a section now above, which also named a heading that does not
  exist.
- Adding a target now points at `npm run results:check-leaks` rather than only
  suggesting a grep.

The section move was made by a script asserting the output is a permutation of
the input, so it cannot have dropped or altered a line. `results/summary.json`
is byte-identical: no published figure moves.

## Checklist

- ~~New or modified tests run against real AWS DynamoDB and pass~~ - documentation
  and table rendering, no suite tests touched.
- ~~New or modified tests run against at least one emulator target and behave as
  expected~~ - as above. The tooling and site suites cover the rendering change.
- [x] Linked issue or a short note explaining the motivation
- [x] I agree my contribution is licensed under the project's terms
  (Apache License, Version 2.0)
