### PR TITLE
fix(ci): regenerate the derived board when the sweep records region health

### DIFF
--- a/.github/workflows/sweep.yml
+++ b/.github/workflows/sweep.yml
@@ -279,20 +279,74 @@ jobs:
           # Re-auth with the freshly minted token; checkout's persisted one has expired.
           git remote set-url origin "https://x-access-token:${BOT_TOKEN}@github.com/${{ github.repository }}.git"
           git add registry/regions.json
-          if git diff --staged --quiet; then
-            echo "Region health unchanged."
-          else
-            git commit -m "chore: update region health"
-            pushed=0
-            for i in 1 2 3; do
-              if git pull --rebase && git push; then pushed=1; break; fi
-              echo "push attempt $i failed; retrying"
-              sleep 5
-            done
-            if [ "$pushed" -ne 1 ]; then
-              echo "::warning title=Region health::push failed after 3 attempts; this sweep's health record was not persisted"
-              exit 1
+
+          # The published board is derived from this record, so it moves with
+          # it: the observed set is the denominator of every target's Regions
+          # column, and admitting or dropping a region can change which region
+          # is a target's headline and so its grade. Both the table and the
+          # badges read the health record through the shared scorer.
+          #
+          # Regenerating here rather than leaving it to a later run, because
+          # there is no later run: all three paths below sit in conformance.yml's
+          # paths-ignore, so this push starts no conformance run, and the results
+          # table only publishes off one. The board would keep the previous
+          # region set until an unrelated merge happened to refresh it, and the
+          # freshness tests in the cheap gate would hold main red until then.
+          # Regeneration degrades rather than aborting the step. Both scripts
+          # refuse to publish rather than publish something wrong - summarise
+          # asserts the suite it is scoring against, and the observed set it
+          # reads is the one this sweep just wrote - and the step runs under
+          # `bash -e`, so a throw between staging the record and committing it
+          # would end the step with the record uncommitted on a runner about to
+          # vanish. That is the loss the always() above exists to prevent, and
+          # it would cost a week of health for a board that can be rebuilt on
+          # the next run. So the record is committed either way, and a board
+          # that could not be rebuilt leaves main red and says so - the state
+          # this step was already in before it regenerated anything.
+          # Regeneration is unconditional, and the "nothing to do" exit comes
+          # after it rather than before. Gating it on the record having changed
+          # would strand exactly the run that needs it: a degraded run commits
+          # the record with a stale board, and the obvious way to fix that -
+          # re-running the sweep by hand the same day - produces a byte-identical
+          # record, so a gate on the record alone would skip the rebuild and do
+          # nothing. Rebuilding costs a second or two and is idempotent, so the
+          # step is safe to re-run and self-heals whether or not health moved.
+          msg="chore: update region health and the board derived from it"
+          if node scripts/summarise.mjs --write && node scripts/badges.mjs; then
+            git add README.md results
+            if git diff --staged --quiet -- registry/regions.json; then
+              # Health did not move, so this run only rebuilt a board that had
+              # drifted from it. Say that rather than claim a health update.
+              msg="chore: rebuild the board from the region health record"
             fi
+          else
+            echo "::warning title=Board::regeneration failed; committing the health record alone. The board is stale until a later run rebuilds it, and main stays red on the freshness tests until then."
+            # publish() splices README.md before it writes results/summary.json,
+            # so a half-written board is possible and has to go rather than be
+            # committed as though it were derived from the record beside it.
+            git checkout -- README.md results
+            msg="chore: update region health"
+          fi
+
+          if git diff --staged --quiet; then
+            echo "Region health unchanged, and the board already matches it."
+            exit 0
+          fi
+
+          git commit -m "$msg"
+          pushed=0
+          for i in 1 2 3; do
+            # A conflicted `git pull --rebase` leaves the rebase in progress and
+            # every later pull refuses while one is, so without this the second
+            # and third attempts cannot do anything the first did not.
+            git rebase --abort 2>/dev/null || true
+            if git pull --rebase && git push; then pushed=1; break; fi
+            echo "push attempt $i failed; retrying"
+            sleep 5
+          done
+          if [ "$pushed" -ne 1 ]; then
+            echo "::warning title=Region health::push failed after 3 attempts; this sweep's health record was not persisted"
+            exit 1
           fi
 
   cleanup:

--- a/scripts/sweep-publish-wiring.test.mjs
+++ b/scripts/sweep-publish-wiring.test.mjs
@@ -1,0 +1,98 @@
+import { readFileSync } from 'node:fs'
+import { describe, expect, it } from 'vitest'
+
+// The sweep commits registry/regions.json to main, and the published board is
+// derived from that record: the observed set is the denominator of every
+// target's Regions column, and admitting or dropping a region can move a
+// target's headline region and so its grade. All three paths sit in
+// conformance.yml's paths-ignore, so the sweep's push starts no conformance
+// run and results-table.yml - which only publishes off one - never fires. If
+// the sweep records health without rebuilding the board, nothing else will,
+// and the freshness tests in the cheap gate hold main red until an unrelated
+// merge happens to refresh it.
+//
+// The freshness tests catch that only once a bad sweep has already landed.
+// These assertions are what make the wiring itself loud, in the same spirit as
+// registry-wiring.test.mjs: prose identity joined across artefacts, asserted
+// here rather than discovered in production a week later.
+
+const workflow = readFileSync('.github/workflows/sweep.yml', 'utf8')
+
+// The commit step, isolated so an occurrence of any of these strings elsewhere
+// in the file cannot satisfy the ordering assertions below.
+const step = (() => {
+  const start = workflow.indexOf('- name: Commit the region health record')
+  expect(start, 'sweep.yml no longer has a "Commit the region health record" step').toBeGreaterThan(
+    -1,
+  )
+  const next = workflow.indexOf('\n  cleanup:', start)
+  return workflow.slice(start, next === -1 ? undefined : next)
+})()
+
+// Comments stripped before any ordering is asserted. This step explains itself
+// at length, and prose that quotes a command it is describing would otherwise
+// satisfy - or, worse, silently invert - an ordering assertion about the code.
+const code = step
+  .split('\n')
+  .filter((line) => !line.trim().startsWith('#'))
+  .join('\n')
+
+// Presence is asserted on every lookup, so an ordering check cannot pass
+// vacuously. `expect(at(a)).toBeLessThan(at(b))` reads as a claim about order,
+// but a deleted `a` indexes to -1 and satisfies it against any b - so the
+// assertion guarding a line goes green precisely when that line is removed,
+// which is the regression it exists to catch.
+const at = (needle) => {
+  const index = code.indexOf(needle)
+  expect(index, `sweep.yml's commit step no longer contains \`${needle}\``).toBeGreaterThan(-1)
+  return index
+}
+
+describe('the sweep publishes the board it derives from the health record', () => {
+  it('regenerates the table and the badges', () => {
+    expect(at('node scripts/summarise.mjs --write')).toBeGreaterThan(-1)
+    expect(at('node scripts/badges.mjs')).toBeGreaterThan(-1)
+  })
+
+  it('regenerates after staging the record and before committing', () => {
+    expect(at('git add registry/regions.json')).toBeLessThan(at('node scripts/summarise.mjs'))
+    expect(at('node scripts/badges.mjs')).toBeLessThan(at('git commit'))
+  })
+
+  it('stages the board before the commit, not after it', () => {
+    // Presence alone is not the invariant. Staging that lands after the commit
+    // leaves the board staged-but-never-committed, which pushes nothing and
+    // reads, in the diff, exactly like staging that works.
+    expect(at('git add README.md results')).toBeLessThan(at('git commit'))
+  })
+
+  it('regenerates before deciding there is nothing to commit', () => {
+    // The early exit must not gate regeneration, or the run that most needs a
+    // rebuild - a hand re-run after a degraded run, whose health record comes
+    // out byte-identical - is the one run that skips it.
+    expect(at('node scripts/summarise.mjs --write')).toBeLessThan(
+      at('if git diff --staged --quiet; then'),
+    )
+  })
+
+  it('commits the record even when regeneration fails', () => {
+    // The step runs under `bash -e` and both scripts refuse to publish rather
+    // than publish something wrong, so an unguarded invocation between the
+    // staging and the commit would end the step with the record uncommitted -
+    // losing a week of health for a board the next run could have rebuilt.
+    const guarded = /if node scripts\/summarise\.mjs --write && node scripts\/badges\.mjs; then/.test(
+      code,
+    )
+    expect(guarded, 'regeneration must be guarded so a throw cannot skip the commit').toBe(true)
+    expect(at('::warning title=Board')).toBeGreaterThan(-1)
+    // A half-written board (publish() splices README before writing the
+    // summary) must be discarded rather than committed beside the record.
+    expect(at('git checkout -- README.md results')).toBeGreaterThan(-1)
+  })
+
+  it('clears a conflicted rebase before each push retry', () => {
+    // Every later `git pull --rebase` refuses while a rebase is in progress,
+    // so without this the second and third attempts are dead on arrival.
+    expect(at('git rebase --abort')).toBeLessThan(at('git pull --rebase'))
+  })
+})


### PR DESCRIPTION
## What this changes

The sweep commits `registry/regions.json`, and the published board is derived from that record: the observed set is the denominator of every target's Regions column, and admitting or dropping a region can move a target's headline region and so its grade. Nothing rebuilt the board afterwards.

There was no later run to do it, either. All three paths sit in `conformance.yml`'s `paths-ignore`, so the sweep's push starts no conformance run, and the results table only publishes off one. The board kept the previous region set until an unrelated merge happened to refresh it, with the freshness tests holding main red in the meantime.

The sweep now rebuilds the table and the badges and commits them with the record.

**Regeneration degrades rather than aborting the step.** Both scripts refuse to publish rather than publish something wrong, and the step runs under `bash -e`, so an unguarded invocation between staging the record and committing it would end the step with the record uncommitted on a runner about to vanish. That is the loss the step's `always()` exists to prevent, and it would cost a week of health for a board the next run could rebuild. So the record is committed either way, and a board that could not be rebuilt warns and leaves main red, which is the state the step was already in.

**Regeneration is unconditional, and the "nothing to do" exit comes after it.** Gating it on the record having changed would strand the run that most needs a rebuild: re-running the sweep by hand after a degraded run produces a byte-identical record, so a gate on the record alone would skip the rebuild and the run would do nothing. Rebuilding is idempotent and costs a second, so the step is safe to re-run and self-heals whether or not health moved.

`scripts/sweep-publish-wiring.test.mjs` guards the ordering. The freshness tests catch a stale board only once a bad sweep has already landed.

## Checklist

- ~~New or modified tests run against real AWS DynamoDB and pass~~ (no conformance test changes; the added test is a tooling unit test)
- ~~New or modified tests run against at least one emulator target and behave as expected~~ (same)
- [x] Linked issue or a short note explaining the motivation
- [x] I agree my contribution is licensed under the project's terms
  (Apache License, Version 2.0)

## Tier and scope

Touches the results pipeline, and adds a second writer of `README.md`, `results/summary.json` and the badges alongside Update Results Table. No tier definitions, no target configuration, and no change to how anything is scored. From here the weekly sweep's commit carries the regenerated board with it.

Known gap, left for its own issue: the two writers share no concurrency group. The detect job holds `conformance-aws` so it cannot race the AWS table cleanup, so it cannot simply join a board-write group instead.
