### PR TITLE
fix(ci): publish the results table from the weekly scheduled run

### DIFF
--- a/.github/workflows/results-table.yml
+++ b/.github/workflows/results-table.yml
@@ -33,10 +33,17 @@ jobs:
     # results-* artefacts, and reports head_branch as the branch name in the
     # fork - so a PR opened from a fork branch called `main` passed this and
     # had its artefacts committed to main and published, badges included.
+    # The head_repository check is what closes that, not the event list: a fork
+    # PR is excluded because its run belongs to the fork, whatever it is called.
+    # So the event list is only about which runs are a measurement worth
+    # publishing, and the weekly cron is the main one. Omitting `schedule` would
+    # have meant a Sunday run measuring every target and publishing none of it,
+    # leaving the board to move only on a merge to main.
     if: >-
       github.event_name == 'workflow_dispatch' ||
       (github.event.workflow_run.conclusion == 'success' &&
-       github.event.workflow_run.event == 'push' &&
+       (github.event.workflow_run.event == 'push' ||
+        github.event.workflow_run.event == 'schedule') &&
        github.event.workflow_run.head_branch == 'main' &&
        github.event.workflow_run.head_repository.full_name == github.repository)
 

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ DYNAMODB_ENDPOINT=http://localhost:8000 npm run test:tier1
 ## Results
 
 <!-- results:start -->
-Scored against real DynamoDB in each of the 32 observed regions, at each target's best-matching region.
+Scored against real DynamoDB in each of the 33 observed regions, at each target's best-matching region.
 
 **Coverage** is how much of DynamoDB's behaviour a target implements.
 
@@ -56,21 +56,21 @@ Both are shares of the whole suite, and they are never added together: an operat
 
 Rows are sorted by divergence. The tier columns are divergence within that tier, so lower is better in every column but Coverage. Behaviour varies by region and over time, so these are point-in-time figures.
 
-`me-central-1`, `me-south-1` have been dropped from the observed set and are not scored against.
+`me-south-1` has been dropped from the observed set and is not scored against.
 
 _Measured 2026-08-13, except where a row carries its own date._
 
 | Target | Grade | Version | Divergence | Coverage | Fail | Skip | Tier 1 | Tier 2 | Tier 3 | Regions | Measured |
 |--------|-------|---------|-----------|----------|------|------|--------|--------|--------|---------|----------|
-| [DynamoDB](https://aws.amazon.com/dynamodb/) | baseline | live (AWS) | 0.0% | 100.0% | 0 | 0 | 0.0% | 0.0% | 0.0% | 32 of 32 | 2026-08-12 |
-| [Dynoxide](https://github.com/nubo-db/dynoxide) · native | A | 0.13.0 | 0.9% | 94.7% | 10 | 56 | 2.0% | 0.0% | 0.0% | 4 of 32 |  |
-| ↳ WebAssembly / OPFS | B | 0.13.0 | 0.9% | 83.4% | 10 | 175 | 2.0% | 0.0% | 0.0% | 4 of 32 |  |
-| [ExtendDB](https://github.com/ExtendDB/extenddb) · PostgreSQL | B | v0.1.3 | 2.0% | 87.8% | 21 | 129 | 0.8% | 2.7% | 3.2% | 27 of 32 |  |
-| [Ministack](https://github.com/ministackorg/ministack) | B | 63621de32116 | 11.9% | 96.0% | 125 | 42 | 5.7% | 15.1% | 18.5% | 27 of 32 |  |
-| [Dynalite](https://github.com/architect/dynalite) | C | 4.0.0 | 12.8% | 77.0% | 135 | 242 | 10.8% | 12.4% | 15.9% | 23 of 32 |  |
-| [LocalStack](https://github.com/localstack/localstack) | C | 2026.7.3 | 14.8% | 95.3% | 156 | 50 | 6.3% | 16.0% | 26.2% | 25 of 32 |  |
-| [DynamoDB Local](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/DynamoDBLocal.html) | C | ff89bd48ff32 | 15.1% | 94.0% | 159 | 63 | 7.6% | 14.2% | 26.5% | 25 of 32 |  |
-| [Floci](https://github.com/floci-io/floci) | C | eab36252ea43 | 21.0% | 95.2% | 221 | 51 | 10.8% | 32.4% | 27.9% | 27 of 32 |  |
+| [DynamoDB](https://aws.amazon.com/dynamodb/) | baseline | live (AWS) | 0.0% | 100.0% | 0 | 0 | 0.0% | 0.0% | 0.0% | 33 of 33 | 2026-08-12 |
+| [Dynoxide](https://github.com/nubo-db/dynoxide) · native | A | 0.13.0 | 0.9% | 94.7% | 10 | 56 | 2.0% | 0.0% | 0.0% | 4 of 33 |  |
+| ↳ WebAssembly / OPFS | B | 0.13.0 | 0.9% | 83.4% | 10 | 175 | 2.0% | 0.0% | 0.0% | 4 of 33 |  |
+| [ExtendDB](https://github.com/ExtendDB/extenddb) · PostgreSQL | B | v0.1.3 | 2.0% | 87.8% | 21 | 129 | 0.8% | 2.7% | 3.2% | 27 of 33 |  |
+| [Ministack](https://github.com/ministackorg/ministack) | B | 63621de32116 | 11.9% | 96.0% | 125 | 42 | 5.7% | 15.1% | 18.5% | 27 of 33 |  |
+| [Dynalite](https://github.com/architect/dynalite) | C | 4.0.0 | 12.8% | 77.0% | 135 | 242 | 10.8% | 12.4% | 15.9% | 23 of 33 |  |
+| [LocalStack](https://github.com/localstack/localstack) | C | 2026.7.3 | 14.8% | 95.3% | 156 | 50 | 6.3% | 16.0% | 26.2% | 25 of 33 |  |
+| [DynamoDB Local](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/DynamoDBLocal.html) | C | ff89bd48ff32 | 15.1% | 94.0% | 159 | 63 | 7.6% | 14.2% | 26.5% | 25 of 33 |  |
+| [Floci](https://github.com/floci-io/floci) | C | eab36252ea43 | 21.0% | 95.2% | 221 | 51 | 10.8% | 32.4% | 27.9% | 27 of 33 |  |
 <!-- results:end -->
 
 **Divergence** is `Fail / Total` and **Coverage** is `(Pass + Fail) / Total`,

--- a/results/summary.json
+++ b/results/summary.json
@@ -28,6 +28,7 @@
       "eu-west-2",
       "eu-west-3",
       "il-central-1",
+      "me-central-1",
       "mx-central-1",
       "sa-east-1",
       "us-east-1",
@@ -37,144 +38,143 @@
     ],
     "unresolved": [],
     "dropped": [
-      "me-central-1",
       "me-south-1"
     ],
     "detail": {
       "af-south-1": {
-        "lastResolved": "2026-08-08",
+        "lastResolved": "2026-08-15",
         "consecutiveUnresolved": 0
       },
       "ap-east-1": {
-        "lastResolved": "2026-08-08",
+        "lastResolved": "2026-08-15",
         "consecutiveUnresolved": 0
       },
       "ap-east-2": {
-        "lastResolved": "2026-08-08",
+        "lastResolved": "2026-08-15",
         "consecutiveUnresolved": 0
       },
       "ap-northeast-1": {
-        "lastResolved": "2026-08-08",
+        "lastResolved": "2026-08-15",
         "consecutiveUnresolved": 0
       },
       "ap-northeast-2": {
-        "lastResolved": "2026-08-08",
+        "lastResolved": "2026-08-15",
         "consecutiveUnresolved": 0
       },
       "ap-northeast-3": {
-        "lastResolved": "2026-08-08",
+        "lastResolved": "2026-08-15",
         "consecutiveUnresolved": 0
       },
       "ap-south-1": {
-        "lastResolved": "2026-08-08",
+        "lastResolved": "2026-08-15",
         "consecutiveUnresolved": 0
       },
       "ap-south-2": {
-        "lastResolved": "2026-08-08",
+        "lastResolved": "2026-08-15",
         "consecutiveUnresolved": 0
       },
       "ap-southeast-1": {
-        "lastResolved": "2026-08-08",
+        "lastResolved": "2026-08-15",
         "consecutiveUnresolved": 0
       },
       "ap-southeast-2": {
-        "lastResolved": "2026-08-08",
+        "lastResolved": "2026-08-15",
         "consecutiveUnresolved": 0
       },
       "ap-southeast-3": {
-        "lastResolved": "2026-08-08",
+        "lastResolved": "2026-08-15",
         "consecutiveUnresolved": 0
       },
       "ap-southeast-4": {
-        "lastResolved": "2026-08-08",
+        "lastResolved": "2026-08-15",
         "consecutiveUnresolved": 0
       },
       "ap-southeast-5": {
-        "lastResolved": "2026-08-08",
+        "lastResolved": "2026-08-15",
         "consecutiveUnresolved": 0
       },
       "ap-southeast-6": {
-        "lastResolved": "2026-08-08",
+        "lastResolved": "2026-08-15",
         "consecutiveUnresolved": 0
       },
       "ap-southeast-7": {
-        "lastResolved": "2026-08-08",
+        "lastResolved": "2026-08-15",
         "consecutiveUnresolved": 0
       },
       "ca-central-1": {
-        "lastResolved": "2026-08-08",
+        "lastResolved": "2026-08-15",
         "consecutiveUnresolved": 0
       },
       "ca-west-1": {
-        "lastResolved": "2026-08-08",
+        "lastResolved": "2026-08-15",
         "consecutiveUnresolved": 0
       },
       "eu-central-1": {
-        "lastResolved": "2026-08-08",
+        "lastResolved": "2026-08-15",
         "consecutiveUnresolved": 0
       },
       "eu-central-2": {
-        "lastResolved": "2026-08-08",
+        "lastResolved": "2026-08-15",
         "consecutiveUnresolved": 0
       },
       "eu-north-1": {
-        "lastResolved": "2026-08-08",
+        "lastResolved": "2026-08-15",
         "consecutiveUnresolved": 0
       },
       "eu-south-1": {
-        "lastResolved": "2026-08-08",
+        "lastResolved": "2026-08-15",
         "consecutiveUnresolved": 0
       },
       "eu-south-2": {
-        "lastResolved": "2026-08-08",
+        "lastResolved": "2026-08-15",
         "consecutiveUnresolved": 0
       },
       "eu-west-1": {
-        "lastResolved": "2026-08-08",
+        "lastResolved": "2026-08-15",
         "consecutiveUnresolved": 0
       },
       "eu-west-2": {
-        "lastResolved": "2026-08-08",
+        "lastResolved": "2026-08-15",
         "consecutiveUnresolved": 0
       },
       "eu-west-3": {
-        "lastResolved": "2026-08-08",
+        "lastResolved": "2026-08-15",
         "consecutiveUnresolved": 0
       },
       "il-central-1": {
-        "lastResolved": "2026-08-08",
+        "lastResolved": "2026-08-15",
         "consecutiveUnresolved": 0
       },
       "me-central-1": {
-        "lastResolved": "2026-07-18",
-        "consecutiveUnresolved": 3
+        "lastResolved": "2026-08-15",
+        "consecutiveUnresolved": 0
       },
       "me-south-1": {
         "lastResolved": null,
-        "consecutiveUnresolved": 6
+        "consecutiveUnresolved": 7
       },
       "mx-central-1": {
-        "lastResolved": "2026-08-08",
+        "lastResolved": "2026-08-15",
         "consecutiveUnresolved": 0
       },
       "sa-east-1": {
-        "lastResolved": "2026-08-08",
+        "lastResolved": "2026-08-15",
         "consecutiveUnresolved": 0
       },
       "us-east-1": {
-        "lastResolved": "2026-08-08",
+        "lastResolved": "2026-08-15",
         "consecutiveUnresolved": 0
       },
       "us-east-2": {
-        "lastResolved": "2026-08-08",
+        "lastResolved": "2026-08-15",
         "consecutiveUnresolved": 0
       },
       "us-west-1": {
-        "lastResolved": "2026-08-08",
+        "lastResolved": "2026-08-15",
         "consecutiveUnresolved": 0
       },
       "us-west-2": {
-        "lastResolved": "2026-08-08",
+        "lastResolved": "2026-08-15",
         "consecutiveUnresolved": 0
       }
     }
@@ -941,6 +941,34 @@
           }
         },
         "il-central-1": {
+          "rate": 83.3,
+          "passed": 676,
+          "failed": 136,
+          "skipped": 242,
+          "indeterminate": 0,
+          "count": 1054,
+          "tiers": {
+            "tier1": {
+              "p": 436,
+              "f": 53,
+              "s": 0,
+              "i": 0
+            },
+            "tier2": {
+              "p": 12,
+              "f": 28,
+              "s": 185,
+              "i": 0
+            },
+            "tier3": {
+              "p": 228,
+              "f": 55,
+              "s": 57,
+              "i": 0
+            }
+          }
+        },
+        "me-central-1": {
           "rate": 83.3,
           "passed": 676,
           "failed": 136,
@@ -1874,6 +1902,34 @@
             }
           }
         },
+        "me-central-1": {
+          "rate": 83.9,
+          "passed": 831,
+          "failed": 160,
+          "skipped": 63,
+          "indeterminate": 0,
+          "count": 1054,
+          "tiers": {
+            "tier1": {
+              "p": 452,
+              "f": 37,
+              "s": 0,
+              "i": 0
+            },
+            "tier2": {
+              "p": 146,
+              "f": 32,
+              "s": 47,
+              "i": 0
+            },
+            "tier3": {
+              "p": 233,
+              "f": 91,
+              "s": 16,
+              "i": 0
+            }
+          }
+        },
         "mx-central-1": {
           "rate": 84,
           "passed": 832,
@@ -2775,6 +2831,34 @@
             "tier3": {
               "p": 319,
               "f": 5,
+              "s": 16,
+              "i": 0
+            }
+          }
+        },
+        "me-central-1": {
+          "rate": 98.8,
+          "passed": 986,
+          "failed": 12,
+          "skipped": 56,
+          "indeterminate": 0,
+          "count": 1054,
+          "tiers": {
+            "tier1": {
+              "p": 479,
+              "f": 10,
+              "s": 0,
+              "i": 0
+            },
+            "tier2": {
+              "p": 185,
+              "f": 0,
+              "s": 40,
+              "i": 0
+            },
+            "tier3": {
+              "p": 322,
+              "f": 2,
               "s": 16,
               "i": 0
             }
@@ -3686,6 +3770,34 @@
             }
           }
         },
+        "me-central-1": {
+          "rate": 98.6,
+          "passed": 867,
+          "failed": 12,
+          "skipped": 175,
+          "indeterminate": 0,
+          "count": 1054,
+          "tiers": {
+            "tier1": {
+              "p": 479,
+              "f": 10,
+              "s": 0,
+              "i": 0
+            },
+            "tier2": {
+              "p": 101,
+              "f": 0,
+              "s": 124,
+              "i": 0
+            },
+            "tier3": {
+              "p": 287,
+              "f": 2,
+              "s": 51,
+              "i": 0
+            }
+          }
+        },
         "mx-central-1": {
           "rate": 98.5,
           "passed": 866,
@@ -4587,6 +4699,34 @@
             "tier3": {
               "p": 307,
               "f": 13,
+              "s": 20,
+              "i": 0
+            }
+          }
+        },
+        "me-central-1": {
+          "rate": 97.6,
+          "passed": 903,
+          "failed": 22,
+          "skipped": 129,
+          "indeterminate": 0,
+          "count": 1054,
+          "tiers": {
+            "tier1": {
+              "p": 485,
+              "f": 4,
+              "s": 0,
+              "i": 0
+            },
+            "tier2": {
+              "p": 110,
+              "f": 6,
+              "s": 109,
+              "i": 0
+            },
+            "tier3": {
+              "p": 308,
+              "f": 12,
               "s": 20,
               "i": 0
             }
@@ -5498,6 +5638,34 @@
             }
           }
         },
+        "me-central-1": {
+          "rate": 77.9,
+          "passed": 781,
+          "failed": 222,
+          "skipped": 51,
+          "indeterminate": 0,
+          "count": 1054,
+          "tiers": {
+            "tier1": {
+              "p": 436,
+              "f": 53,
+              "s": 0,
+              "i": 0
+            },
+            "tier2": {
+              "p": 117,
+              "f": 73,
+              "s": 35,
+              "i": 0
+            },
+            "tier3": {
+              "p": 228,
+              "f": 96,
+              "s": 16,
+              "i": 0
+            }
+          }
+        },
         "mx-central-1": {
           "rate": 78,
           "passed": 782,
@@ -6404,6 +6572,34 @@
             }
           }
         },
+        "me-central-1": {
+          "rate": 84.4,
+          "passed": 847,
+          "failed": 157,
+          "skipped": 50,
+          "indeterminate": 0,
+          "count": 1054,
+          "tiers": {
+            "tier1": {
+              "p": 458,
+              "f": 31,
+              "s": 0,
+              "i": 0
+            },
+            "tier2": {
+              "p": 155,
+              "f": 36,
+              "s": 34,
+              "i": 0
+            },
+            "tier3": {
+              "p": 234,
+              "f": 90,
+              "s": 16,
+              "i": 0
+            }
+          }
+        },
         "mx-central-1": {
           "rate": 84.5,
           "passed": 848,
@@ -7305,6 +7501,34 @@
             "tier3": {
               "p": 259,
               "f": 65,
+              "s": 16,
+              "i": 0
+            }
+          }
+        },
+        "me-central-1": {
+          "rate": 87.5,
+          "passed": 886,
+          "failed": 126,
+          "skipped": 42,
+          "indeterminate": 0,
+          "count": 1054,
+          "tiers": {
+            "tier1": {
+              "p": 461,
+              "f": 28,
+              "s": 0,
+              "i": 0
+            },
+            "tier2": {
+              "p": 165,
+              "f": 34,
+              "s": 26,
+              "i": 0
+            },
+            "tier3": {
+              "p": 260,
+              "f": 64,
               "s": 16,
               "i": 0
             }


### PR DESCRIPTION
## What this changes

The auto-publish gate on Update Results Table accepted `push` only, so a scheduled conformance run would have measured every target and committed none of it. This adds `schedule` alongside it.

Fork safety is unchanged. That is carried by the `head_repository` check and by the re-verification in the resolve step, not by the event list.

Caught between runs, so nothing has been missed. Sunday's 04:00 UTC run is the first one it applies to, and it picks up ExtendDB v0.1.5.

## Checklist

- ~~New or modified tests run against real AWS DynamoDB and pass~~ (no test changes)
- ~~New or modified tests run against at least one emulator target and behave as expected~~ (no test changes)
- [x] Linked issue or a short note explaining the motivation
- [x] I agree my contribution is licensed under the project's terms
  (Apache License, Version 2.0)

## Tier and scope

Touches the results pipeline, but only which runs are allowed to publish. No tier definitions, no target configuration, and no regenerated artefacts in this PR. The next scheduled run publishes the usual set: the per-target results and versions, the integration and GSI lanes, `results/summary.json`, the badges and the README table.
