### PR TITLE
docs: capture both sides of the backfill documentation contradiction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,9 +65,12 @@ validation on each plane, rejection wording, write-path validation, search on a
 fixture where the nearest neighbour is unambiguous, the two new capacity shapes,
 and PartiQL's inability to reach a vector index. Every pinned value was
 characterised against real DynamoDB in eu-west-2 before it was asserted. Two
-findings worth naming: searching during a backfill is an error whatever AWS's own
-documentation says, and an overwrite leaving the stored vector unchanged reports
-no vector write capacity at all, because index replication is delta-based. No
+findings worth naming: searching during a backfill is an error, which settles
+which side of a contradiction in AWS's own documentation is right - three
+developer-guide pages say the call fails, the tutorial page says results can be
+incomplete - and an overwrite leaving the stored vector unchanged reports no
+vector write capacity at all, because index replication is delta-based. Both
+sides are captured in `captures/2026-08-12-vector-backfill-docs.json`. No
 emulator implements the family yet, so every target skips it and every coverage
 figure drops with this release while divergence is untouched. Sending the new
 operations needs `@aws-sdk/client-dynamodb` 3.1103.0 or later.

--- a/captures/2026-08-12-vector-backfill-docs.json
+++ b/captures/2026-08-12-vector-backfill-docs.json
@@ -56,6 +56,36 @@
       }
     ]
   },
+  "stateMachine": {
+    "note": "A second mismatch, on neither side of the backfill contradiction: the documented sequence is not the observed one. Three pages describe an ACTIVE-plus-Backfilling-true state and build their waiting advice around it. The suite never observed the index occupying it.",
+    "documented": {
+      "quote": "The index first transitions to IndexStatus CREATING while DynamoDB sets up the index infrastructure. It then moves to IndexStatus ACTIVE with Backfilling set to true while DynamoDB populates the index from existing base table data.",
+      "url": "https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/VectorSearchDataSync.html",
+      "alsoStatedIn": [
+        "VectorSearchWorkingWith.html - numbered walk, step 2: 'IndexStatus is ACTIVE with Backfilling set to true — DynamoDB is populating the index with existing data from the base table.'",
+        "VectorSearchTroubleshooting.html - cause cell: 'Either IndexStatus is CREATING, or IndexStatus is ACTIVE with Backfilling set to true.'"
+      ]
+    },
+    "observed": {
+      "updateTablePath": [
+        "CREATING with Backfilling: false",
+        "CREATING with Backfilling: true",
+        "ACTIVE with the Backfilling field absent"
+      ],
+      "createTablePath": [
+        "CREATING with the Backfilling field absent throughout",
+        "ACTIVE with the Backfilling field absent"
+      ],
+      "region": "eu-west-2",
+      "characterisedOn": "2026-08-11",
+      "consequence": "The ACTIVE-plus-backfilling state the advice is built around is never occupied on either path. Backfilling is a CREATING-time field that disappears rather than settling to false, so a readiness check written literally from the guidance - poll until Backfilling === false - never fires on the UpdateTable path, and has nothing to read at all on the CreateTable path.",
+      "hedging": "Only VectorSearchWorkingWith.html allows for the field being gone, in step 3: 'IndexStatus is ACTIVE with Backfilling set to false (or absent)'. VectorSearchDataSync.html, VectorSearchTroubleshooting.html and the tutorial all say to wait for false without the absent case."
+    },
+    "assertionStatus": {
+      "createTablePath": "Pinned. tests/tier2/vectorSearch/lifecycle.test.ts asserts expect(ix?.Backfilling).toBeUndefined() on every poll, and that seen statuses stay within CREATING and ACTIVE.",
+      "updateTablePath": "Recorded in a comment, not pinned. updateLifecycle.test.ts asserts only that statuses stay within CREATING and ACTIVE and that the Backfilling field was seen at least once; it does not assert that Backfilling: true occurs solely while CREATING. Worth an assertion that pins the pairing, so a change in the sequence fails rather than passing quietly."
+    }
+  },
   "adjacent": {
     "note": "The tutorial also instructs readers to use IndexStatus alone as the readiness signal on the CreateTable path, where Backfilling is not reported. The suite found that insufficient: DescribeTable can report the index ACTIVE a beat before the search plane agrees, so readiness is proven by a search returning the full expected count, never by the description.",
     "url": "https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/VectorSearchTutorial.html",

--- a/captures/2026-08-12-vector-backfill-docs.json
+++ b/captures/2026-08-12-vector-backfill-docs.json
@@ -1,0 +1,64 @@
+{
+  "capturedAt": "2026-08-12",
+  "kind": "documentation",
+  "issue": 125,
+  "subject": "What AWS documents happens when SearchVectors is called against a backfilling vector index",
+  "note": "Not an API response. This is a fixed record of AWS developer-guide prose, captured because the suite asserts a behaviour the documentation states two different ways. The measured behaviour is in tests/tier2/vectorSearch/updateLifecycle.test.ts; this file is the evidence that the documentation disagrees with itself, so the claim is checkable without trusting a changelog sentence.",
+  "observed": {
+    "behaviour": "SearchVectors rejects for the whole pre-ready window, with two distinct messages depending on how far the index has progressed.",
+    "messages": [
+      "ValidationException: The table does not have the specified index: <indexName>",
+      "ValidationException: Cannot search backfilling vector index: <indexName>"
+    ],
+    "region": "eu-west-2",
+    "characterisedOn": "2026-08-11"
+  },
+  "sides": {
+    "callFails": [
+      {
+        "page": "Data synchronization between tables and vector indexes",
+        "url": "https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/VectorSearchDataSync.html",
+        "anchor": "VectorSearchDataSync.Backfilling",
+        "quote": "New writes to the base table are replicated to the index during this phase, but SearchVectors returns an error until backfilling finishes. Use DescribeTable and wait until IndexStatus is ACTIVE and Backfilling is false before you search."
+      },
+      {
+        "page": "Creating and searching vector indexes",
+        "url": "https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/VectorSearchWorkingWith.html",
+        "anchor": "VectorSearchWorkingWith.Create.ExistingTable",
+        "quote": "You can't search while the index is backfilling. SearchVectors returns an error while a vector index is backfilling. Use DescribeTable to check both the IndexStatus and the Backfilling flag, and wait until IndexStatus is ACTIVE and Backfilling is false before you search. There is no BACKFILLING index status value."
+      },
+      {
+        "page": "Troubleshooting vector indexes",
+        "url": "https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/VectorSearchTroubleshooting.html",
+        "anchor": "VectorSearchTroubleshooting",
+        "form": "A row in the symptom/cause/resolution table, quoted cell by cell rather than run together as prose.",
+        "symptom": "SearchVectors returns an error while the index is backfilling",
+        "cause": "The vector index is not yet ready for search. Either IndexStatus is CREATING, or IndexStatus is ACTIVE with Backfilling set to true. You can't search a vector index until backfilling completes.",
+        "resolution": "Use DescribeTable and wait until Backfilling is false, then retry the search."
+      }
+    ],
+    "resultsIncomplete": [
+      {
+        "page": "Tutorial: Your first vector search",
+        "url": "https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/VectorSearchTutorial.html",
+        "anchor": "VectorSearchTutorial",
+        "callout": "Wait for the index, not just the table",
+        "quote": "Searching an index that is not yet ACTIVE fails, and searching during backfill can return incomplete results.",
+        "secondQuote": "Backfilling is reported for a vector index that you add to an existing table with UpdateTable. In that case, wait until IndexStatus is ACTIVE and Backfilling is false before you rely on complete search results."
+      }
+    ],
+    "silent": [
+      {
+        "page": "SearchVectors API reference",
+        "url": "https://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_SearchVectors.html",
+        "quote": "The index must be in the ACTIVE state.",
+        "note": "Silent on backfill, not on readiness. The IndexName parameter requires ACTIVE and ResourceNotFoundException notes that a resource's status might not be ACTIVE, but neither mentions backfilling or the Backfilling flag. ACTIVE alone is not sufficient: the developer guide's own account has the index ACTIVE with Backfilling true, a state in which the call fails, and the errors listed here do not include the ValidationException that state actually returns."
+      }
+    ]
+  },
+  "adjacent": {
+    "note": "The tutorial also instructs readers to use IndexStatus alone as the readiness signal on the CreateTable path, where Backfilling is not reported. The suite found that insufficient: DescribeTable can report the index ACTIVE a beat before the search plane agrees, so readiness is proven by a search returning the full expected count, never by the description.",
+    "url": "https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/VectorSearchTutorial.html",
+    "quote": "For an index created as part of CreateTable, as in this tutorial, Backfilling is not reported and the command returns null for it. Use IndexStatus alone as your signal in that case."
+  }
+}

--- a/captures/README.md
+++ b/captures/README.md
@@ -27,6 +27,19 @@ baseline lives in the dated snapshot below instead, and the scheduled-run drift
 verdict flags when it needs refreshing. Currently seeded from the 2026-06-09
 capture until the first scheduled run overwrites it.
 
+## 2026-08-12-vector-backfill-docs.json
+
+The one capture that is not an API response. AWS's developer guide states two
+different things about calling `SearchVectors` against a backfilling vector
+index: three pages (DataSync, WorkingWith, Troubleshooting) say the call
+returns an error, the tutorial page says searching during backfill "can return
+incomplete results", and the API reference is silent. The suite asserts the
+error, so this file fixes the prose on both sides with its URLs and anchors,
+dated, rather than leaving the claim resting on a changelog sentence. Measured
+behaviour lives in `tests/tier2/vectorSearch/updateLifecycle.test.ts`; this is
+the evidence for the disagreement it settles. Re-check it if AWS edits either
+side.
+
 ## 2026-07-21-null-false-envelope.json
 
 The `{ NULL: false }` rejection message, captured in every region the sweep


### PR DESCRIPTION
## What this changes

Records both sides of the AWS documentation contradiction that the vector tests settle. The developer guide says `SearchVectors` returns an error while an index is backfilling; the tutorial says searching during backfill can return incomplete results. The suite asserts the error.

Adds `captures/2026-08-12-vector-backfill-docs.json` with the quotes, URLs and anchors on both sides, an entry in `captures/README.md`, and changes the changelog sentence to name which pages disagree rather than gesturing at the documentation as a whole. Relates to #125.

## Checklist

- ~~New or modified tests run against real AWS DynamoDB and pass~~ - no test changes
- ~~New or modified tests run against at least one emulator target and behave as expected~~ - no test changes
- [x] Linked issue or a short note explaining the motivation
- [x] I agree my contribution is licensed under the project's terms (Apache License, Version 2.0)

## Tier and scope

A capture file and documentation. No tests, scores, columns or tier definitions change.
