### PR TITLE
Re-characterise the BatchGetItem empty-RequestItems split

### DIFF
--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -189,6 +189,21 @@ jobs:
             --baseline captures/2026-07-13-empty-set-member.json \
             --region eu-west-2 --out "$RUNNER_TEMP/drift.json"
 
+      # Keep what the verdict was read from. The issue asserts drift and names
+      # probes, and the capture behind that claim otherwise dies with the
+      # runner, leaving a maintainer no way to check the reading or reuse it as
+      # the next baseline.
+      - name: Upload the drift evidence
+        if: failure() && github.event_name == 'schedule'
+        continue-on-error: true
+        uses: actions/upload-artifact@v7
+        with:
+          name: drift-evidence
+          path: |
+            ${{ runner.temp }}/euw2.json
+            ${{ runner.temp }}/drift.json
+          if-no-files-found: ignore
+
       # File or update a single deduped issue so a red scheduled run is actionable,
       # not a silent X. The drift verdict (if computed above) labels it aws-drift-confirmed
       # or likely-flake and fills the body's triage slot.
@@ -444,16 +459,33 @@ jobs:
 
   capture-cross-region:
     name: Cross-region drift capture (non-gating)
-    # Capture real AWS's negative-input wording in the candidate regions each
-    # week and commit it, so the paritysuite drift lens has fresh, versioned data
-    # (the site builds from committed files, not CI artefacts). Non-gating: a
-    # capture hiccup never touches the build. Only candidate regions are
-    # captured, never eu-west-2: the IAM role forces a _conformance_ table prefix
-    # that the gating job's cleanup deletes, so an eu-west-2 capture here would
-    # race that cleanup. The lens diffs these against the committed eu-west-2
-    # baseline; the scheduled-run drift verdict flags when the baseline itself
-    # needs refreshing.
-    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+    # Capture real AWS's negative-input wording each week and commit it, so the
+    # paritysuite drift lens has fresh, versioned data (the site builds from
+    # committed files, not CI artefacts). Non-gating: a capture hiccup never
+    # touches the build.
+    #
+    # eu-west-2 is captured here with the candidates, and `needs` is what makes
+    # that safe: the IAM role forces a _conformance_ table prefix that the
+    # gating job's cleanup deletes by prefix, so the two must not run side by
+    # side. Excluding the region was the older way of avoiding that collision,
+    # and it cost the lens the capture feeds - drift-diff.mjs exits 2 in
+    # cross-region mode without the baseline region in the document, rather than
+    # read every other region's probes as added, so the comparison fell back to
+    # a separate and older file. `always()` keeps the capture running when the
+    # gating job goes red, when the wording is most worth having.
+    needs: test-dynamodb
+    if: >-
+      always() &&
+      (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch')
+    # Now that the capture creates tables in eu-west-2, it has to hold the same
+    # lock the gating run does: `needs` only orders it behind its own run, and a
+    # second run's cleanup deletes every _conformance_ table by prefix, which
+    # would take this job's tables out from under it. The gating job has already
+    # released the group by the time this one is eligible, so it queues rather
+    # than deadlocks.
+    concurrency:
+      group: conformance-aws
+      cancel-in-progress: false
     continue-on-error: true
     runs-on: ubuntu-latest
     permissions:
@@ -489,9 +521,9 @@ jobs:
           aws-region: eu-west-2
           role-duration-seconds: 7200
 
-      - name: Capture candidate regions
+      - name: Capture the baseline and candidate regions
         run: |
-          node scripts/capture-validation-messages.mjs us-east-1 ap-southeast-2 eu-central-1 \
+          node scripts/capture-validation-messages.mjs eu-west-2 us-east-1 ap-southeast-2 eu-central-1 \
             > captures/cross-region-latest.json
 
       - name: Commit the capture

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,29 @@ section its date and version, so several branches can write ahead of one.
 
 ## Unreleased
 
+eu-west-2 has crossed to the validation framework's generic constraint message
+for `BatchGetItem` with an empty `RequestItems` map, so the split row recording
+that behaviour is re-characterised against a 34-region capture taken on
+2026-08-17. Eleven of the thirty-three regions that answer now return the
+generic message; twenty-two still return the bespoke required-parameter
+sentence, and me-central-1 joins the row.
+
+The matching validation-ordering row is retired. Both wordings refuse an empty
+`RequestItems` before the map is read, which is all that tier asserts, so the
+assertion now matches the parameter name case-insensitively and spans both. The
+`BatchWriteItem` case beside it, which no region has moved yet, is written the
+same way.
+
+A probe absent from the baseline is no longer reported as drift. Adding a probe
+to the capture script leaves every older baseline without it, and a scheduled
+red then named the new probe as the thing that had moved.
+
+The weekly cross-region capture now includes eu-west-2, so the drift lens reads
+its baseline and the candidate regions from one capture taken at one moment
+rather than comparing today's candidates against an older baseline file. A
+scheduled red also keeps the eu-west-2 capture its drift verdict was read from,
+which was previously discarded with the runner.
+
 ## 2026-08-15 (3.1.0)
 
 ExtendDB's SQLite backend joins the run, built from the same release as the

--- a/README.md
+++ b/README.md
@@ -63,15 +63,15 @@ _Measured 2026-08-15, except where a row carries its own date._
 | Target | Grade | Version | Divergence | Coverage | Fail | Skip | Tier 1 | Tier 2 | Tier 3 | Regions | Measured |
 |--------|-------|---------|-----------|----------|------|------|--------|--------|--------|---------|----------|
 | [DynamoDB](https://aws.amazon.com/dynamodb/) | baseline | live (AWS) | 0.0% | 100.0% | 0 | 0 | 0.0% | 0.0% | 0.0% | 33 of 33 | 2026-08-12 |
-| [Dynoxide](https://github.com/nubo-db/dynoxide) · native SQLite | A | 0.13.0 | 0.9% | 94.7% | 10 | 56 | 2.0% | 0.0% | 0.0% | 4 of 33 |  |
-| ↳ WebAssembly / OPFS | B | 0.13.0 | 0.9% | 83.4% | 10 | 175 | 2.0% | 0.0% | 0.0% | 4 of 33 |  |
-| [ExtendDB](https://github.com/ExtendDB/extenddb) · PostgreSQL | B | v0.1.5 | 1.9% | 87.8% | 20 | 129 | 0.8% | 1.8% | 3.5% | 27 of 33 |  |
-| ↳ SQLite | B | v0.1.5 | 1.8% | 87.8% | 19 | 129 | 0.8% | 1.8% | 3.2% | 27 of 33 |  |
-| [Ministack](https://github.com/ministackorg/ministack) | B | 2b75df610699 | 11.9% | 96.0% | 125 | 42 | 5.7% | 15.1% | 18.5% | 27 of 33 |  |
-| [Dynalite](https://github.com/architect/dynalite) | C | 4.0.0 | 12.8% | 77.0% | 135 | 242 | 10.8% | 12.4% | 15.9% | 23 of 33 |  |
+| [Dynoxide](https://github.com/nubo-db/dynoxide) · native SQLite | A | 0.13.0 | 0.9% | 94.7% | 10 | 56 | 2.0% | 0.0% | 0.0% | 5 of 33 |  |
+| ↳ WebAssembly / OPFS | B | 0.13.0 | 0.9% | 83.4% | 10 | 175 | 2.0% | 0.0% | 0.0% | 5 of 33 |  |
+| [ExtendDB](https://github.com/ExtendDB/extenddb) · PostgreSQL | B | v0.1.5 | 1.9% | 87.8% | 20 | 129 | 0.8% | 1.8% | 3.5% | 11 of 33 |  |
+| ↳ SQLite | B | v0.1.5 | 1.8% | 87.8% | 19 | 129 | 0.8% | 1.8% | 3.2% | 11 of 33 |  |
+| [Ministack](https://github.com/ministackorg/ministack) | B | 2b75df610699 | 11.9% | 96.0% | 125 | 42 | 5.7% | 15.1% | 18.5% | 11 of 33 |  |
+| [Dynalite](https://github.com/architect/dynalite) | C | 4.0.0 | 12.8% | 77.0% | 135 | 242 | 10.8% | 12.4% | 15.9% | 25 of 33 |  |
 | [LocalStack](https://github.com/localstack/localstack) | C | 2026.7.4 | 14.8% | 95.3% | 156 | 50 | 6.3% | 16.0% | 26.2% | 25 of 33 |  |
 | [DynamoDB Local](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/DynamoDBLocal.html) | C | ff89bd48ff32 | 15.1% | 94.0% | 159 | 63 | 7.6% | 14.2% | 26.5% | 25 of 33 |  |
-| [Floci](https://github.com/floci-io/floci) | C | eab36252ea43 | 21.0% | 95.2% | 221 | 51 | 10.8% | 32.4% | 27.9% | 27 of 33 |  |
+| [Floci](https://github.com/floci-io/floci) | C | eab36252ea43 | 21.0% | 95.2% | 221 | 51 | 10.8% | 32.4% | 27.9% | 11 of 33 |  |
 <!-- results:end -->
 
 **Divergence** is `Fail / Total` and **Coverage** is `(Pass + Fail) / Total`,

--- a/captures/2026-08-17-batch-empty-request-items.json
+++ b/captures/2026-08-17-batch-empty-request-items.json
@@ -1,0 +1,946 @@
+{
+  "capturedAt": "2026-08-17T11:03:04.985Z",
+  "note": "Evidence for registry row batch-get-item-empty-request-items-message and for retiring batch-get-item-empty-request-items-ordering (issues #152, #153, #156). Scoped to the empty-RequestItems probe on both batch operations; BatchWriteItem is captured alongside BatchGetItem because the two share an assertion shape and only one of them has moved. me-south-1 did not answer, so it carries no definite result here.",
+  "regions": {
+    "eu-west-2": {
+      "region": "eu-west-2",
+      "probes": [
+        {
+          "id": "o_bg_empty_requestitems",
+          "family": "ordering",
+          "note": "BatchGetItem RequestItems={}",
+          "threw": true,
+          "name": "ValidationException",
+          "message": "1 validation error detected: Value at 'RequestItems' failed to satisfy constraint: Member must have length greater than or equal to 1",
+          "n": 1,
+          "fields": [
+            "RequestItems"
+          ],
+          "cancellationReasons": null
+        },
+        {
+          "id": "o_bw_empty_requestitems",
+          "family": "ordering",
+          "note": "BatchWriteItem RequestItems={}",
+          "threw": true,
+          "name": "ValidationException",
+          "message": "The requestItems parameter is required for BatchWriteItem",
+          "n": null,
+          "fields": [],
+          "cancellationReasons": null
+        }
+      ]
+    },
+    "us-east-1": {
+      "region": "us-east-1",
+      "probes": [
+        {
+          "id": "o_bg_empty_requestitems",
+          "family": "ordering",
+          "note": "BatchGetItem RequestItems={}",
+          "threw": true,
+          "name": "ValidationException",
+          "message": "The requestItems parameter is required for BatchGetItem",
+          "n": null,
+          "fields": [],
+          "cancellationReasons": null
+        },
+        {
+          "id": "o_bw_empty_requestitems",
+          "family": "ordering",
+          "note": "BatchWriteItem RequestItems={}",
+          "threw": true,
+          "name": "ValidationException",
+          "message": "The requestItems parameter is required for BatchWriteItem",
+          "n": null,
+          "fields": [],
+          "cancellationReasons": null
+        }
+      ]
+    },
+    "eu-central-1": {
+      "region": "eu-central-1",
+      "probes": [
+        {
+          "id": "o_bg_empty_requestitems",
+          "family": "ordering",
+          "note": "BatchGetItem RequestItems={}",
+          "threw": true,
+          "name": "ValidationException",
+          "message": "1 validation error detected: Value at 'RequestItems' failed to satisfy constraint: Member must have length greater than or equal to 1",
+          "n": 1,
+          "fields": [
+            "RequestItems"
+          ],
+          "cancellationReasons": null
+        },
+        {
+          "id": "o_bw_empty_requestitems",
+          "family": "ordering",
+          "note": "BatchWriteItem RequestItems={}",
+          "threw": true,
+          "name": "ValidationException",
+          "message": "The requestItems parameter is required for BatchWriteItem",
+          "n": null,
+          "fields": [],
+          "cancellationReasons": null
+        }
+      ]
+    },
+    "ap-southeast-2": {
+      "region": "ap-southeast-2",
+      "probes": [
+        {
+          "id": "o_bg_empty_requestitems",
+          "family": "ordering",
+          "note": "BatchGetItem RequestItems={}",
+          "threw": true,
+          "name": "ValidationException",
+          "message": "The requestItems parameter is required for BatchGetItem",
+          "n": null,
+          "fields": [],
+          "cancellationReasons": null
+        },
+        {
+          "id": "o_bw_empty_requestitems",
+          "family": "ordering",
+          "note": "BatchWriteItem RequestItems={}",
+          "threw": true,
+          "name": "ValidationException",
+          "message": "The requestItems parameter is required for BatchWriteItem",
+          "n": null,
+          "fields": [],
+          "cancellationReasons": null
+        }
+      ]
+    },
+    "af-south-1": {
+      "region": "af-south-1",
+      "probes": [
+        {
+          "id": "o_bg_empty_requestitems",
+          "family": "ordering",
+          "note": "BatchGetItem RequestItems={}",
+          "threw": true,
+          "name": "ValidationException",
+          "message": "1 validation error detected: Value at 'RequestItems' failed to satisfy constraint: Member must have length greater than or equal to 1",
+          "n": 1,
+          "fields": [
+            "RequestItems"
+          ],
+          "cancellationReasons": null
+        },
+        {
+          "id": "o_bw_empty_requestitems",
+          "family": "ordering",
+          "note": "BatchWriteItem RequestItems={}",
+          "threw": true,
+          "name": "ValidationException",
+          "message": "The requestItems parameter is required for BatchWriteItem",
+          "n": null,
+          "fields": [],
+          "cancellationReasons": null
+        }
+      ]
+    },
+    "ap-east-1": {
+      "region": "ap-east-1",
+      "probes": [
+        {
+          "id": "o_bg_empty_requestitems",
+          "family": "ordering",
+          "note": "BatchGetItem RequestItems={}",
+          "threw": true,
+          "name": "ValidationException",
+          "message": "The requestItems parameter is required for BatchGetItem",
+          "n": null,
+          "fields": [],
+          "cancellationReasons": null
+        },
+        {
+          "id": "o_bw_empty_requestitems",
+          "family": "ordering",
+          "note": "BatchWriteItem RequestItems={}",
+          "threw": true,
+          "name": "ValidationException",
+          "message": "The requestItems parameter is required for BatchWriteItem",
+          "n": null,
+          "fields": [],
+          "cancellationReasons": null
+        }
+      ]
+    },
+    "ap-east-2": {
+      "region": "ap-east-2",
+      "probes": [
+        {
+          "id": "o_bg_empty_requestitems",
+          "family": "ordering",
+          "note": "BatchGetItem RequestItems={}",
+          "threw": true,
+          "name": "ValidationException",
+          "message": "The requestItems parameter is required for BatchGetItem",
+          "n": null,
+          "fields": [],
+          "cancellationReasons": null
+        },
+        {
+          "id": "o_bw_empty_requestitems",
+          "family": "ordering",
+          "note": "BatchWriteItem RequestItems={}",
+          "threw": true,
+          "name": "ValidationException",
+          "message": "The requestItems parameter is required for BatchWriteItem",
+          "n": null,
+          "fields": [],
+          "cancellationReasons": null
+        }
+      ]
+    },
+    "ap-northeast-1": {
+      "region": "ap-northeast-1",
+      "probes": [
+        {
+          "id": "o_bg_empty_requestitems",
+          "family": "ordering",
+          "note": "BatchGetItem RequestItems={}",
+          "threw": true,
+          "name": "ValidationException",
+          "message": "The requestItems parameter is required for BatchGetItem",
+          "n": null,
+          "fields": [],
+          "cancellationReasons": null
+        },
+        {
+          "id": "o_bw_empty_requestitems",
+          "family": "ordering",
+          "note": "BatchWriteItem RequestItems={}",
+          "threw": true,
+          "name": "ValidationException",
+          "message": "The requestItems parameter is required for BatchWriteItem",
+          "n": null,
+          "fields": [],
+          "cancellationReasons": null
+        }
+      ]
+    },
+    "ap-northeast-2": {
+      "region": "ap-northeast-2",
+      "probes": [
+        {
+          "id": "o_bg_empty_requestitems",
+          "family": "ordering",
+          "note": "BatchGetItem RequestItems={}",
+          "threw": true,
+          "name": "ValidationException",
+          "message": "1 validation error detected: Value at 'RequestItems' failed to satisfy constraint: Member must have length greater than or equal to 1",
+          "n": 1,
+          "fields": [
+            "RequestItems"
+          ],
+          "cancellationReasons": null
+        },
+        {
+          "id": "o_bw_empty_requestitems",
+          "family": "ordering",
+          "note": "BatchWriteItem RequestItems={}",
+          "threw": true,
+          "name": "ValidationException",
+          "message": "The requestItems parameter is required for BatchWriteItem",
+          "n": null,
+          "fields": [],
+          "cancellationReasons": null
+        }
+      ]
+    },
+    "ap-northeast-3": {
+      "region": "ap-northeast-3",
+      "probes": [
+        {
+          "id": "o_bg_empty_requestitems",
+          "family": "ordering",
+          "note": "BatchGetItem RequestItems={}",
+          "threw": true,
+          "name": "ValidationException",
+          "message": "The requestItems parameter is required for BatchGetItem",
+          "n": null,
+          "fields": [],
+          "cancellationReasons": null
+        },
+        {
+          "id": "o_bw_empty_requestitems",
+          "family": "ordering",
+          "note": "BatchWriteItem RequestItems={}",
+          "threw": true,
+          "name": "ValidationException",
+          "message": "The requestItems parameter is required for BatchWriteItem",
+          "n": null,
+          "fields": [],
+          "cancellationReasons": null
+        }
+      ]
+    },
+    "ap-south-1": {
+      "region": "ap-south-1",
+      "probes": [
+        {
+          "id": "o_bg_empty_requestitems",
+          "family": "ordering",
+          "note": "BatchGetItem RequestItems={}",
+          "threw": true,
+          "name": "ValidationException",
+          "message": "The requestItems parameter is required for BatchGetItem",
+          "n": null,
+          "fields": [],
+          "cancellationReasons": null
+        },
+        {
+          "id": "o_bw_empty_requestitems",
+          "family": "ordering",
+          "note": "BatchWriteItem RequestItems={}",
+          "threw": true,
+          "name": "ValidationException",
+          "message": "The requestItems parameter is required for BatchWriteItem",
+          "n": null,
+          "fields": [],
+          "cancellationReasons": null
+        }
+      ]
+    },
+    "ap-south-2": {
+      "region": "ap-south-2",
+      "probes": [
+        {
+          "id": "o_bg_empty_requestitems",
+          "family": "ordering",
+          "note": "BatchGetItem RequestItems={}",
+          "threw": true,
+          "name": "ValidationException",
+          "message": "The requestItems parameter is required for BatchGetItem",
+          "n": null,
+          "fields": [],
+          "cancellationReasons": null
+        },
+        {
+          "id": "o_bw_empty_requestitems",
+          "family": "ordering",
+          "note": "BatchWriteItem RequestItems={}",
+          "threw": true,
+          "name": "ValidationException",
+          "message": "The requestItems parameter is required for BatchWriteItem",
+          "n": null,
+          "fields": [],
+          "cancellationReasons": null
+        }
+      ]
+    },
+    "ap-southeast-1": {
+      "region": "ap-southeast-1",
+      "probes": [
+        {
+          "id": "o_bg_empty_requestitems",
+          "family": "ordering",
+          "note": "BatchGetItem RequestItems={}",
+          "threw": true,
+          "name": "ValidationException",
+          "message": "1 validation error detected: Value at 'RequestItems' failed to satisfy constraint: Member must have length greater than or equal to 1",
+          "n": 1,
+          "fields": [
+            "RequestItems"
+          ],
+          "cancellationReasons": null
+        },
+        {
+          "id": "o_bw_empty_requestitems",
+          "family": "ordering",
+          "note": "BatchWriteItem RequestItems={}",
+          "threw": true,
+          "name": "ValidationException",
+          "message": "The requestItems parameter is required for BatchWriteItem",
+          "n": null,
+          "fields": [],
+          "cancellationReasons": null
+        }
+      ]
+    },
+    "ap-southeast-3": {
+      "region": "ap-southeast-3",
+      "probes": [
+        {
+          "id": "o_bg_empty_requestitems",
+          "family": "ordering",
+          "note": "BatchGetItem RequestItems={}",
+          "threw": true,
+          "name": "ValidationException",
+          "message": "1 validation error detected: Value at 'RequestItems' failed to satisfy constraint: Member must have length greater than or equal to 1",
+          "n": 1,
+          "fields": [
+            "RequestItems"
+          ],
+          "cancellationReasons": null
+        },
+        {
+          "id": "o_bw_empty_requestitems",
+          "family": "ordering",
+          "note": "BatchWriteItem RequestItems={}",
+          "threw": true,
+          "name": "ValidationException",
+          "message": "The requestItems parameter is required for BatchWriteItem",
+          "n": null,
+          "fields": [],
+          "cancellationReasons": null
+        }
+      ]
+    },
+    "ap-southeast-4": {
+      "region": "ap-southeast-4",
+      "probes": [
+        {
+          "id": "o_bg_empty_requestitems",
+          "family": "ordering",
+          "note": "BatchGetItem RequestItems={}",
+          "threw": true,
+          "name": "ValidationException",
+          "message": "1 validation error detected: Value at 'RequestItems' failed to satisfy constraint: Member must have length greater than or equal to 1",
+          "n": 1,
+          "fields": [
+            "RequestItems"
+          ],
+          "cancellationReasons": null
+        },
+        {
+          "id": "o_bw_empty_requestitems",
+          "family": "ordering",
+          "note": "BatchWriteItem RequestItems={}",
+          "threw": true,
+          "name": "ValidationException",
+          "message": "The requestItems parameter is required for BatchWriteItem",
+          "n": null,
+          "fields": [],
+          "cancellationReasons": null
+        }
+      ]
+    },
+    "ap-southeast-5": {
+      "region": "ap-southeast-5",
+      "probes": [
+        {
+          "id": "o_bg_empty_requestitems",
+          "family": "ordering",
+          "note": "BatchGetItem RequestItems={}",
+          "threw": true,
+          "name": "ValidationException",
+          "message": "1 validation error detected: Value at 'RequestItems' failed to satisfy constraint: Member must have length greater than or equal to 1",
+          "n": 1,
+          "fields": [
+            "RequestItems"
+          ],
+          "cancellationReasons": null
+        },
+        {
+          "id": "o_bw_empty_requestitems",
+          "family": "ordering",
+          "note": "BatchWriteItem RequestItems={}",
+          "threw": true,
+          "name": "ValidationException",
+          "message": "The requestItems parameter is required for BatchWriteItem",
+          "n": null,
+          "fields": [],
+          "cancellationReasons": null
+        }
+      ]
+    },
+    "ap-southeast-6": {
+      "region": "ap-southeast-6",
+      "probes": [
+        {
+          "id": "o_bg_empty_requestitems",
+          "family": "ordering",
+          "note": "BatchGetItem RequestItems={}",
+          "threw": true,
+          "name": "ValidationException",
+          "message": "The requestItems parameter is required for BatchGetItem",
+          "n": null,
+          "fields": [],
+          "cancellationReasons": null
+        },
+        {
+          "id": "o_bw_empty_requestitems",
+          "family": "ordering",
+          "note": "BatchWriteItem RequestItems={}",
+          "threw": true,
+          "name": "ValidationException",
+          "message": "The requestItems parameter is required for BatchWriteItem",
+          "n": null,
+          "fields": [],
+          "cancellationReasons": null
+        }
+      ]
+    },
+    "ap-southeast-7": {
+      "region": "ap-southeast-7",
+      "probes": [
+        {
+          "id": "o_bg_empty_requestitems",
+          "family": "ordering",
+          "note": "BatchGetItem RequestItems={}",
+          "threw": true,
+          "name": "ValidationException",
+          "message": "The requestItems parameter is required for BatchGetItem",
+          "n": null,
+          "fields": [],
+          "cancellationReasons": null
+        },
+        {
+          "id": "o_bw_empty_requestitems",
+          "family": "ordering",
+          "note": "BatchWriteItem RequestItems={}",
+          "threw": true,
+          "name": "ValidationException",
+          "message": "The requestItems parameter is required for BatchWriteItem",
+          "n": null,
+          "fields": [],
+          "cancellationReasons": null
+        }
+      ]
+    },
+    "ca-central-1": {
+      "region": "ca-central-1",
+      "probes": [
+        {
+          "id": "o_bg_empty_requestitems",
+          "family": "ordering",
+          "note": "BatchGetItem RequestItems={}",
+          "threw": true,
+          "name": "ValidationException",
+          "message": "The requestItems parameter is required for BatchGetItem",
+          "n": null,
+          "fields": [],
+          "cancellationReasons": null
+        },
+        {
+          "id": "o_bw_empty_requestitems",
+          "family": "ordering",
+          "note": "BatchWriteItem RequestItems={}",
+          "threw": true,
+          "name": "ValidationException",
+          "message": "The requestItems parameter is required for BatchWriteItem",
+          "n": null,
+          "fields": [],
+          "cancellationReasons": null
+        }
+      ]
+    },
+    "ca-west-1": {
+      "region": "ca-west-1",
+      "probes": [
+        {
+          "id": "o_bg_empty_requestitems",
+          "family": "ordering",
+          "note": "BatchGetItem RequestItems={}",
+          "threw": true,
+          "name": "ValidationException",
+          "message": "The requestItems parameter is required for BatchGetItem",
+          "n": null,
+          "fields": [],
+          "cancellationReasons": null
+        },
+        {
+          "id": "o_bw_empty_requestitems",
+          "family": "ordering",
+          "note": "BatchWriteItem RequestItems={}",
+          "threw": true,
+          "name": "ValidationException",
+          "message": "The requestItems parameter is required for BatchWriteItem",
+          "n": null,
+          "fields": [],
+          "cancellationReasons": null
+        }
+      ]
+    },
+    "eu-central-2": {
+      "region": "eu-central-2",
+      "probes": [
+        {
+          "id": "o_bg_empty_requestitems",
+          "family": "ordering",
+          "note": "BatchGetItem RequestItems={}",
+          "threw": true,
+          "name": "ValidationException",
+          "message": "The requestItems parameter is required for BatchGetItem",
+          "n": null,
+          "fields": [],
+          "cancellationReasons": null
+        },
+        {
+          "id": "o_bw_empty_requestitems",
+          "family": "ordering",
+          "note": "BatchWriteItem RequestItems={}",
+          "threw": true,
+          "name": "ValidationException",
+          "message": "The requestItems parameter is required for BatchWriteItem",
+          "n": null,
+          "fields": [],
+          "cancellationReasons": null
+        }
+      ]
+    },
+    "eu-north-1": {
+      "region": "eu-north-1",
+      "probes": [
+        {
+          "id": "o_bg_empty_requestitems",
+          "family": "ordering",
+          "note": "BatchGetItem RequestItems={}",
+          "threw": true,
+          "name": "ValidationException",
+          "message": "1 validation error detected: Value at 'RequestItems' failed to satisfy constraint: Member must have length greater than or equal to 1",
+          "n": 1,
+          "fields": [
+            "RequestItems"
+          ],
+          "cancellationReasons": null
+        },
+        {
+          "id": "o_bw_empty_requestitems",
+          "family": "ordering",
+          "note": "BatchWriteItem RequestItems={}",
+          "threw": true,
+          "name": "ValidationException",
+          "message": "The requestItems parameter is required for BatchWriteItem",
+          "n": null,
+          "fields": [],
+          "cancellationReasons": null
+        }
+      ]
+    },
+    "eu-south-1": {
+      "region": "eu-south-1",
+      "probes": [
+        {
+          "id": "o_bg_empty_requestitems",
+          "family": "ordering",
+          "note": "BatchGetItem RequestItems={}",
+          "threw": true,
+          "name": "ValidationException",
+          "message": "The requestItems parameter is required for BatchGetItem",
+          "n": null,
+          "fields": [],
+          "cancellationReasons": null
+        },
+        {
+          "id": "o_bw_empty_requestitems",
+          "family": "ordering",
+          "note": "BatchWriteItem RequestItems={}",
+          "threw": true,
+          "name": "ValidationException",
+          "message": "The requestItems parameter is required for BatchWriteItem",
+          "n": null,
+          "fields": [],
+          "cancellationReasons": null
+        }
+      ]
+    },
+    "eu-south-2": {
+      "region": "eu-south-2",
+      "probes": [
+        {
+          "id": "o_bg_empty_requestitems",
+          "family": "ordering",
+          "note": "BatchGetItem RequestItems={}",
+          "threw": true,
+          "name": "ValidationException",
+          "message": "The requestItems parameter is required for BatchGetItem",
+          "n": null,
+          "fields": [],
+          "cancellationReasons": null
+        },
+        {
+          "id": "o_bw_empty_requestitems",
+          "family": "ordering",
+          "note": "BatchWriteItem RequestItems={}",
+          "threw": true,
+          "name": "ValidationException",
+          "message": "The requestItems parameter is required for BatchWriteItem",
+          "n": null,
+          "fields": [],
+          "cancellationReasons": null
+        }
+      ]
+    },
+    "eu-west-1": {
+      "region": "eu-west-1",
+      "probes": [
+        {
+          "id": "o_bg_empty_requestitems",
+          "family": "ordering",
+          "note": "BatchGetItem RequestItems={}",
+          "threw": true,
+          "name": "ValidationException",
+          "message": "The requestItems parameter is required for BatchGetItem",
+          "n": null,
+          "fields": [],
+          "cancellationReasons": null
+        },
+        {
+          "id": "o_bw_empty_requestitems",
+          "family": "ordering",
+          "note": "BatchWriteItem RequestItems={}",
+          "threw": true,
+          "name": "ValidationException",
+          "message": "The requestItems parameter is required for BatchWriteItem",
+          "n": null,
+          "fields": [],
+          "cancellationReasons": null
+        }
+      ]
+    },
+    "eu-west-3": {
+      "region": "eu-west-3",
+      "probes": [
+        {
+          "id": "o_bg_empty_requestitems",
+          "family": "ordering",
+          "note": "BatchGetItem RequestItems={}",
+          "threw": true,
+          "name": "ValidationException",
+          "message": "The requestItems parameter is required for BatchGetItem",
+          "n": null,
+          "fields": [],
+          "cancellationReasons": null
+        },
+        {
+          "id": "o_bw_empty_requestitems",
+          "family": "ordering",
+          "note": "BatchWriteItem RequestItems={}",
+          "threw": true,
+          "name": "ValidationException",
+          "message": "The requestItems parameter is required for BatchWriteItem",
+          "n": null,
+          "fields": [],
+          "cancellationReasons": null
+        }
+      ]
+    },
+    "il-central-1": {
+      "region": "il-central-1",
+      "probes": [
+        {
+          "id": "o_bg_empty_requestitems",
+          "family": "ordering",
+          "note": "BatchGetItem RequestItems={}",
+          "threw": true,
+          "name": "ValidationException",
+          "message": "1 validation error detected: Value at 'RequestItems' failed to satisfy constraint: Member must have length greater than or equal to 1",
+          "n": 1,
+          "fields": [
+            "RequestItems"
+          ],
+          "cancellationReasons": null
+        },
+        {
+          "id": "o_bw_empty_requestitems",
+          "family": "ordering",
+          "note": "BatchWriteItem RequestItems={}",
+          "threw": true,
+          "name": "ValidationException",
+          "message": "The requestItems parameter is required for BatchWriteItem",
+          "n": null,
+          "fields": [],
+          "cancellationReasons": null
+        }
+      ]
+    },
+    "me-central-1": {
+      "region": "me-central-1",
+      "probes": [
+        {
+          "id": "o_bg_empty_requestitems",
+          "family": "ordering",
+          "note": "BatchGetItem RequestItems={}",
+          "threw": true,
+          "name": "ValidationException",
+          "message": "The requestItems parameter is required for BatchGetItem",
+          "n": null,
+          "fields": [],
+          "cancellationReasons": null
+        },
+        {
+          "id": "o_bw_empty_requestitems",
+          "family": "ordering",
+          "note": "BatchWriteItem RequestItems={}",
+          "threw": true,
+          "name": "ValidationException",
+          "message": "The requestItems parameter is required for BatchWriteItem",
+          "n": null,
+          "fields": [],
+          "cancellationReasons": null
+        }
+      ]
+    },
+    "me-south-1": {
+      "region": "me-south-1",
+      "probes": [
+        {
+          "id": "o_bg_empty_requestitems",
+          "family": "ordering",
+          "note": "BatchGetItem RequestItems={}",
+          "threw": true,
+          "name": "TimeoutError",
+          "message": "@smithy/node-http-handler - the request socket did not establish a connection with the server within the configured timeout of 5000 ms.",
+          "n": null,
+          "fields": [],
+          "cancellationReasons": null
+        },
+        {
+          "id": "o_bw_empty_requestitems",
+          "family": "ordering",
+          "note": "BatchWriteItem RequestItems={}",
+          "threw": true,
+          "name": "TimeoutError",
+          "message": "@smithy/node-http-handler - the request socket did not establish a connection with the server within the configured timeout of 5000 ms.",
+          "n": null,
+          "fields": [],
+          "cancellationReasons": null
+        }
+      ]
+    },
+    "mx-central-1": {
+      "region": "mx-central-1",
+      "probes": [
+        {
+          "id": "o_bg_empty_requestitems",
+          "family": "ordering",
+          "note": "BatchGetItem RequestItems={}",
+          "threw": true,
+          "name": "ValidationException",
+          "message": "The requestItems parameter is required for BatchGetItem",
+          "n": null,
+          "fields": [],
+          "cancellationReasons": null
+        },
+        {
+          "id": "o_bw_empty_requestitems",
+          "family": "ordering",
+          "note": "BatchWriteItem RequestItems={}",
+          "threw": true,
+          "name": "ValidationException",
+          "message": "The requestItems parameter is required for BatchWriteItem",
+          "n": null,
+          "fields": [],
+          "cancellationReasons": null
+        }
+      ]
+    },
+    "sa-east-1": {
+      "region": "sa-east-1",
+      "probes": [
+        {
+          "id": "o_bg_empty_requestitems",
+          "family": "ordering",
+          "note": "BatchGetItem RequestItems={}",
+          "threw": true,
+          "name": "ValidationException",
+          "message": "The requestItems parameter is required for BatchGetItem",
+          "n": null,
+          "fields": [],
+          "cancellationReasons": null
+        },
+        {
+          "id": "o_bw_empty_requestitems",
+          "family": "ordering",
+          "note": "BatchWriteItem RequestItems={}",
+          "threw": true,
+          "name": "ValidationException",
+          "message": "The requestItems parameter is required for BatchWriteItem",
+          "n": null,
+          "fields": [],
+          "cancellationReasons": null
+        }
+      ]
+    },
+    "us-east-2": {
+      "region": "us-east-2",
+      "probes": [
+        {
+          "id": "o_bg_empty_requestitems",
+          "family": "ordering",
+          "note": "BatchGetItem RequestItems={}",
+          "threw": true,
+          "name": "ValidationException",
+          "message": "The requestItems parameter is required for BatchGetItem",
+          "n": null,
+          "fields": [],
+          "cancellationReasons": null
+        },
+        {
+          "id": "o_bw_empty_requestitems",
+          "family": "ordering",
+          "note": "BatchWriteItem RequestItems={}",
+          "threw": true,
+          "name": "ValidationException",
+          "message": "The requestItems parameter is required for BatchWriteItem",
+          "n": null,
+          "fields": [],
+          "cancellationReasons": null
+        }
+      ]
+    },
+    "us-west-1": {
+      "region": "us-west-1",
+      "probes": [
+        {
+          "id": "o_bg_empty_requestitems",
+          "family": "ordering",
+          "note": "BatchGetItem RequestItems={}",
+          "threw": true,
+          "name": "ValidationException",
+          "message": "1 validation error detected: Value at 'RequestItems' failed to satisfy constraint: Member must have length greater than or equal to 1",
+          "n": 1,
+          "fields": [
+            "RequestItems"
+          ],
+          "cancellationReasons": null
+        },
+        {
+          "id": "o_bw_empty_requestitems",
+          "family": "ordering",
+          "note": "BatchWriteItem RequestItems={}",
+          "threw": true,
+          "name": "ValidationException",
+          "message": "The requestItems parameter is required for BatchWriteItem",
+          "n": null,
+          "fields": [],
+          "cancellationReasons": null
+        }
+      ]
+    },
+    "us-west-2": {
+      "region": "us-west-2",
+      "probes": [
+        {
+          "id": "o_bg_empty_requestitems",
+          "family": "ordering",
+          "note": "BatchGetItem RequestItems={}",
+          "threw": true,
+          "name": "ValidationException",
+          "message": "The requestItems parameter is required for BatchGetItem",
+          "n": null,
+          "fields": [],
+          "cancellationReasons": null
+        },
+        {
+          "id": "o_bw_empty_requestitems",
+          "family": "ordering",
+          "note": "BatchWriteItem RequestItems={}",
+          "threw": true,
+          "name": "ValidationException",
+          "message": "The requestItems parameter is required for BatchWriteItem",
+          "n": null,
+          "fields": [],
+          "cancellationReasons": null
+        }
+      ]
+    }
+  }
+}

--- a/registry/splits.json
+++ b/registry/splits.json
@@ -708,16 +708,16 @@
         "file": "tests/tier3/error-messages/batchGetItem.test.ts",
         "fullName": "BatchGetItem — exact error messages empty RequestItems: full required-parameter error"
       },
-      "behaviour": "BatchGetItem with an empty RequestItems map: part of the 2026-06 validation-framework rollout. New-cohort regions reject with the framework's generic constraint message naming 'RequestItems'; the rest return the bespoke required-parameter sentence.",
+      "behaviour": "BatchGetItem with an empty RequestItems map: part of the 2026-06 validation-framework rollout. New-cohort regions reject with the framework's generic constraint message naming 'RequestItems'; the rest return the bespoke required-parameter sentence. eu-west-2 crossed to the new cohort between the 2026-08-08 and 2026-08-15 sweeps, so the pinned answer is now the generic message.",
       "pinned": "eu-west-2",
       "firstObserved": "2026-08-08",
-      "lastRefreshed": "2026-08-12",
+      "lastRefreshed": "2026-08-17",
       "regions": {
         "af-south-1": {
           "outcome": "rejected",
           "error": {
             "name": "ValidationException",
-            "message": "The requestItems parameter is required for BatchGetItem"
+            "message": "1 validation error detected: Value at 'RequestItems' failed to satisfy constraint: Member must have length greater than or equal to 1"
           }
         },
         "ap-east-1": {
@@ -745,7 +745,7 @@
           "outcome": "rejected",
           "error": {
             "name": "ValidationException",
-            "message": "The requestItems parameter is required for BatchGetItem"
+            "message": "1 validation error detected: Value at 'RequestItems' failed to satisfy constraint: Member must have length greater than or equal to 1"
           }
         },
         "ap-northeast-3": {
@@ -794,14 +794,14 @@
           "outcome": "rejected",
           "error": {
             "name": "ValidationException",
-            "message": "The requestItems parameter is required for BatchGetItem"
+            "message": "1 validation error detected: Value at 'RequestItems' failed to satisfy constraint: Member must have length greater than or equal to 1"
           }
         },
         "ap-southeast-5": {
           "outcome": "rejected",
           "error": {
             "name": "ValidationException",
-            "message": "The requestItems parameter is required for BatchGetItem"
+            "message": "1 validation error detected: Value at 'RequestItems' failed to satisfy constraint: Member must have length greater than or equal to 1"
           }
         },
         "ap-southeast-6": {
@@ -878,7 +878,7 @@
           "outcome": "rejected",
           "error": {
             "name": "ValidationException",
-            "message": "The requestItems parameter is required for BatchGetItem"
+            "message": "1 validation error detected: Value at 'RequestItems' failed to satisfy constraint: Member must have length greater than or equal to 1"
           }
         },
         "eu-west-3": {
@@ -893,6 +893,13 @@
           "error": {
             "name": "ValidationException",
             "message": "1 validation error detected: Value at 'RequestItems' failed to satisfy constraint: Member must have length greater than or equal to 1"
+          }
+        },
+        "me-central-1": {
+          "outcome": "rejected",
+          "error": {
+            "name": "ValidationException",
+            "message": "The requestItems parameter is required for BatchGetItem"
           }
         },
         "mx-central-1": {
@@ -927,7 +934,7 @@
           "outcome": "rejected",
           "error": {
             "name": "ValidationException",
-            "message": "The requestItems parameter is required for BatchGetItem"
+            "message": "1 validation error detected: Value at 'RequestItems' failed to satisfy constraint: Member must have length greater than or equal to 1"
           }
         },
         "us-west-2": {
@@ -940,258 +947,13 @@
       },
       "evidence": [
         "captures/2026-08-12-batch-empty-and-nesting.json",
-        "https://github.com/paritysuite/dynamodb-conformance/actions/runs/31586467950"
+        "captures/2026-08-17-batch-empty-request-items.json",
+        "https://github.com/paritysuite/dynamodb-conformance/actions/runs/31861859337"
       ],
       "admitted": {
         "by": "Martin Hicks",
         "date": "2026-08-12",
         "issue": "https://github.com/paritysuite/dynamodb-conformance/issues/126"
-      }
-    },
-    {
-      "id": "batch-get-item-empty-request-items-ordering",
-      "test": {
-        "file": "tests/tier3/validation-ordering/batchOperations.test.ts",
-        "fullName": "Batch operations — validation ordering BatchGetItem rejects empty RequestItems"
-      },
-      "behaviour": "BatchGetItem with an empty RequestItems map: part of the 2026-06 validation-framework rollout. New-cohort regions reject with the framework's generic constraint message naming 'RequestItems'; the rest return the bespoke required-parameter sentence.",
-      "pinned": "eu-west-2",
-      "firstObserved": "2026-08-08",
-      "lastRefreshed": "2026-08-12",
-      "regions": {
-        "af-south-1": {
-          "outcome": "rejected",
-          "error": {
-            "name": "ValidationException",
-            "message": "The requestItems parameter is required for BatchGetItem"
-          }
-        },
-        "ap-east-1": {
-          "outcome": "rejected",
-          "error": {
-            "name": "ValidationException",
-            "message": "The requestItems parameter is required for BatchGetItem"
-          }
-        },
-        "ap-east-2": {
-          "outcome": "rejected",
-          "error": {
-            "name": "ValidationException",
-            "message": "The requestItems parameter is required for BatchGetItem"
-          }
-        },
-        "ap-northeast-1": {
-          "outcome": "rejected",
-          "error": {
-            "name": "ValidationException",
-            "message": "The requestItems parameter is required for BatchGetItem"
-          }
-        },
-        "ap-northeast-2": {
-          "outcome": "rejected",
-          "error": {
-            "name": "ValidationException",
-            "message": "The requestItems parameter is required for BatchGetItem"
-          }
-        },
-        "ap-northeast-3": {
-          "outcome": "rejected",
-          "error": {
-            "name": "ValidationException",
-            "message": "The requestItems parameter is required for BatchGetItem"
-          }
-        },
-        "ap-south-1": {
-          "outcome": "rejected",
-          "error": {
-            "name": "ValidationException",
-            "message": "The requestItems parameter is required for BatchGetItem"
-          }
-        },
-        "ap-south-2": {
-          "outcome": "rejected",
-          "error": {
-            "name": "ValidationException",
-            "message": "The requestItems parameter is required for BatchGetItem"
-          }
-        },
-        "ap-southeast-1": {
-          "outcome": "rejected",
-          "error": {
-            "name": "ValidationException",
-            "message": "1 validation error detected: Value at 'RequestItems' failed to satisfy constraint: Member must have length greater than or equal to 1"
-          }
-        },
-        "ap-southeast-2": {
-          "outcome": "rejected",
-          "error": {
-            "name": "ValidationException",
-            "message": "The requestItems parameter is required for BatchGetItem"
-          }
-        },
-        "ap-southeast-3": {
-          "outcome": "rejected",
-          "error": {
-            "name": "ValidationException",
-            "message": "1 validation error detected: Value at 'RequestItems' failed to satisfy constraint: Member must have length greater than or equal to 1"
-          }
-        },
-        "ap-southeast-4": {
-          "outcome": "rejected",
-          "error": {
-            "name": "ValidationException",
-            "message": "The requestItems parameter is required for BatchGetItem"
-          }
-        },
-        "ap-southeast-5": {
-          "outcome": "rejected",
-          "error": {
-            "name": "ValidationException",
-            "message": "The requestItems parameter is required for BatchGetItem"
-          }
-        },
-        "ap-southeast-6": {
-          "outcome": "rejected",
-          "error": {
-            "name": "ValidationException",
-            "message": "The requestItems parameter is required for BatchGetItem"
-          }
-        },
-        "ap-southeast-7": {
-          "outcome": "rejected",
-          "error": {
-            "name": "ValidationException",
-            "message": "The requestItems parameter is required for BatchGetItem"
-          }
-        },
-        "ca-central-1": {
-          "outcome": "rejected",
-          "error": {
-            "name": "ValidationException",
-            "message": "The requestItems parameter is required for BatchGetItem"
-          }
-        },
-        "ca-west-1": {
-          "outcome": "rejected",
-          "error": {
-            "name": "ValidationException",
-            "message": "The requestItems parameter is required for BatchGetItem"
-          }
-        },
-        "eu-central-1": {
-          "outcome": "rejected",
-          "error": {
-            "name": "ValidationException",
-            "message": "1 validation error detected: Value at 'RequestItems' failed to satisfy constraint: Member must have length greater than or equal to 1"
-          }
-        },
-        "eu-central-2": {
-          "outcome": "rejected",
-          "error": {
-            "name": "ValidationException",
-            "message": "The requestItems parameter is required for BatchGetItem"
-          }
-        },
-        "eu-north-1": {
-          "outcome": "rejected",
-          "error": {
-            "name": "ValidationException",
-            "message": "1 validation error detected: Value at 'RequestItems' failed to satisfy constraint: Member must have length greater than or equal to 1"
-          }
-        },
-        "eu-south-1": {
-          "outcome": "rejected",
-          "error": {
-            "name": "ValidationException",
-            "message": "The requestItems parameter is required for BatchGetItem"
-          }
-        },
-        "eu-south-2": {
-          "outcome": "rejected",
-          "error": {
-            "name": "ValidationException",
-            "message": "The requestItems parameter is required for BatchGetItem"
-          }
-        },
-        "eu-west-1": {
-          "outcome": "rejected",
-          "error": {
-            "name": "ValidationException",
-            "message": "The requestItems parameter is required for BatchGetItem"
-          }
-        },
-        "eu-west-2": {
-          "outcome": "rejected",
-          "error": {
-            "name": "ValidationException",
-            "message": "The requestItems parameter is required for BatchGetItem"
-          }
-        },
-        "eu-west-3": {
-          "outcome": "rejected",
-          "error": {
-            "name": "ValidationException",
-            "message": "The requestItems parameter is required for BatchGetItem"
-          }
-        },
-        "il-central-1": {
-          "outcome": "rejected",
-          "error": {
-            "name": "ValidationException",
-            "message": "1 validation error detected: Value at 'RequestItems' failed to satisfy constraint: Member must have length greater than or equal to 1"
-          }
-        },
-        "mx-central-1": {
-          "outcome": "rejected",
-          "error": {
-            "name": "ValidationException",
-            "message": "The requestItems parameter is required for BatchGetItem"
-          }
-        },
-        "sa-east-1": {
-          "outcome": "rejected",
-          "error": {
-            "name": "ValidationException",
-            "message": "The requestItems parameter is required for BatchGetItem"
-          }
-        },
-        "us-east-1": {
-          "outcome": "rejected",
-          "error": {
-            "name": "ValidationException",
-            "message": "The requestItems parameter is required for BatchGetItem"
-          }
-        },
-        "us-east-2": {
-          "outcome": "rejected",
-          "error": {
-            "name": "ValidationException",
-            "message": "The requestItems parameter is required for BatchGetItem"
-          }
-        },
-        "us-west-1": {
-          "outcome": "rejected",
-          "error": {
-            "name": "ValidationException",
-            "message": "The requestItems parameter is required for BatchGetItem"
-          }
-        },
-        "us-west-2": {
-          "outcome": "rejected",
-          "error": {
-            "name": "ValidationException",
-            "message": "The requestItems parameter is required for BatchGetItem"
-          }
-        }
-      },
-      "evidence": [
-        "captures/2026-08-12-batch-empty-and-nesting.json",
-        "https://github.com/paritysuite/dynamodb-conformance/actions/runs/31586467950"
-      ],
-      "admitted": {
-        "by": "Martin Hicks",
-        "date": "2026-08-12",
-        "issue": "https://github.com/paritysuite/dynamodb-conformance/issues/127"
       }
     }
   ]

--- a/registry/suite-manifest.json
+++ b/registry/suite-manifest.json
@@ -1,6 +1,6 @@
 {
-  "generated": "2026-08-12",
-  "commit": "b26f356a30edaa40eed0d1952a27c9d10259b2c7",
+  "generated": "2026-08-17",
+  "commit": "a82d4567e03439f606a991a5bb6caa2c3c80b9af",
   "count": 1054,
   "tests": [
     "tests/tier1/batchGetItem/basic.test.ts::BatchGetItem — ProjectionExpression returns only projected attributes",

--- a/results/summary.json
+++ b/results/summary.json
@@ -465,9 +465,9 @@
           }
         },
         "ap-southeast-1": {
-          "rate": 83,
-          "passed": 674,
-          "failed": 138,
+          "rate": 83.1,
+          "passed": 675,
+          "failed": 137,
           "skipped": 242,
           "indeterminate": 0,
           "count": 1054,
@@ -485,8 +485,8 @@
               "i": 0
             },
             "tier3": {
-              "p": 226,
-              "f": 57,
+              "p": 227,
+              "f": 56,
               "s": 57,
               "i": 0
             }
@@ -521,9 +521,9 @@
           }
         },
         "ap-southeast-3": {
-          "rate": 83.3,
-          "passed": 676,
-          "failed": 136,
+          "rate": 83.4,
+          "passed": 677,
+          "failed": 135,
           "skipped": 242,
           "indeterminate": 0,
           "count": 1054,
@@ -541,8 +541,8 @@
               "i": 0
             },
             "tier3": {
-              "p": 228,
-              "f": 55,
+              "p": 229,
+              "f": 54,
               "s": 57,
               "i": 0
             }
@@ -717,9 +717,9 @@
           }
         },
         "eu-central-1": {
-          "rate": 83,
-          "passed": 674,
-          "failed": 138,
+          "rate": 83.1,
+          "passed": 675,
+          "failed": 137,
           "skipped": 242,
           "indeterminate": 0,
           "count": 1054,
@@ -737,8 +737,8 @@
               "i": 0
             },
             "tier3": {
-              "p": 226,
-              "f": 57,
+              "p": 227,
+              "f": 56,
               "s": 57,
               "i": 0
             }
@@ -773,9 +773,9 @@
           }
         },
         "eu-north-1": {
-          "rate": 83,
-          "passed": 674,
-          "failed": 138,
+          "rate": 83.1,
+          "passed": 675,
+          "failed": 137,
           "skipped": 242,
           "indeterminate": 0,
           "count": 1054,
@@ -793,8 +793,8 @@
               "i": 0
             },
             "tier3": {
-              "p": 226,
-              "f": 57,
+              "p": 227,
+              "f": 56,
               "s": 57,
               "i": 0
             }
@@ -941,9 +941,9 @@
           }
         },
         "il-central-1": {
-          "rate": 83.3,
-          "passed": 676,
-          "failed": 136,
+          "rate": 83.4,
+          "passed": 677,
+          "failed": 135,
           "skipped": 242,
           "indeterminate": 0,
           "count": 1054,
@@ -961,8 +961,8 @@
               "i": 0
             },
             "tier3": {
-              "p": 228,
-              "f": 55,
+              "p": 229,
+              "f": 54,
               "s": 57,
               "i": 0
             }
@@ -2104,7 +2104,7 @@
     },
     "dynoxide": {
       "headline": {
-        "region": "ap-east-2",
+        "region": "ap-northeast-2",
         "rate": 99
       },
       "regions": {
@@ -2137,9 +2137,9 @@
           }
         },
         "ap-east-1": {
-          "rate": 98.7,
-          "passed": 985,
-          "failed": 13,
+          "rate": 98.6,
+          "passed": 984,
+          "failed": 14,
           "skipped": 56,
           "indeterminate": 0,
           "count": 1054,
@@ -2157,17 +2157,17 @@
               "i": 0
             },
             "tier3": {
-              "p": 321,
-              "f": 3,
+              "p": 320,
+              "f": 4,
               "s": 16,
               "i": 0
             }
           }
         },
         "ap-east-2": {
-          "rate": 99,
-          "passed": 988,
-          "failed": 10,
+          "rate": 98.9,
+          "passed": 987,
+          "failed": 11,
           "skipped": 56,
           "indeterminate": 0,
           "count": 1054,
@@ -2185,17 +2185,17 @@
               "i": 0
             },
             "tier3": {
-              "p": 324,
-              "f": 0,
+              "p": 323,
+              "f": 1,
               "s": 16,
               "i": 0
             }
           }
         },
         "ap-northeast-1": {
-          "rate": 98.7,
-          "passed": 985,
-          "failed": 13,
+          "rate": 98.6,
+          "passed": 984,
+          "failed": 14,
           "skipped": 56,
           "indeterminate": 0,
           "count": 1054,
@@ -2213,8 +2213,8 @@
               "i": 0
             },
             "tier3": {
-              "p": 321,
-              "f": 3,
+              "p": 320,
+              "f": 4,
               "s": 16,
               "i": 0
             }
@@ -2249,9 +2249,9 @@
           }
         },
         "ap-northeast-3": {
-          "rate": 98.7,
-          "passed": 985,
-          "failed": 13,
+          "rate": 98.6,
+          "passed": 984,
+          "failed": 14,
           "skipped": 56,
           "indeterminate": 0,
           "count": 1054,
@@ -2269,17 +2269,17 @@
               "i": 0
             },
             "tier3": {
-              "p": 321,
-              "f": 3,
+              "p": 320,
+              "f": 4,
               "s": 16,
               "i": 0
             }
           }
         },
         "ap-south-1": {
-          "rate": 98.7,
-          "passed": 985,
-          "failed": 13,
+          "rate": 98.6,
+          "passed": 984,
+          "failed": 14,
           "skipped": 56,
           "indeterminate": 0,
           "count": 1054,
@@ -2297,17 +2297,17 @@
               "i": 0
             },
             "tier3": {
-              "p": 321,
-              "f": 3,
+              "p": 320,
+              "f": 4,
               "s": 16,
               "i": 0
             }
           }
         },
         "ap-south-2": {
-          "rate": 98.7,
-          "passed": 985,
-          "failed": 13,
+          "rate": 98.6,
+          "passed": 984,
+          "failed": 14,
           "skipped": 56,
           "indeterminate": 0,
           "count": 1054,
@@ -2325,17 +2325,17 @@
               "i": 0
             },
             "tier3": {
-              "p": 321,
-              "f": 3,
+              "p": 320,
+              "f": 4,
               "s": 16,
               "i": 0
             }
           }
         },
         "ap-southeast-1": {
-          "rate": 98.8,
-          "passed": 986,
-          "failed": 12,
+          "rate": 99,
+          "passed": 988,
+          "failed": 10,
           "skipped": 56,
           "indeterminate": 0,
           "count": 1054,
@@ -2353,14 +2353,42 @@
               "i": 0
             },
             "tier3": {
-              "p": 322,
-              "f": 2,
+              "p": 324,
+              "f": 0,
               "s": 16,
               "i": 0
             }
           }
         },
         "ap-southeast-2": {
+          "rate": 98.6,
+          "passed": 984,
+          "failed": 14,
+          "skipped": 56,
+          "indeterminate": 0,
+          "count": 1054,
+          "tiers": {
+            "tier1": {
+              "p": 479,
+              "f": 10,
+              "s": 0,
+              "i": 0
+            },
+            "tier2": {
+              "p": 185,
+              "f": 0,
+              "s": 40,
+              "i": 0
+            },
+            "tier3": {
+              "p": 320,
+              "f": 4,
+              "s": 16,
+              "i": 0
+            }
+          }
+        },
+        "ap-southeast-3": {
           "rate": 98.7,
           "passed": 985,
           "failed": 13,
@@ -2383,34 +2411,6 @@
             "tier3": {
               "p": 321,
               "f": 3,
-              "s": 16,
-              "i": 0
-            }
-          }
-        },
-        "ap-southeast-3": {
-          "rate": 98.5,
-          "passed": 983,
-          "failed": 15,
-          "skipped": 56,
-          "indeterminate": 0,
-          "count": 1054,
-          "tiers": {
-            "tier1": {
-              "p": 479,
-              "f": 10,
-              "s": 0,
-              "i": 0
-            },
-            "tier2": {
-              "p": 185,
-              "f": 0,
-              "s": 40,
-              "i": 0
-            },
-            "tier3": {
-              "p": 319,
-              "f": 5,
               "s": 16,
               "i": 0
             }
@@ -2473,9 +2473,9 @@
           }
         },
         "ap-southeast-6": {
-          "rate": 98.7,
-          "passed": 985,
-          "failed": 13,
+          "rate": 98.6,
+          "passed": 984,
+          "failed": 14,
           "skipped": 56,
           "indeterminate": 0,
           "count": 1054,
@@ -2493,17 +2493,17 @@
               "i": 0
             },
             "tier3": {
-              "p": 321,
-              "f": 3,
+              "p": 320,
+              "f": 4,
               "s": 16,
               "i": 0
             }
           }
         },
         "ap-southeast-7": {
-          "rate": 98.7,
-          "passed": 985,
-          "failed": 13,
+          "rate": 98.6,
+          "passed": 984,
+          "failed": 14,
           "skipped": 56,
           "indeterminate": 0,
           "count": 1054,
@@ -2521,17 +2521,17 @@
               "i": 0
             },
             "tier3": {
-              "p": 321,
-              "f": 3,
+              "p": 320,
+              "f": 4,
               "s": 16,
               "i": 0
             }
           }
         },
         "ca-central-1": {
-          "rate": 98.7,
-          "passed": 985,
-          "failed": 13,
+          "rate": 98.6,
+          "passed": 984,
+          "failed": 14,
           "skipped": 56,
           "indeterminate": 0,
           "count": 1054,
@@ -2549,17 +2549,17 @@
               "i": 0
             },
             "tier3": {
-              "p": 321,
-              "f": 3,
+              "p": 320,
+              "f": 4,
               "s": 16,
               "i": 0
             }
           }
         },
         "ca-west-1": {
-          "rate": 98.7,
-          "passed": 985,
-          "failed": 13,
+          "rate": 98.6,
+          "passed": 984,
+          "failed": 14,
           "skipped": 56,
           "indeterminate": 0,
           "count": 1054,
@@ -2577,17 +2577,17 @@
               "i": 0
             },
             "tier3": {
-              "p": 321,
-              "f": 3,
+              "p": 320,
+              "f": 4,
               "s": 16,
               "i": 0
             }
           }
         },
         "eu-central-1": {
-          "rate": 98.8,
-          "passed": 986,
-          "failed": 12,
+          "rate": 99,
+          "passed": 988,
+          "failed": 10,
           "skipped": 56,
           "indeterminate": 0,
           "count": 1054,
@@ -2605,17 +2605,17 @@
               "i": 0
             },
             "tier3": {
-              "p": 322,
-              "f": 2,
+              "p": 324,
+              "f": 0,
               "s": 16,
               "i": 0
             }
           }
         },
         "eu-central-2": {
-          "rate": 98.7,
-          "passed": 985,
-          "failed": 13,
+          "rate": 98.6,
+          "passed": 984,
+          "failed": 14,
           "skipped": 56,
           "indeterminate": 0,
           "count": 1054,
@@ -2633,17 +2633,17 @@
               "i": 0
             },
             "tier3": {
-              "p": 321,
-              "f": 3,
+              "p": 320,
+              "f": 4,
               "s": 16,
               "i": 0
             }
           }
         },
         "eu-north-1": {
-          "rate": 98.8,
-          "passed": 986,
-          "failed": 12,
+          "rate": 99,
+          "passed": 988,
+          "failed": 10,
           "skipped": 56,
           "indeterminate": 0,
           "count": 1054,
@@ -2661,17 +2661,17 @@
               "i": 0
             },
             "tier3": {
-              "p": 322,
-              "f": 2,
+              "p": 324,
+              "f": 0,
               "s": 16,
               "i": 0
             }
           }
         },
         "eu-south-1": {
-          "rate": 98.7,
-          "passed": 985,
-          "failed": 13,
+          "rate": 98.6,
+          "passed": 984,
+          "failed": 14,
           "skipped": 56,
           "indeterminate": 0,
           "count": 1054,
@@ -2689,17 +2689,17 @@
               "i": 0
             },
             "tier3": {
-              "p": 321,
-              "f": 3,
+              "p": 320,
+              "f": 4,
               "s": 16,
               "i": 0
             }
           }
         },
         "eu-south-2": {
-          "rate": 98.7,
-          "passed": 985,
-          "failed": 13,
+          "rate": 98.6,
+          "passed": 984,
+          "failed": 14,
           "skipped": 56,
           "indeterminate": 0,
           "count": 1054,
@@ -2717,17 +2717,17 @@
               "i": 0
             },
             "tier3": {
-              "p": 321,
-              "f": 3,
+              "p": 320,
+              "f": 4,
               "s": 16,
               "i": 0
             }
           }
         },
         "eu-west-1": {
-          "rate": 98.7,
-          "passed": 985,
-          "failed": 13,
+          "rate": 98.6,
+          "passed": 984,
+          "failed": 14,
           "skipped": 56,
           "indeterminate": 0,
           "count": 1054,
@@ -2745,8 +2745,8 @@
               "i": 0
             },
             "tier3": {
-              "p": 321,
-              "f": 3,
+              "p": 320,
+              "f": 4,
               "s": 16,
               "i": 0
             }
@@ -2781,9 +2781,9 @@
           }
         },
         "eu-west-3": {
-          "rate": 98.7,
-          "passed": 985,
-          "failed": 13,
+          "rate": 98.6,
+          "passed": 984,
+          "failed": 14,
           "skipped": 56,
           "indeterminate": 0,
           "count": 1054,
@@ -2801,17 +2801,17 @@
               "i": 0
             },
             "tier3": {
-              "p": 321,
-              "f": 3,
+              "p": 320,
+              "f": 4,
               "s": 16,
               "i": 0
             }
           }
         },
         "il-central-1": {
-          "rate": 98.5,
-          "passed": 983,
-          "failed": 15,
+          "rate": 98.7,
+          "passed": 985,
+          "failed": 13,
           "skipped": 56,
           "indeterminate": 0,
           "count": 1054,
@@ -2829,17 +2829,17 @@
               "i": 0
             },
             "tier3": {
-              "p": 319,
-              "f": 5,
+              "p": 321,
+              "f": 3,
               "s": 16,
               "i": 0
             }
           }
         },
         "me-central-1": {
-          "rate": 98.8,
-          "passed": 986,
-          "failed": 12,
+          "rate": 98.7,
+          "passed": 985,
+          "failed": 13,
           "skipped": 56,
           "indeterminate": 0,
           "count": 1054,
@@ -2857,17 +2857,17 @@
               "i": 0
             },
             "tier3": {
-              "p": 322,
-              "f": 2,
+              "p": 321,
+              "f": 3,
               "s": 16,
               "i": 0
             }
           }
         },
         "mx-central-1": {
-          "rate": 98.7,
-          "passed": 985,
-          "failed": 13,
+          "rate": 98.6,
+          "passed": 984,
+          "failed": 14,
           "skipped": 56,
           "indeterminate": 0,
           "count": 1054,
@@ -2885,17 +2885,17 @@
               "i": 0
             },
             "tier3": {
-              "p": 321,
-              "f": 3,
+              "p": 320,
+              "f": 4,
               "s": 16,
               "i": 0
             }
           }
         },
         "sa-east-1": {
-          "rate": 98.7,
-          "passed": 985,
-          "failed": 13,
+          "rate": 98.6,
+          "passed": 984,
+          "failed": 14,
           "skipped": 56,
           "indeterminate": 0,
           "count": 1054,
@@ -2913,17 +2913,17 @@
               "i": 0
             },
             "tier3": {
-              "p": 321,
-              "f": 3,
+              "p": 320,
+              "f": 4,
               "s": 16,
               "i": 0
             }
           }
         },
         "us-east-1": {
-          "rate": 99,
-          "passed": 988,
-          "failed": 10,
+          "rate": 98.9,
+          "passed": 987,
+          "failed": 11,
           "skipped": 56,
           "indeterminate": 0,
           "count": 1054,
@@ -2941,17 +2941,17 @@
               "i": 0
             },
             "tier3": {
-              "p": 324,
-              "f": 0,
+              "p": 323,
+              "f": 1,
               "s": 16,
               "i": 0
             }
           }
         },
         "us-east-2": {
-          "rate": 98.7,
-          "passed": 985,
-          "failed": 13,
+          "rate": 98.6,
+          "passed": 984,
+          "failed": 14,
           "skipped": 56,
           "indeterminate": 0,
           "count": 1054,
@@ -2969,8 +2969,8 @@
               "i": 0
             },
             "tier3": {
-              "p": 321,
-              "f": 3,
+              "p": 320,
+              "f": 4,
               "s": 16,
               "i": 0
             }
@@ -3005,9 +3005,9 @@
           }
         },
         "us-west-2": {
-          "rate": 98.7,
-          "passed": 985,
-          "failed": 13,
+          "rate": 98.6,
+          "passed": 984,
+          "failed": 14,
           "skipped": 56,
           "indeterminate": 0,
           "count": 1054,
@@ -3025,8 +3025,8 @@
               "i": 0
             },
             "tier3": {
-              "p": 321,
-              "f": 3,
+              "p": 320,
+              "f": 4,
               "s": 16,
               "i": 0
             }
@@ -3038,7 +3038,7 @@
     },
     "dynoxide-wasm": {
       "headline": {
-        "region": "ap-east-2",
+        "region": "ap-northeast-2",
         "rate": 98.9
       },
       "regions": {
@@ -3071,9 +3071,9 @@
           }
         },
         "ap-east-1": {
-          "rate": 98.5,
-          "passed": 866,
-          "failed": 13,
+          "rate": 98.4,
+          "passed": 865,
+          "failed": 14,
           "skipped": 175,
           "indeterminate": 0,
           "count": 1054,
@@ -3091,17 +3091,17 @@
               "i": 0
             },
             "tier3": {
-              "p": 286,
-              "f": 3,
+              "p": 285,
+              "f": 4,
               "s": 51,
               "i": 0
             }
           }
         },
         "ap-east-2": {
-          "rate": 98.9,
-          "passed": 869,
-          "failed": 10,
+          "rate": 98.7,
+          "passed": 868,
+          "failed": 11,
           "skipped": 175,
           "indeterminate": 0,
           "count": 1054,
@@ -3119,17 +3119,17 @@
               "i": 0
             },
             "tier3": {
-              "p": 289,
-              "f": 0,
+              "p": 288,
+              "f": 1,
               "s": 51,
               "i": 0
             }
           }
         },
         "ap-northeast-1": {
-          "rate": 98.5,
-          "passed": 866,
-          "failed": 13,
+          "rate": 98.4,
+          "passed": 865,
+          "failed": 14,
           "skipped": 175,
           "indeterminate": 0,
           "count": 1054,
@@ -3147,8 +3147,8 @@
               "i": 0
             },
             "tier3": {
-              "p": 286,
-              "f": 3,
+              "p": 285,
+              "f": 4,
               "s": 51,
               "i": 0
             }
@@ -3183,9 +3183,9 @@
           }
         },
         "ap-northeast-3": {
-          "rate": 98.5,
-          "passed": 866,
-          "failed": 13,
+          "rate": 98.4,
+          "passed": 865,
+          "failed": 14,
           "skipped": 175,
           "indeterminate": 0,
           "count": 1054,
@@ -3203,17 +3203,17 @@
               "i": 0
             },
             "tier3": {
-              "p": 286,
-              "f": 3,
+              "p": 285,
+              "f": 4,
               "s": 51,
               "i": 0
             }
           }
         },
         "ap-south-1": {
-          "rate": 98.5,
-          "passed": 866,
-          "failed": 13,
+          "rate": 98.4,
+          "passed": 865,
+          "failed": 14,
           "skipped": 175,
           "indeterminate": 0,
           "count": 1054,
@@ -3231,17 +3231,17 @@
               "i": 0
             },
             "tier3": {
-              "p": 286,
-              "f": 3,
+              "p": 285,
+              "f": 4,
               "s": 51,
               "i": 0
             }
           }
         },
         "ap-south-2": {
-          "rate": 98.5,
-          "passed": 866,
-          "failed": 13,
+          "rate": 98.4,
+          "passed": 865,
+          "failed": 14,
           "skipped": 175,
           "indeterminate": 0,
           "count": 1054,
@@ -3259,17 +3259,17 @@
               "i": 0
             },
             "tier3": {
-              "p": 286,
-              "f": 3,
+              "p": 285,
+              "f": 4,
               "s": 51,
               "i": 0
             }
           }
         },
         "ap-southeast-1": {
-          "rate": 98.6,
-          "passed": 867,
-          "failed": 12,
+          "rate": 98.9,
+          "passed": 869,
+          "failed": 10,
           "skipped": 175,
           "indeterminate": 0,
           "count": 1054,
@@ -3287,14 +3287,42 @@
               "i": 0
             },
             "tier3": {
-              "p": 287,
-              "f": 2,
+              "p": 289,
+              "f": 0,
               "s": 51,
               "i": 0
             }
           }
         },
         "ap-southeast-2": {
+          "rate": 98.4,
+          "passed": 865,
+          "failed": 14,
+          "skipped": 175,
+          "indeterminate": 0,
+          "count": 1054,
+          "tiers": {
+            "tier1": {
+              "p": 479,
+              "f": 10,
+              "s": 0,
+              "i": 0
+            },
+            "tier2": {
+              "p": 101,
+              "f": 0,
+              "s": 124,
+              "i": 0
+            },
+            "tier3": {
+              "p": 285,
+              "f": 4,
+              "s": 51,
+              "i": 0
+            }
+          }
+        },
+        "ap-southeast-3": {
           "rate": 98.5,
           "passed": 866,
           "failed": 13,
@@ -3317,34 +3345,6 @@
             "tier3": {
               "p": 286,
               "f": 3,
-              "s": 51,
-              "i": 0
-            }
-          }
-        },
-        "ap-southeast-3": {
-          "rate": 98.3,
-          "passed": 864,
-          "failed": 15,
-          "skipped": 175,
-          "indeterminate": 0,
-          "count": 1054,
-          "tiers": {
-            "tier1": {
-              "p": 479,
-              "f": 10,
-              "s": 0,
-              "i": 0
-            },
-            "tier2": {
-              "p": 101,
-              "f": 0,
-              "s": 124,
-              "i": 0
-            },
-            "tier3": {
-              "p": 284,
-              "f": 5,
               "s": 51,
               "i": 0
             }
@@ -3407,9 +3407,9 @@
           }
         },
         "ap-southeast-6": {
-          "rate": 98.5,
-          "passed": 866,
-          "failed": 13,
+          "rate": 98.4,
+          "passed": 865,
+          "failed": 14,
           "skipped": 175,
           "indeterminate": 0,
           "count": 1054,
@@ -3427,17 +3427,17 @@
               "i": 0
             },
             "tier3": {
-              "p": 286,
-              "f": 3,
+              "p": 285,
+              "f": 4,
               "s": 51,
               "i": 0
             }
           }
         },
         "ap-southeast-7": {
-          "rate": 98.5,
-          "passed": 866,
-          "failed": 13,
+          "rate": 98.4,
+          "passed": 865,
+          "failed": 14,
           "skipped": 175,
           "indeterminate": 0,
           "count": 1054,
@@ -3455,17 +3455,17 @@
               "i": 0
             },
             "tier3": {
-              "p": 286,
-              "f": 3,
+              "p": 285,
+              "f": 4,
               "s": 51,
               "i": 0
             }
           }
         },
         "ca-central-1": {
-          "rate": 98.5,
-          "passed": 866,
-          "failed": 13,
+          "rate": 98.4,
+          "passed": 865,
+          "failed": 14,
           "skipped": 175,
           "indeterminate": 0,
           "count": 1054,
@@ -3483,17 +3483,17 @@
               "i": 0
             },
             "tier3": {
-              "p": 286,
-              "f": 3,
+              "p": 285,
+              "f": 4,
               "s": 51,
               "i": 0
             }
           }
         },
         "ca-west-1": {
-          "rate": 98.5,
-          "passed": 866,
-          "failed": 13,
+          "rate": 98.4,
+          "passed": 865,
+          "failed": 14,
           "skipped": 175,
           "indeterminate": 0,
           "count": 1054,
@@ -3511,17 +3511,17 @@
               "i": 0
             },
             "tier3": {
-              "p": 286,
-              "f": 3,
+              "p": 285,
+              "f": 4,
               "s": 51,
               "i": 0
             }
           }
         },
         "eu-central-1": {
-          "rate": 98.6,
-          "passed": 867,
-          "failed": 12,
+          "rate": 98.9,
+          "passed": 869,
+          "failed": 10,
           "skipped": 175,
           "indeterminate": 0,
           "count": 1054,
@@ -3539,17 +3539,17 @@
               "i": 0
             },
             "tier3": {
-              "p": 287,
-              "f": 2,
+              "p": 289,
+              "f": 0,
               "s": 51,
               "i": 0
             }
           }
         },
         "eu-central-2": {
-          "rate": 98.5,
-          "passed": 866,
-          "failed": 13,
+          "rate": 98.4,
+          "passed": 865,
+          "failed": 14,
           "skipped": 175,
           "indeterminate": 0,
           "count": 1054,
@@ -3567,17 +3567,17 @@
               "i": 0
             },
             "tier3": {
-              "p": 286,
-              "f": 3,
+              "p": 285,
+              "f": 4,
               "s": 51,
               "i": 0
             }
           }
         },
         "eu-north-1": {
-          "rate": 98.6,
-          "passed": 867,
-          "failed": 12,
+          "rate": 98.9,
+          "passed": 869,
+          "failed": 10,
           "skipped": 175,
           "indeterminate": 0,
           "count": 1054,
@@ -3595,17 +3595,17 @@
               "i": 0
             },
             "tier3": {
-              "p": 287,
-              "f": 2,
+              "p": 289,
+              "f": 0,
               "s": 51,
               "i": 0
             }
           }
         },
         "eu-south-1": {
-          "rate": 98.5,
-          "passed": 866,
-          "failed": 13,
+          "rate": 98.4,
+          "passed": 865,
+          "failed": 14,
           "skipped": 175,
           "indeterminate": 0,
           "count": 1054,
@@ -3623,17 +3623,17 @@
               "i": 0
             },
             "tier3": {
-              "p": 286,
-              "f": 3,
+              "p": 285,
+              "f": 4,
               "s": 51,
               "i": 0
             }
           }
         },
         "eu-south-2": {
-          "rate": 98.5,
-          "passed": 866,
-          "failed": 13,
+          "rate": 98.4,
+          "passed": 865,
+          "failed": 14,
           "skipped": 175,
           "indeterminate": 0,
           "count": 1054,
@@ -3651,17 +3651,17 @@
               "i": 0
             },
             "tier3": {
-              "p": 286,
-              "f": 3,
+              "p": 285,
+              "f": 4,
               "s": 51,
               "i": 0
             }
           }
         },
         "eu-west-1": {
-          "rate": 98.5,
-          "passed": 866,
-          "failed": 13,
+          "rate": 98.4,
+          "passed": 865,
+          "failed": 14,
           "skipped": 175,
           "indeterminate": 0,
           "count": 1054,
@@ -3679,8 +3679,8 @@
               "i": 0
             },
             "tier3": {
-              "p": 286,
-              "f": 3,
+              "p": 285,
+              "f": 4,
               "s": 51,
               "i": 0
             }
@@ -3715,9 +3715,9 @@
           }
         },
         "eu-west-3": {
-          "rate": 98.5,
-          "passed": 866,
-          "failed": 13,
+          "rate": 98.4,
+          "passed": 865,
+          "failed": 14,
           "skipped": 175,
           "indeterminate": 0,
           "count": 1054,
@@ -3735,17 +3735,17 @@
               "i": 0
             },
             "tier3": {
-              "p": 286,
-              "f": 3,
+              "p": 285,
+              "f": 4,
               "s": 51,
               "i": 0
             }
           }
         },
         "il-central-1": {
-          "rate": 98.3,
-          "passed": 864,
-          "failed": 15,
+          "rate": 98.5,
+          "passed": 866,
+          "failed": 13,
           "skipped": 175,
           "indeterminate": 0,
           "count": 1054,
@@ -3763,17 +3763,17 @@
               "i": 0
             },
             "tier3": {
-              "p": 284,
-              "f": 5,
+              "p": 286,
+              "f": 3,
               "s": 51,
               "i": 0
             }
           }
         },
         "me-central-1": {
-          "rate": 98.6,
-          "passed": 867,
-          "failed": 12,
+          "rate": 98.5,
+          "passed": 866,
+          "failed": 13,
           "skipped": 175,
           "indeterminate": 0,
           "count": 1054,
@@ -3791,17 +3791,17 @@
               "i": 0
             },
             "tier3": {
-              "p": 287,
-              "f": 2,
+              "p": 286,
+              "f": 3,
               "s": 51,
               "i": 0
             }
           }
         },
         "mx-central-1": {
-          "rate": 98.5,
-          "passed": 866,
-          "failed": 13,
+          "rate": 98.4,
+          "passed": 865,
+          "failed": 14,
           "skipped": 175,
           "indeterminate": 0,
           "count": 1054,
@@ -3819,17 +3819,17 @@
               "i": 0
             },
             "tier3": {
-              "p": 286,
-              "f": 3,
+              "p": 285,
+              "f": 4,
               "s": 51,
               "i": 0
             }
           }
         },
         "sa-east-1": {
-          "rate": 98.5,
-          "passed": 866,
-          "failed": 13,
+          "rate": 98.4,
+          "passed": 865,
+          "failed": 14,
           "skipped": 175,
           "indeterminate": 0,
           "count": 1054,
@@ -3847,17 +3847,17 @@
               "i": 0
             },
             "tier3": {
-              "p": 286,
-              "f": 3,
+              "p": 285,
+              "f": 4,
               "s": 51,
               "i": 0
             }
           }
         },
         "us-east-1": {
-          "rate": 98.9,
-          "passed": 869,
-          "failed": 10,
+          "rate": 98.7,
+          "passed": 868,
+          "failed": 11,
           "skipped": 175,
           "indeterminate": 0,
           "count": 1054,
@@ -3875,17 +3875,17 @@
               "i": 0
             },
             "tier3": {
-              "p": 289,
-              "f": 0,
+              "p": 288,
+              "f": 1,
               "s": 51,
               "i": 0
             }
           }
         },
         "us-east-2": {
-          "rate": 98.5,
-          "passed": 866,
-          "failed": 13,
+          "rate": 98.4,
+          "passed": 865,
+          "failed": 14,
           "skipped": 175,
           "indeterminate": 0,
           "count": 1054,
@@ -3903,8 +3903,8 @@
               "i": 0
             },
             "tier3": {
-              "p": 286,
-              "f": 3,
+              "p": 285,
+              "f": 4,
               "s": 51,
               "i": 0
             }
@@ -3939,9 +3939,9 @@
           }
         },
         "us-west-2": {
-          "rate": 98.5,
-          "passed": 866,
-          "failed": 13,
+          "rate": 98.4,
+          "passed": 865,
+          "failed": 14,
           "skipped": 175,
           "indeterminate": 0,
           "count": 1054,
@@ -3959,8 +3959,8 @@
               "i": 0
             },
             "tier3": {
-              "p": 286,
-              "f": 3,
+              "p": 285,
+              "f": 4,
               "s": 51,
               "i": 0
             }
@@ -4005,9 +4005,9 @@
           }
         },
         "ap-east-1": {
-          "rate": 97.8,
-          "passed": 905,
-          "failed": 20,
+          "rate": 97.7,
+          "passed": 904,
+          "failed": 21,
           "skipped": 129,
           "indeterminate": 0,
           "count": 1054,
@@ -4025,17 +4025,17 @@
               "i": 0
             },
             "tier3": {
-              "p": 308,
-              "f": 12,
+              "p": 307,
+              "f": 13,
               "s": 20,
               "i": 0
             }
           }
         },
         "ap-east-2": {
-          "rate": 97.8,
-          "passed": 905,
-          "failed": 20,
+          "rate": 97.7,
+          "passed": 904,
+          "failed": 21,
           "skipped": 129,
           "indeterminate": 0,
           "count": 1054,
@@ -4053,17 +4053,17 @@
               "i": 0
             },
             "tier3": {
-              "p": 308,
-              "f": 12,
+              "p": 307,
+              "f": 13,
               "s": 20,
               "i": 0
             }
           }
         },
         "ap-northeast-1": {
-          "rate": 97.8,
-          "passed": 905,
-          "failed": 20,
+          "rate": 97.7,
+          "passed": 904,
+          "failed": 21,
           "skipped": 129,
           "indeterminate": 0,
           "count": 1054,
@@ -4081,8 +4081,8 @@
               "i": 0
             },
             "tier3": {
-              "p": 308,
-              "f": 12,
+              "p": 307,
+              "f": 13,
               "s": 20,
               "i": 0
             }
@@ -4117,9 +4117,9 @@
           }
         },
         "ap-northeast-3": {
-          "rate": 97.8,
-          "passed": 905,
-          "failed": 20,
+          "rate": 97.7,
+          "passed": 904,
+          "failed": 21,
           "skipped": 129,
           "indeterminate": 0,
           "count": 1054,
@@ -4137,17 +4137,17 @@
               "i": 0
             },
             "tier3": {
-              "p": 308,
-              "f": 12,
+              "p": 307,
+              "f": 13,
               "s": 20,
               "i": 0
             }
           }
         },
         "ap-south-1": {
-          "rate": 97.8,
-          "passed": 905,
-          "failed": 20,
+          "rate": 97.7,
+          "passed": 904,
+          "failed": 21,
           "skipped": 129,
           "indeterminate": 0,
           "count": 1054,
@@ -4165,17 +4165,17 @@
               "i": 0
             },
             "tier3": {
-              "p": 308,
-              "f": 12,
+              "p": 307,
+              "f": 13,
               "s": 20,
               "i": 0
             }
           }
         },
         "ap-south-2": {
-          "rate": 97.8,
-          "passed": 905,
-          "failed": 20,
+          "rate": 97.7,
+          "passed": 904,
+          "failed": 21,
           "skipped": 129,
           "indeterminate": 0,
           "count": 1054,
@@ -4193,42 +4193,14 @@
               "i": 0
             },
             "tier3": {
-              "p": 308,
-              "f": 12,
+              "p": 307,
+              "f": 13,
               "s": 20,
               "i": 0
             }
           }
         },
         "ap-southeast-1": {
-          "rate": 97.6,
-          "passed": 903,
-          "failed": 22,
-          "skipped": 129,
-          "indeterminate": 0,
-          "count": 1054,
-          "tiers": {
-            "tier1": {
-              "p": 485,
-              "f": 4,
-              "s": 0,
-              "i": 0
-            },
-            "tier2": {
-              "p": 112,
-              "f": 4,
-              "s": 109,
-              "i": 0
-            },
-            "tier3": {
-              "p": 306,
-              "f": 14,
-              "s": 20,
-              "i": 0
-            }
-          }
-        },
-        "ap-southeast-2": {
           "rate": 97.8,
           "passed": 905,
           "failed": 20,
@@ -4256,10 +4228,10 @@
             }
           }
         },
-        "ap-southeast-3": {
-          "rate": 97.6,
-          "passed": 903,
-          "failed": 22,
+        "ap-southeast-2": {
+          "rate": 97.7,
+          "passed": 904,
+          "failed": 21,
           "skipped": 129,
           "indeterminate": 0,
           "count": 1054,
@@ -4277,8 +4249,36 @@
               "i": 0
             },
             "tier3": {
-              "p": 306,
-              "f": 14,
+              "p": 307,
+              "f": 13,
+              "s": 20,
+              "i": 0
+            }
+          }
+        },
+        "ap-southeast-3": {
+          "rate": 97.8,
+          "passed": 905,
+          "failed": 20,
+          "skipped": 129,
+          "indeterminate": 0,
+          "count": 1054,
+          "tiers": {
+            "tier1": {
+              "p": 485,
+              "f": 4,
+              "s": 0,
+              "i": 0
+            },
+            "tier2": {
+              "p": 112,
+              "f": 4,
+              "s": 109,
+              "i": 0
+            },
+            "tier3": {
+              "p": 308,
+              "f": 12,
               "s": 20,
               "i": 0
             }
@@ -4341,9 +4341,9 @@
           }
         },
         "ap-southeast-6": {
-          "rate": 97.8,
-          "passed": 905,
-          "failed": 20,
+          "rate": 97.7,
+          "passed": 904,
+          "failed": 21,
           "skipped": 129,
           "indeterminate": 0,
           "count": 1054,
@@ -4361,17 +4361,17 @@
               "i": 0
             },
             "tier3": {
-              "p": 308,
-              "f": 12,
+              "p": 307,
+              "f": 13,
               "s": 20,
               "i": 0
             }
           }
         },
         "ap-southeast-7": {
-          "rate": 97.8,
-          "passed": 905,
-          "failed": 20,
+          "rate": 97.7,
+          "passed": 904,
+          "failed": 21,
           "skipped": 129,
           "indeterminate": 0,
           "count": 1054,
@@ -4389,17 +4389,17 @@
               "i": 0
             },
             "tier3": {
-              "p": 308,
-              "f": 12,
+              "p": 307,
+              "f": 13,
               "s": 20,
               "i": 0
             }
           }
         },
         "ca-central-1": {
-          "rate": 97.8,
-          "passed": 905,
-          "failed": 20,
+          "rate": 97.7,
+          "passed": 904,
+          "failed": 21,
           "skipped": 129,
           "indeterminate": 0,
           "count": 1054,
@@ -4417,17 +4417,17 @@
               "i": 0
             },
             "tier3": {
-              "p": 308,
-              "f": 12,
+              "p": 307,
+              "f": 13,
               "s": 20,
               "i": 0
             }
           }
         },
         "ca-west-1": {
-          "rate": 97.8,
-          "passed": 905,
-          "failed": 20,
+          "rate": 97.7,
+          "passed": 904,
+          "failed": 21,
           "skipped": 129,
           "indeterminate": 0,
           "count": 1054,
@@ -4445,17 +4445,17 @@
               "i": 0
             },
             "tier3": {
-              "p": 308,
-              "f": 12,
+              "p": 307,
+              "f": 13,
               "s": 20,
               "i": 0
             }
           }
         },
         "eu-central-1": {
-          "rate": 97.6,
-          "passed": 903,
-          "failed": 22,
+          "rate": 97.8,
+          "passed": 905,
+          "failed": 20,
           "skipped": 129,
           "indeterminate": 0,
           "count": 1054,
@@ -4473,17 +4473,17 @@
               "i": 0
             },
             "tier3": {
-              "p": 306,
-              "f": 14,
+              "p": 308,
+              "f": 12,
               "s": 20,
               "i": 0
             }
           }
         },
         "eu-central-2": {
-          "rate": 97.8,
-          "passed": 905,
-          "failed": 20,
+          "rate": 97.7,
+          "passed": 904,
+          "failed": 21,
           "skipped": 129,
           "indeterminate": 0,
           "count": 1054,
@@ -4501,17 +4501,17 @@
               "i": 0
             },
             "tier3": {
-              "p": 308,
-              "f": 12,
+              "p": 307,
+              "f": 13,
               "s": 20,
               "i": 0
             }
           }
         },
         "eu-north-1": {
-          "rate": 97.6,
-          "passed": 903,
-          "failed": 22,
+          "rate": 97.8,
+          "passed": 905,
+          "failed": 20,
           "skipped": 129,
           "indeterminate": 0,
           "count": 1054,
@@ -4529,17 +4529,17 @@
               "i": 0
             },
             "tier3": {
-              "p": 306,
-              "f": 14,
+              "p": 308,
+              "f": 12,
               "s": 20,
               "i": 0
             }
           }
         },
         "eu-south-1": {
-          "rate": 97.8,
-          "passed": 905,
-          "failed": 20,
+          "rate": 97.7,
+          "passed": 904,
+          "failed": 21,
           "skipped": 129,
           "indeterminate": 0,
           "count": 1054,
@@ -4557,17 +4557,17 @@
               "i": 0
             },
             "tier3": {
-              "p": 308,
-              "f": 12,
+              "p": 307,
+              "f": 13,
               "s": 20,
               "i": 0
             }
           }
         },
         "eu-south-2": {
-          "rate": 97.8,
-          "passed": 905,
-          "failed": 20,
+          "rate": 97.7,
+          "passed": 904,
+          "failed": 21,
           "skipped": 129,
           "indeterminate": 0,
           "count": 1054,
@@ -4585,17 +4585,17 @@
               "i": 0
             },
             "tier3": {
-              "p": 308,
-              "f": 12,
+              "p": 307,
+              "f": 13,
               "s": 20,
               "i": 0
             }
           }
         },
         "eu-west-1": {
-          "rate": 97.8,
-          "passed": 905,
-          "failed": 20,
+          "rate": 97.7,
+          "passed": 904,
+          "failed": 21,
           "skipped": 129,
           "indeterminate": 0,
           "count": 1054,
@@ -4613,8 +4613,8 @@
               "i": 0
             },
             "tier3": {
-              "p": 308,
-              "f": 12,
+              "p": 307,
+              "f": 13,
               "s": 20,
               "i": 0
             }
@@ -4649,62 +4649,6 @@
           }
         },
         "eu-west-3": {
-          "rate": 97.8,
-          "passed": 905,
-          "failed": 20,
-          "skipped": 129,
-          "indeterminate": 0,
-          "count": 1054,
-          "tiers": {
-            "tier1": {
-              "p": 485,
-              "f": 4,
-              "s": 0,
-              "i": 0
-            },
-            "tier2": {
-              "p": 112,
-              "f": 4,
-              "s": 109,
-              "i": 0
-            },
-            "tier3": {
-              "p": 308,
-              "f": 12,
-              "s": 20,
-              "i": 0
-            }
-          }
-        },
-        "il-central-1": {
-          "rate": 97.6,
-          "passed": 903,
-          "failed": 22,
-          "skipped": 129,
-          "indeterminate": 0,
-          "count": 1054,
-          "tiers": {
-            "tier1": {
-              "p": 485,
-              "f": 4,
-              "s": 0,
-              "i": 0
-            },
-            "tier2": {
-              "p": 112,
-              "f": 4,
-              "s": 109,
-              "i": 0
-            },
-            "tier3": {
-              "p": 306,
-              "f": 14,
-              "s": 20,
-              "i": 0
-            }
-          }
-        },
-        "me-central-1": {
           "rate": 97.7,
           "passed": 904,
           "failed": 21,
@@ -4732,7 +4676,7 @@
             }
           }
         },
-        "mx-central-1": {
+        "il-central-1": {
           "rate": 97.8,
           "passed": 905,
           "failed": 20,
@@ -4755,15 +4699,71 @@
             "tier3": {
               "p": 308,
               "f": 12,
+              "s": 20,
+              "i": 0
+            }
+          }
+        },
+        "me-central-1": {
+          "rate": 97.6,
+          "passed": 903,
+          "failed": 22,
+          "skipped": 129,
+          "indeterminate": 0,
+          "count": 1054,
+          "tiers": {
+            "tier1": {
+              "p": 485,
+              "f": 4,
+              "s": 0,
+              "i": 0
+            },
+            "tier2": {
+              "p": 112,
+              "f": 4,
+              "s": 109,
+              "i": 0
+            },
+            "tier3": {
+              "p": 306,
+              "f": 14,
+              "s": 20,
+              "i": 0
+            }
+          }
+        },
+        "mx-central-1": {
+          "rate": 97.7,
+          "passed": 904,
+          "failed": 21,
+          "skipped": 129,
+          "indeterminate": 0,
+          "count": 1054,
+          "tiers": {
+            "tier1": {
+              "p": 485,
+              "f": 4,
+              "s": 0,
+              "i": 0
+            },
+            "tier2": {
+              "p": 112,
+              "f": 4,
+              "s": 109,
+              "i": 0
+            },
+            "tier3": {
+              "p": 307,
+              "f": 13,
               "s": 20,
               "i": 0
             }
           }
         },
         "sa-east-1": {
-          "rate": 97.8,
-          "passed": 905,
-          "failed": 20,
+          "rate": 97.7,
+          "passed": 904,
+          "failed": 21,
           "skipped": 129,
           "indeterminate": 0,
           "count": 1054,
@@ -4781,17 +4781,17 @@
               "i": 0
             },
             "tier3": {
-              "p": 308,
-              "f": 12,
+              "p": 307,
+              "f": 13,
               "s": 20,
               "i": 0
             }
           }
         },
         "us-east-1": {
-          "rate": 97.8,
-          "passed": 905,
-          "failed": 20,
+          "rate": 97.7,
+          "passed": 904,
+          "failed": 21,
           "skipped": 129,
           "indeterminate": 0,
           "count": 1054,
@@ -4809,17 +4809,17 @@
               "i": 0
             },
             "tier3": {
-              "p": 308,
-              "f": 12,
+              "p": 307,
+              "f": 13,
               "s": 20,
               "i": 0
             }
           }
         },
         "us-east-2": {
-          "rate": 97.8,
-          "passed": 905,
-          "failed": 20,
+          "rate": 97.7,
+          "passed": 904,
+          "failed": 21,
           "skipped": 129,
           "indeterminate": 0,
           "count": 1054,
@@ -4837,8 +4837,8 @@
               "i": 0
             },
             "tier3": {
-              "p": 308,
-              "f": 12,
+              "p": 307,
+              "f": 13,
               "s": 20,
               "i": 0
             }
@@ -4873,9 +4873,9 @@
           }
         },
         "us-west-2": {
-          "rate": 97.8,
-          "passed": 905,
-          "failed": 20,
+          "rate": 97.7,
+          "passed": 904,
+          "failed": 21,
           "skipped": 129,
           "indeterminate": 0,
           "count": 1054,
@@ -4893,8 +4893,8 @@
               "i": 0
             },
             "tier3": {
-              "p": 308,
-              "f": 12,
+              "p": 307,
+              "f": 13,
               "s": 20,
               "i": 0
             }
@@ -4939,9 +4939,9 @@
           }
         },
         "ap-east-1": {
-          "rate": 97.9,
-          "passed": 906,
-          "failed": 19,
+          "rate": 97.8,
+          "passed": 905,
+          "failed": 20,
           "skipped": 129,
           "indeterminate": 0,
           "count": 1054,
@@ -4959,17 +4959,17 @@
               "i": 0
             },
             "tier3": {
-              "p": 309,
-              "f": 11,
+              "p": 308,
+              "f": 12,
               "s": 20,
               "i": 0
             }
           }
         },
         "ap-east-2": {
-          "rate": 97.9,
-          "passed": 906,
-          "failed": 19,
+          "rate": 97.8,
+          "passed": 905,
+          "failed": 20,
           "skipped": 129,
           "indeterminate": 0,
           "count": 1054,
@@ -4987,17 +4987,17 @@
               "i": 0
             },
             "tier3": {
-              "p": 309,
-              "f": 11,
+              "p": 308,
+              "f": 12,
               "s": 20,
               "i": 0
             }
           }
         },
         "ap-northeast-1": {
-          "rate": 97.9,
-          "passed": 906,
-          "failed": 19,
+          "rate": 97.8,
+          "passed": 905,
+          "failed": 20,
           "skipped": 129,
           "indeterminate": 0,
           "count": 1054,
@@ -5015,8 +5015,8 @@
               "i": 0
             },
             "tier3": {
-              "p": 309,
-              "f": 11,
+              "p": 308,
+              "f": 12,
               "s": 20,
               "i": 0
             }
@@ -5051,9 +5051,9 @@
           }
         },
         "ap-northeast-3": {
-          "rate": 97.9,
-          "passed": 906,
-          "failed": 19,
+          "rate": 97.8,
+          "passed": 905,
+          "failed": 20,
           "skipped": 129,
           "indeterminate": 0,
           "count": 1054,
@@ -5071,17 +5071,17 @@
               "i": 0
             },
             "tier3": {
-              "p": 309,
-              "f": 11,
+              "p": 308,
+              "f": 12,
               "s": 20,
               "i": 0
             }
           }
         },
         "ap-south-1": {
-          "rate": 97.9,
-          "passed": 906,
-          "failed": 19,
+          "rate": 97.8,
+          "passed": 905,
+          "failed": 20,
           "skipped": 129,
           "indeterminate": 0,
           "count": 1054,
@@ -5099,17 +5099,17 @@
               "i": 0
             },
             "tier3": {
-              "p": 309,
-              "f": 11,
+              "p": 308,
+              "f": 12,
               "s": 20,
               "i": 0
             }
           }
         },
         "ap-south-2": {
-          "rate": 97.9,
-          "passed": 906,
-          "failed": 19,
+          "rate": 97.8,
+          "passed": 905,
+          "failed": 20,
           "skipped": 129,
           "indeterminate": 0,
           "count": 1054,
@@ -5127,42 +5127,14 @@
               "i": 0
             },
             "tier3": {
-              "p": 309,
-              "f": 11,
+              "p": 308,
+              "f": 12,
               "s": 20,
               "i": 0
             }
           }
         },
         "ap-southeast-1": {
-          "rate": 97.7,
-          "passed": 904,
-          "failed": 21,
-          "skipped": 129,
-          "indeterminate": 0,
-          "count": 1054,
-          "tiers": {
-            "tier1": {
-              "p": 485,
-              "f": 4,
-              "s": 0,
-              "i": 0
-            },
-            "tier2": {
-              "p": 112,
-              "f": 4,
-              "s": 109,
-              "i": 0
-            },
-            "tier3": {
-              "p": 307,
-              "f": 13,
-              "s": 20,
-              "i": 0
-            }
-          }
-        },
-        "ap-southeast-2": {
           "rate": 97.9,
           "passed": 906,
           "failed": 19,
@@ -5190,10 +5162,10 @@
             }
           }
         },
-        "ap-southeast-3": {
-          "rate": 97.7,
-          "passed": 904,
-          "failed": 21,
+        "ap-southeast-2": {
+          "rate": 97.8,
+          "passed": 905,
+          "failed": 20,
           "skipped": 129,
           "indeterminate": 0,
           "count": 1054,
@@ -5211,8 +5183,36 @@
               "i": 0
             },
             "tier3": {
-              "p": 307,
-              "f": 13,
+              "p": 308,
+              "f": 12,
+              "s": 20,
+              "i": 0
+            }
+          }
+        },
+        "ap-southeast-3": {
+          "rate": 97.9,
+          "passed": 906,
+          "failed": 19,
+          "skipped": 129,
+          "indeterminate": 0,
+          "count": 1054,
+          "tiers": {
+            "tier1": {
+              "p": 485,
+              "f": 4,
+              "s": 0,
+              "i": 0
+            },
+            "tier2": {
+              "p": 112,
+              "f": 4,
+              "s": 109,
+              "i": 0
+            },
+            "tier3": {
+              "p": 309,
+              "f": 11,
               "s": 20,
               "i": 0
             }
@@ -5275,9 +5275,9 @@
           }
         },
         "ap-southeast-6": {
-          "rate": 97.9,
-          "passed": 906,
-          "failed": 19,
+          "rate": 97.8,
+          "passed": 905,
+          "failed": 20,
           "skipped": 129,
           "indeterminate": 0,
           "count": 1054,
@@ -5295,17 +5295,17 @@
               "i": 0
             },
             "tier3": {
-              "p": 309,
-              "f": 11,
+              "p": 308,
+              "f": 12,
               "s": 20,
               "i": 0
             }
           }
         },
         "ap-southeast-7": {
-          "rate": 97.9,
-          "passed": 906,
-          "failed": 19,
+          "rate": 97.8,
+          "passed": 905,
+          "failed": 20,
           "skipped": 129,
           "indeterminate": 0,
           "count": 1054,
@@ -5323,17 +5323,17 @@
               "i": 0
             },
             "tier3": {
-              "p": 309,
-              "f": 11,
+              "p": 308,
+              "f": 12,
               "s": 20,
               "i": 0
             }
           }
         },
         "ca-central-1": {
-          "rate": 97.9,
-          "passed": 906,
-          "failed": 19,
+          "rate": 97.8,
+          "passed": 905,
+          "failed": 20,
           "skipped": 129,
           "indeterminate": 0,
           "count": 1054,
@@ -5351,17 +5351,17 @@
               "i": 0
             },
             "tier3": {
-              "p": 309,
-              "f": 11,
+              "p": 308,
+              "f": 12,
               "s": 20,
               "i": 0
             }
           }
         },
         "ca-west-1": {
-          "rate": 97.9,
-          "passed": 906,
-          "failed": 19,
+          "rate": 97.8,
+          "passed": 905,
+          "failed": 20,
           "skipped": 129,
           "indeterminate": 0,
           "count": 1054,
@@ -5379,17 +5379,17 @@
               "i": 0
             },
             "tier3": {
-              "p": 309,
-              "f": 11,
+              "p": 308,
+              "f": 12,
               "s": 20,
               "i": 0
             }
           }
         },
         "eu-central-1": {
-          "rate": 97.7,
-          "passed": 904,
-          "failed": 21,
+          "rate": 97.9,
+          "passed": 906,
+          "failed": 19,
           "skipped": 129,
           "indeterminate": 0,
           "count": 1054,
@@ -5407,17 +5407,17 @@
               "i": 0
             },
             "tier3": {
-              "p": 307,
-              "f": 13,
+              "p": 309,
+              "f": 11,
               "s": 20,
               "i": 0
             }
           }
         },
         "eu-central-2": {
-          "rate": 97.9,
-          "passed": 906,
-          "failed": 19,
+          "rate": 97.8,
+          "passed": 905,
+          "failed": 20,
           "skipped": 129,
           "indeterminate": 0,
           "count": 1054,
@@ -5435,17 +5435,17 @@
               "i": 0
             },
             "tier3": {
-              "p": 309,
-              "f": 11,
+              "p": 308,
+              "f": 12,
               "s": 20,
               "i": 0
             }
           }
         },
         "eu-north-1": {
-          "rate": 97.7,
-          "passed": 904,
-          "failed": 21,
+          "rate": 97.9,
+          "passed": 906,
+          "failed": 19,
           "skipped": 129,
           "indeterminate": 0,
           "count": 1054,
@@ -5463,17 +5463,17 @@
               "i": 0
             },
             "tier3": {
-              "p": 307,
-              "f": 13,
+              "p": 309,
+              "f": 11,
               "s": 20,
               "i": 0
             }
           }
         },
         "eu-south-1": {
-          "rate": 97.9,
-          "passed": 906,
-          "failed": 19,
+          "rate": 97.8,
+          "passed": 905,
+          "failed": 20,
           "skipped": 129,
           "indeterminate": 0,
           "count": 1054,
@@ -5491,17 +5491,17 @@
               "i": 0
             },
             "tier3": {
-              "p": 309,
-              "f": 11,
+              "p": 308,
+              "f": 12,
               "s": 20,
               "i": 0
             }
           }
         },
         "eu-south-2": {
-          "rate": 97.9,
-          "passed": 906,
-          "failed": 19,
+          "rate": 97.8,
+          "passed": 905,
+          "failed": 20,
           "skipped": 129,
           "indeterminate": 0,
           "count": 1054,
@@ -5519,17 +5519,17 @@
               "i": 0
             },
             "tier3": {
-              "p": 309,
-              "f": 11,
+              "p": 308,
+              "f": 12,
               "s": 20,
               "i": 0
             }
           }
         },
         "eu-west-1": {
-          "rate": 97.9,
-          "passed": 906,
-          "failed": 19,
+          "rate": 97.8,
+          "passed": 905,
+          "failed": 20,
           "skipped": 129,
           "indeterminate": 0,
           "count": 1054,
@@ -5547,8 +5547,8 @@
               "i": 0
             },
             "tier3": {
-              "p": 309,
-              "f": 11,
+              "p": 308,
+              "f": 12,
               "s": 20,
               "i": 0
             }
@@ -5583,62 +5583,6 @@
           }
         },
         "eu-west-3": {
-          "rate": 97.9,
-          "passed": 906,
-          "failed": 19,
-          "skipped": 129,
-          "indeterminate": 0,
-          "count": 1054,
-          "tiers": {
-            "tier1": {
-              "p": 485,
-              "f": 4,
-              "s": 0,
-              "i": 0
-            },
-            "tier2": {
-              "p": 112,
-              "f": 4,
-              "s": 109,
-              "i": 0
-            },
-            "tier3": {
-              "p": 309,
-              "f": 11,
-              "s": 20,
-              "i": 0
-            }
-          }
-        },
-        "il-central-1": {
-          "rate": 97.7,
-          "passed": 904,
-          "failed": 21,
-          "skipped": 129,
-          "indeterminate": 0,
-          "count": 1054,
-          "tiers": {
-            "tier1": {
-              "p": 485,
-              "f": 4,
-              "s": 0,
-              "i": 0
-            },
-            "tier2": {
-              "p": 112,
-              "f": 4,
-              "s": 109,
-              "i": 0
-            },
-            "tier3": {
-              "p": 307,
-              "f": 13,
-              "s": 20,
-              "i": 0
-            }
-          }
-        },
-        "me-central-1": {
           "rate": 97.8,
           "passed": 905,
           "failed": 20,
@@ -5666,7 +5610,7 @@
             }
           }
         },
-        "mx-central-1": {
+        "il-central-1": {
           "rate": 97.9,
           "passed": 906,
           "failed": 19,
@@ -5689,15 +5633,71 @@
             "tier3": {
               "p": 309,
               "f": 11,
+              "s": 20,
+              "i": 0
+            }
+          }
+        },
+        "me-central-1": {
+          "rate": 97.7,
+          "passed": 904,
+          "failed": 21,
+          "skipped": 129,
+          "indeterminate": 0,
+          "count": 1054,
+          "tiers": {
+            "tier1": {
+              "p": 485,
+              "f": 4,
+              "s": 0,
+              "i": 0
+            },
+            "tier2": {
+              "p": 112,
+              "f": 4,
+              "s": 109,
+              "i": 0
+            },
+            "tier3": {
+              "p": 307,
+              "f": 13,
+              "s": 20,
+              "i": 0
+            }
+          }
+        },
+        "mx-central-1": {
+          "rate": 97.8,
+          "passed": 905,
+          "failed": 20,
+          "skipped": 129,
+          "indeterminate": 0,
+          "count": 1054,
+          "tiers": {
+            "tier1": {
+              "p": 485,
+              "f": 4,
+              "s": 0,
+              "i": 0
+            },
+            "tier2": {
+              "p": 112,
+              "f": 4,
+              "s": 109,
+              "i": 0
+            },
+            "tier3": {
+              "p": 308,
+              "f": 12,
               "s": 20,
               "i": 0
             }
           }
         },
         "sa-east-1": {
-          "rate": 97.9,
-          "passed": 906,
-          "failed": 19,
+          "rate": 97.8,
+          "passed": 905,
+          "failed": 20,
           "skipped": 129,
           "indeterminate": 0,
           "count": 1054,
@@ -5715,17 +5715,17 @@
               "i": 0
             },
             "tier3": {
-              "p": 309,
-              "f": 11,
+              "p": 308,
+              "f": 12,
               "s": 20,
               "i": 0
             }
           }
         },
         "us-east-1": {
-          "rate": 97.9,
-          "passed": 906,
-          "failed": 19,
+          "rate": 97.8,
+          "passed": 905,
+          "failed": 20,
           "skipped": 129,
           "indeterminate": 0,
           "count": 1054,
@@ -5743,17 +5743,17 @@
               "i": 0
             },
             "tier3": {
-              "p": 309,
-              "f": 11,
+              "p": 308,
+              "f": 12,
               "s": 20,
               "i": 0
             }
           }
         },
         "us-east-2": {
-          "rate": 97.9,
-          "passed": 906,
-          "failed": 19,
+          "rate": 97.8,
+          "passed": 905,
+          "failed": 20,
           "skipped": 129,
           "indeterminate": 0,
           "count": 1054,
@@ -5771,8 +5771,8 @@
               "i": 0
             },
             "tier3": {
-              "p": 309,
-              "f": 11,
+              "p": 308,
+              "f": 12,
               "s": 20,
               "i": 0
             }
@@ -5807,9 +5807,9 @@
           }
         },
         "us-west-2": {
-          "rate": 97.9,
-          "passed": 906,
-          "failed": 19,
+          "rate": 97.8,
+          "passed": 905,
+          "failed": 20,
           "skipped": 129,
           "indeterminate": 0,
           "count": 1054,
@@ -5827,8 +5827,8 @@
               "i": 0
             },
             "tier3": {
-              "p": 309,
-              "f": 11,
+              "p": 308,
+              "f": 12,
               "s": 20,
               "i": 0
             }
@@ -5873,9 +5873,9 @@
           }
         },
         "ap-east-1": {
-          "rate": 78,
-          "passed": 782,
-          "failed": 221,
+          "rate": 77.9,
+          "passed": 781,
+          "failed": 222,
           "skipped": 51,
           "indeterminate": 0,
           "count": 1054,
@@ -5893,17 +5893,17 @@
               "i": 0
             },
             "tier3": {
-              "p": 229,
-              "f": 95,
+              "p": 228,
+              "f": 96,
               "s": 16,
               "i": 0
             }
           }
         },
         "ap-east-2": {
-          "rate": 78,
-          "passed": 782,
-          "failed": 221,
+          "rate": 77.9,
+          "passed": 781,
+          "failed": 222,
           "skipped": 51,
           "indeterminate": 0,
           "count": 1054,
@@ -5921,17 +5921,17 @@
               "i": 0
             },
             "tier3": {
-              "p": 229,
-              "f": 95,
+              "p": 228,
+              "f": 96,
               "s": 16,
               "i": 0
             }
           }
         },
         "ap-northeast-1": {
-          "rate": 78,
-          "passed": 782,
-          "failed": 221,
+          "rate": 77.9,
+          "passed": 781,
+          "failed": 222,
           "skipped": 51,
           "indeterminate": 0,
           "count": 1054,
@@ -5949,8 +5949,8 @@
               "i": 0
             },
             "tier3": {
-              "p": 229,
-              "f": 95,
+              "p": 228,
+              "f": 96,
               "s": 16,
               "i": 0
             }
@@ -5985,9 +5985,9 @@
           }
         },
         "ap-northeast-3": {
-          "rate": 78,
-          "passed": 782,
-          "failed": 221,
+          "rate": 77.9,
+          "passed": 781,
+          "failed": 222,
           "skipped": 51,
           "indeterminate": 0,
           "count": 1054,
@@ -6005,17 +6005,17 @@
               "i": 0
             },
             "tier3": {
-              "p": 229,
-              "f": 95,
+              "p": 228,
+              "f": 96,
               "s": 16,
               "i": 0
             }
           }
         },
         "ap-south-1": {
-          "rate": 78,
-          "passed": 782,
-          "failed": 221,
+          "rate": 77.9,
+          "passed": 781,
+          "failed": 222,
           "skipped": 51,
           "indeterminate": 0,
           "count": 1054,
@@ -6033,17 +6033,17 @@
               "i": 0
             },
             "tier3": {
-              "p": 229,
-              "f": 95,
+              "p": 228,
+              "f": 96,
               "s": 16,
               "i": 0
             }
           }
         },
         "ap-south-2": {
-          "rate": 78,
-          "passed": 782,
-          "failed": 221,
+          "rate": 77.9,
+          "passed": 781,
+          "failed": 222,
           "skipped": 51,
           "indeterminate": 0,
           "count": 1054,
@@ -6061,42 +6061,14 @@
               "i": 0
             },
             "tier3": {
-              "p": 229,
-              "f": 95,
+              "p": 228,
+              "f": 96,
               "s": 16,
               "i": 0
             }
           }
         },
         "ap-southeast-1": {
-          "rate": 77.8,
-          "passed": 780,
-          "failed": 223,
-          "skipped": 51,
-          "indeterminate": 0,
-          "count": 1054,
-          "tiers": {
-            "tier1": {
-              "p": 436,
-              "f": 53,
-              "s": 0,
-              "i": 0
-            },
-            "tier2": {
-              "p": 117,
-              "f": 73,
-              "s": 35,
-              "i": 0
-            },
-            "tier3": {
-              "p": 227,
-              "f": 97,
-              "s": 16,
-              "i": 0
-            }
-          }
-        },
-        "ap-southeast-2": {
           "rate": 78,
           "passed": 782,
           "failed": 221,
@@ -6124,10 +6096,10 @@
             }
           }
         },
-        "ap-southeast-3": {
-          "rate": 77.8,
-          "passed": 780,
-          "failed": 223,
+        "ap-southeast-2": {
+          "rate": 77.9,
+          "passed": 781,
+          "failed": 222,
           "skipped": 51,
           "indeterminate": 0,
           "count": 1054,
@@ -6145,8 +6117,36 @@
               "i": 0
             },
             "tier3": {
-              "p": 227,
-              "f": 97,
+              "p": 228,
+              "f": 96,
+              "s": 16,
+              "i": 0
+            }
+          }
+        },
+        "ap-southeast-3": {
+          "rate": 78,
+          "passed": 782,
+          "failed": 221,
+          "skipped": 51,
+          "indeterminate": 0,
+          "count": 1054,
+          "tiers": {
+            "tier1": {
+              "p": 436,
+              "f": 53,
+              "s": 0,
+              "i": 0
+            },
+            "tier2": {
+              "p": 117,
+              "f": 73,
+              "s": 35,
+              "i": 0
+            },
+            "tier3": {
+              "p": 229,
+              "f": 95,
               "s": 16,
               "i": 0
             }
@@ -6209,9 +6209,9 @@
           }
         },
         "ap-southeast-6": {
-          "rate": 78,
-          "passed": 782,
-          "failed": 221,
+          "rate": 77.9,
+          "passed": 781,
+          "failed": 222,
           "skipped": 51,
           "indeterminate": 0,
           "count": 1054,
@@ -6229,17 +6229,17 @@
               "i": 0
             },
             "tier3": {
-              "p": 229,
-              "f": 95,
+              "p": 228,
+              "f": 96,
               "s": 16,
               "i": 0
             }
           }
         },
         "ap-southeast-7": {
-          "rate": 78,
-          "passed": 782,
-          "failed": 221,
+          "rate": 77.9,
+          "passed": 781,
+          "failed": 222,
           "skipped": 51,
           "indeterminate": 0,
           "count": 1054,
@@ -6257,17 +6257,17 @@
               "i": 0
             },
             "tier3": {
-              "p": 229,
-              "f": 95,
+              "p": 228,
+              "f": 96,
               "s": 16,
               "i": 0
             }
           }
         },
         "ca-central-1": {
-          "rate": 78,
-          "passed": 782,
-          "failed": 221,
+          "rate": 77.9,
+          "passed": 781,
+          "failed": 222,
           "skipped": 51,
           "indeterminate": 0,
           "count": 1054,
@@ -6285,17 +6285,17 @@
               "i": 0
             },
             "tier3": {
-              "p": 229,
-              "f": 95,
+              "p": 228,
+              "f": 96,
               "s": 16,
               "i": 0
             }
           }
         },
         "ca-west-1": {
-          "rate": 78,
-          "passed": 782,
-          "failed": 221,
+          "rate": 77.9,
+          "passed": 781,
+          "failed": 222,
           "skipped": 51,
           "indeterminate": 0,
           "count": 1054,
@@ -6313,17 +6313,17 @@
               "i": 0
             },
             "tier3": {
-              "p": 229,
-              "f": 95,
+              "p": 228,
+              "f": 96,
               "s": 16,
               "i": 0
             }
           }
         },
         "eu-central-1": {
-          "rate": 77.8,
-          "passed": 780,
-          "failed": 223,
+          "rate": 78,
+          "passed": 782,
+          "failed": 221,
           "skipped": 51,
           "indeterminate": 0,
           "count": 1054,
@@ -6341,17 +6341,17 @@
               "i": 0
             },
             "tier3": {
-              "p": 227,
-              "f": 97,
+              "p": 229,
+              "f": 95,
               "s": 16,
               "i": 0
             }
           }
         },
         "eu-central-2": {
-          "rate": 78,
-          "passed": 782,
-          "failed": 221,
+          "rate": 77.9,
+          "passed": 781,
+          "failed": 222,
           "skipped": 51,
           "indeterminate": 0,
           "count": 1054,
@@ -6369,17 +6369,17 @@
               "i": 0
             },
             "tier3": {
-              "p": 229,
-              "f": 95,
+              "p": 228,
+              "f": 96,
               "s": 16,
               "i": 0
             }
           }
         },
         "eu-north-1": {
-          "rate": 77.8,
-          "passed": 780,
-          "failed": 223,
+          "rate": 78,
+          "passed": 782,
+          "failed": 221,
           "skipped": 51,
           "indeterminate": 0,
           "count": 1054,
@@ -6397,17 +6397,17 @@
               "i": 0
             },
             "tier3": {
-              "p": 227,
-              "f": 97,
+              "p": 229,
+              "f": 95,
               "s": 16,
               "i": 0
             }
           }
         },
         "eu-south-1": {
-          "rate": 78,
-          "passed": 782,
-          "failed": 221,
+          "rate": 77.9,
+          "passed": 781,
+          "failed": 222,
           "skipped": 51,
           "indeterminate": 0,
           "count": 1054,
@@ -6425,17 +6425,17 @@
               "i": 0
             },
             "tier3": {
-              "p": 229,
-              "f": 95,
+              "p": 228,
+              "f": 96,
               "s": 16,
               "i": 0
             }
           }
         },
         "eu-south-2": {
-          "rate": 78,
-          "passed": 782,
-          "failed": 221,
+          "rate": 77.9,
+          "passed": 781,
+          "failed": 222,
           "skipped": 51,
           "indeterminate": 0,
           "count": 1054,
@@ -6453,17 +6453,17 @@
               "i": 0
             },
             "tier3": {
-              "p": 229,
-              "f": 95,
+              "p": 228,
+              "f": 96,
               "s": 16,
               "i": 0
             }
           }
         },
         "eu-west-1": {
-          "rate": 78,
-          "passed": 782,
-          "failed": 221,
+          "rate": 77.9,
+          "passed": 781,
+          "failed": 222,
           "skipped": 51,
           "indeterminate": 0,
           "count": 1054,
@@ -6481,8 +6481,8 @@
               "i": 0
             },
             "tier3": {
-              "p": 229,
-              "f": 95,
+              "p": 228,
+              "f": 96,
               "s": 16,
               "i": 0
             }
@@ -6517,62 +6517,6 @@
           }
         },
         "eu-west-3": {
-          "rate": 78,
-          "passed": 782,
-          "failed": 221,
-          "skipped": 51,
-          "indeterminate": 0,
-          "count": 1054,
-          "tiers": {
-            "tier1": {
-              "p": 436,
-              "f": 53,
-              "s": 0,
-              "i": 0
-            },
-            "tier2": {
-              "p": 117,
-              "f": 73,
-              "s": 35,
-              "i": 0
-            },
-            "tier3": {
-              "p": 229,
-              "f": 95,
-              "s": 16,
-              "i": 0
-            }
-          }
-        },
-        "il-central-1": {
-          "rate": 77.8,
-          "passed": 780,
-          "failed": 223,
-          "skipped": 51,
-          "indeterminate": 0,
-          "count": 1054,
-          "tiers": {
-            "tier1": {
-              "p": 436,
-              "f": 53,
-              "s": 0,
-              "i": 0
-            },
-            "tier2": {
-              "p": 117,
-              "f": 73,
-              "s": 35,
-              "i": 0
-            },
-            "tier3": {
-              "p": 227,
-              "f": 97,
-              "s": 16,
-              "i": 0
-            }
-          }
-        },
-        "me-central-1": {
           "rate": 77.9,
           "passed": 781,
           "failed": 222,
@@ -6600,7 +6544,7 @@
             }
           }
         },
-        "mx-central-1": {
+        "il-central-1": {
           "rate": 78,
           "passed": 782,
           "failed": 221,
@@ -6623,15 +6567,71 @@
             "tier3": {
               "p": 229,
               "f": 95,
+              "s": 16,
+              "i": 0
+            }
+          }
+        },
+        "me-central-1": {
+          "rate": 77.8,
+          "passed": 780,
+          "failed": 223,
+          "skipped": 51,
+          "indeterminate": 0,
+          "count": 1054,
+          "tiers": {
+            "tier1": {
+              "p": 436,
+              "f": 53,
+              "s": 0,
+              "i": 0
+            },
+            "tier2": {
+              "p": 117,
+              "f": 73,
+              "s": 35,
+              "i": 0
+            },
+            "tier3": {
+              "p": 227,
+              "f": 97,
+              "s": 16,
+              "i": 0
+            }
+          }
+        },
+        "mx-central-1": {
+          "rate": 77.9,
+          "passed": 781,
+          "failed": 222,
+          "skipped": 51,
+          "indeterminate": 0,
+          "count": 1054,
+          "tiers": {
+            "tier1": {
+              "p": 436,
+              "f": 53,
+              "s": 0,
+              "i": 0
+            },
+            "tier2": {
+              "p": 117,
+              "f": 73,
+              "s": 35,
+              "i": 0
+            },
+            "tier3": {
+              "p": 228,
+              "f": 96,
               "s": 16,
               "i": 0
             }
           }
         },
         "sa-east-1": {
-          "rate": 78,
-          "passed": 782,
-          "failed": 221,
+          "rate": 77.9,
+          "passed": 781,
+          "failed": 222,
           "skipped": 51,
           "indeterminate": 0,
           "count": 1054,
@@ -6649,17 +6649,17 @@
               "i": 0
             },
             "tier3": {
-              "p": 229,
-              "f": 95,
+              "p": 228,
+              "f": 96,
               "s": 16,
               "i": 0
             }
           }
         },
         "us-east-1": {
-          "rate": 78,
-          "passed": 782,
-          "failed": 221,
+          "rate": 77.9,
+          "passed": 781,
+          "failed": 222,
           "skipped": 51,
           "indeterminate": 0,
           "count": 1054,
@@ -6677,17 +6677,17 @@
               "i": 0
             },
             "tier3": {
-              "p": 229,
-              "f": 95,
+              "p": 228,
+              "f": 96,
               "s": 16,
               "i": 0
             }
           }
         },
         "us-east-2": {
-          "rate": 78,
-          "passed": 782,
-          "failed": 221,
+          "rate": 77.9,
+          "passed": 781,
+          "failed": 222,
           "skipped": 51,
           "indeterminate": 0,
           "count": 1054,
@@ -6705,8 +6705,8 @@
               "i": 0
             },
             "tier3": {
-              "p": 229,
-              "f": 95,
+              "p": 228,
+              "f": 96,
               "s": 16,
               "i": 0
             }
@@ -6741,9 +6741,9 @@
           }
         },
         "us-west-2": {
-          "rate": 78,
-          "passed": 782,
-          "failed": 221,
+          "rate": 77.9,
+          "passed": 781,
+          "failed": 222,
           "skipped": 51,
           "indeterminate": 0,
           "count": 1054,
@@ -6761,8 +6761,8 @@
               "i": 0
             },
             "tier3": {
-              "p": 229,
-              "f": 95,
+              "p": 228,
+              "f": 96,
               "s": 16,
               "i": 0
             }
@@ -7741,9 +7741,9 @@
           }
         },
         "ap-east-1": {
-          "rate": 87.6,
-          "passed": 887,
-          "failed": 125,
+          "rate": 87.5,
+          "passed": 886,
+          "failed": 126,
           "skipped": 42,
           "indeterminate": 0,
           "count": 1054,
@@ -7761,17 +7761,17 @@
               "i": 0
             },
             "tier3": {
-              "p": 261,
-              "f": 63,
+              "p": 260,
+              "f": 64,
               "s": 16,
               "i": 0
             }
           }
         },
         "ap-east-2": {
-          "rate": 87.6,
-          "passed": 887,
-          "failed": 125,
+          "rate": 87.5,
+          "passed": 886,
+          "failed": 126,
           "skipped": 42,
           "indeterminate": 0,
           "count": 1054,
@@ -7789,17 +7789,17 @@
               "i": 0
             },
             "tier3": {
-              "p": 261,
-              "f": 63,
+              "p": 260,
+              "f": 64,
               "s": 16,
               "i": 0
             }
           }
         },
         "ap-northeast-1": {
-          "rate": 87.6,
-          "passed": 887,
-          "failed": 125,
+          "rate": 87.5,
+          "passed": 886,
+          "failed": 126,
           "skipped": 42,
           "indeterminate": 0,
           "count": 1054,
@@ -7817,8 +7817,8 @@
               "i": 0
             },
             "tier3": {
-              "p": 261,
-              "f": 63,
+              "p": 260,
+              "f": 64,
               "s": 16,
               "i": 0
             }
@@ -7853,9 +7853,9 @@
           }
         },
         "ap-northeast-3": {
-          "rate": 87.6,
-          "passed": 887,
-          "failed": 125,
+          "rate": 87.5,
+          "passed": 886,
+          "failed": 126,
           "skipped": 42,
           "indeterminate": 0,
           "count": 1054,
@@ -7873,17 +7873,17 @@
               "i": 0
             },
             "tier3": {
-              "p": 261,
-              "f": 63,
+              "p": 260,
+              "f": 64,
               "s": 16,
               "i": 0
             }
           }
         },
         "ap-south-1": {
-          "rate": 87.6,
-          "passed": 887,
-          "failed": 125,
+          "rate": 87.5,
+          "passed": 886,
+          "failed": 126,
           "skipped": 42,
           "indeterminate": 0,
           "count": 1054,
@@ -7901,17 +7901,17 @@
               "i": 0
             },
             "tier3": {
-              "p": 261,
-              "f": 63,
+              "p": 260,
+              "f": 64,
               "s": 16,
               "i": 0
             }
           }
         },
         "ap-south-2": {
-          "rate": 87.6,
-          "passed": 887,
-          "failed": 125,
+          "rate": 87.5,
+          "passed": 886,
+          "failed": 126,
           "skipped": 42,
           "indeterminate": 0,
           "count": 1054,
@@ -7929,42 +7929,14 @@
               "i": 0
             },
             "tier3": {
-              "p": 261,
-              "f": 63,
+              "p": 260,
+              "f": 64,
               "s": 16,
               "i": 0
             }
           }
         },
         "ap-southeast-1": {
-          "rate": 87.5,
-          "passed": 885,
-          "failed": 127,
-          "skipped": 42,
-          "indeterminate": 0,
-          "count": 1054,
-          "tiers": {
-            "tier1": {
-              "p": 461,
-              "f": 28,
-              "s": 0,
-              "i": 0
-            },
-            "tier2": {
-              "p": 165,
-              "f": 34,
-              "s": 26,
-              "i": 0
-            },
-            "tier3": {
-              "p": 259,
-              "f": 65,
-              "s": 16,
-              "i": 0
-            }
-          }
-        },
-        "ap-southeast-2": {
           "rate": 87.6,
           "passed": 887,
           "failed": 125,
@@ -7992,10 +7964,10 @@
             }
           }
         },
-        "ap-southeast-3": {
+        "ap-southeast-2": {
           "rate": 87.5,
-          "passed": 885,
-          "failed": 127,
+          "passed": 886,
+          "failed": 126,
           "skipped": 42,
           "indeterminate": 0,
           "count": 1054,
@@ -8013,8 +7985,36 @@
               "i": 0
             },
             "tier3": {
-              "p": 259,
-              "f": 65,
+              "p": 260,
+              "f": 64,
+              "s": 16,
+              "i": 0
+            }
+          }
+        },
+        "ap-southeast-3": {
+          "rate": 87.6,
+          "passed": 887,
+          "failed": 125,
+          "skipped": 42,
+          "indeterminate": 0,
+          "count": 1054,
+          "tiers": {
+            "tier1": {
+              "p": 461,
+              "f": 28,
+              "s": 0,
+              "i": 0
+            },
+            "tier2": {
+              "p": 165,
+              "f": 34,
+              "s": 26,
+              "i": 0
+            },
+            "tier3": {
+              "p": 261,
+              "f": 63,
               "s": 16,
               "i": 0
             }
@@ -8077,9 +8077,9 @@
           }
         },
         "ap-southeast-6": {
-          "rate": 87.6,
-          "passed": 887,
-          "failed": 125,
+          "rate": 87.5,
+          "passed": 886,
+          "failed": 126,
           "skipped": 42,
           "indeterminate": 0,
           "count": 1054,
@@ -8097,17 +8097,17 @@
               "i": 0
             },
             "tier3": {
-              "p": 261,
-              "f": 63,
+              "p": 260,
+              "f": 64,
               "s": 16,
               "i": 0
             }
           }
         },
         "ap-southeast-7": {
-          "rate": 87.6,
-          "passed": 887,
-          "failed": 125,
+          "rate": 87.5,
+          "passed": 886,
+          "failed": 126,
           "skipped": 42,
           "indeterminate": 0,
           "count": 1054,
@@ -8125,17 +8125,17 @@
               "i": 0
             },
             "tier3": {
-              "p": 261,
-              "f": 63,
+              "p": 260,
+              "f": 64,
               "s": 16,
               "i": 0
             }
           }
         },
         "ca-central-1": {
-          "rate": 87.6,
-          "passed": 887,
-          "failed": 125,
+          "rate": 87.5,
+          "passed": 886,
+          "failed": 126,
           "skipped": 42,
           "indeterminate": 0,
           "count": 1054,
@@ -8153,17 +8153,17 @@
               "i": 0
             },
             "tier3": {
-              "p": 261,
-              "f": 63,
+              "p": 260,
+              "f": 64,
               "s": 16,
               "i": 0
             }
           }
         },
         "ca-west-1": {
-          "rate": 87.6,
-          "passed": 887,
-          "failed": 125,
+          "rate": 87.5,
+          "passed": 886,
+          "failed": 126,
           "skipped": 42,
           "indeterminate": 0,
           "count": 1054,
@@ -8181,17 +8181,17 @@
               "i": 0
             },
             "tier3": {
-              "p": 261,
-              "f": 63,
+              "p": 260,
+              "f": 64,
               "s": 16,
               "i": 0
             }
           }
         },
         "eu-central-1": {
-          "rate": 87.5,
-          "passed": 885,
-          "failed": 127,
+          "rate": 87.6,
+          "passed": 887,
+          "failed": 125,
           "skipped": 42,
           "indeterminate": 0,
           "count": 1054,
@@ -8209,17 +8209,17 @@
               "i": 0
             },
             "tier3": {
-              "p": 259,
-              "f": 65,
+              "p": 261,
+              "f": 63,
               "s": 16,
               "i": 0
             }
           }
         },
         "eu-central-2": {
-          "rate": 87.6,
-          "passed": 887,
-          "failed": 125,
+          "rate": 87.5,
+          "passed": 886,
+          "failed": 126,
           "skipped": 42,
           "indeterminate": 0,
           "count": 1054,
@@ -8237,17 +8237,17 @@
               "i": 0
             },
             "tier3": {
-              "p": 261,
-              "f": 63,
+              "p": 260,
+              "f": 64,
               "s": 16,
               "i": 0
             }
           }
         },
         "eu-north-1": {
-          "rate": 87.5,
-          "passed": 885,
-          "failed": 127,
+          "rate": 87.6,
+          "passed": 887,
+          "failed": 125,
           "skipped": 42,
           "indeterminate": 0,
           "count": 1054,
@@ -8265,17 +8265,17 @@
               "i": 0
             },
             "tier3": {
-              "p": 259,
-              "f": 65,
+              "p": 261,
+              "f": 63,
               "s": 16,
               "i": 0
             }
           }
         },
         "eu-south-1": {
-          "rate": 87.6,
-          "passed": 887,
-          "failed": 125,
+          "rate": 87.5,
+          "passed": 886,
+          "failed": 126,
           "skipped": 42,
           "indeterminate": 0,
           "count": 1054,
@@ -8293,17 +8293,17 @@
               "i": 0
             },
             "tier3": {
-              "p": 261,
-              "f": 63,
+              "p": 260,
+              "f": 64,
               "s": 16,
               "i": 0
             }
           }
         },
         "eu-south-2": {
-          "rate": 87.6,
-          "passed": 887,
-          "failed": 125,
+          "rate": 87.5,
+          "passed": 886,
+          "failed": 126,
           "skipped": 42,
           "indeterminate": 0,
           "count": 1054,
@@ -8321,17 +8321,17 @@
               "i": 0
             },
             "tier3": {
-              "p": 261,
-              "f": 63,
+              "p": 260,
+              "f": 64,
               "s": 16,
               "i": 0
             }
           }
         },
         "eu-west-1": {
-          "rate": 87.6,
-          "passed": 887,
-          "failed": 125,
+          "rate": 87.5,
+          "passed": 886,
+          "failed": 126,
           "skipped": 42,
           "indeterminate": 0,
           "count": 1054,
@@ -8349,8 +8349,8 @@
               "i": 0
             },
             "tier3": {
-              "p": 261,
-              "f": 63,
+              "p": 260,
+              "f": 64,
               "s": 16,
               "i": 0
             }
@@ -8385,62 +8385,6 @@
           }
         },
         "eu-west-3": {
-          "rate": 87.6,
-          "passed": 887,
-          "failed": 125,
-          "skipped": 42,
-          "indeterminate": 0,
-          "count": 1054,
-          "tiers": {
-            "tier1": {
-              "p": 461,
-              "f": 28,
-              "s": 0,
-              "i": 0
-            },
-            "tier2": {
-              "p": 165,
-              "f": 34,
-              "s": 26,
-              "i": 0
-            },
-            "tier3": {
-              "p": 261,
-              "f": 63,
-              "s": 16,
-              "i": 0
-            }
-          }
-        },
-        "il-central-1": {
-          "rate": 87.5,
-          "passed": 885,
-          "failed": 127,
-          "skipped": 42,
-          "indeterminate": 0,
-          "count": 1054,
-          "tiers": {
-            "tier1": {
-              "p": 461,
-              "f": 28,
-              "s": 0,
-              "i": 0
-            },
-            "tier2": {
-              "p": 165,
-              "f": 34,
-              "s": 26,
-              "i": 0
-            },
-            "tier3": {
-              "p": 259,
-              "f": 65,
-              "s": 16,
-              "i": 0
-            }
-          }
-        },
-        "me-central-1": {
           "rate": 87.5,
           "passed": 886,
           "failed": 126,
@@ -8468,7 +8412,7 @@
             }
           }
         },
-        "mx-central-1": {
+        "il-central-1": {
           "rate": 87.6,
           "passed": 887,
           "failed": 125,
@@ -8491,15 +8435,71 @@
             "tier3": {
               "p": 261,
               "f": 63,
+              "s": 16,
+              "i": 0
+            }
+          }
+        },
+        "me-central-1": {
+          "rate": 87.5,
+          "passed": 885,
+          "failed": 127,
+          "skipped": 42,
+          "indeterminate": 0,
+          "count": 1054,
+          "tiers": {
+            "tier1": {
+              "p": 461,
+              "f": 28,
+              "s": 0,
+              "i": 0
+            },
+            "tier2": {
+              "p": 165,
+              "f": 34,
+              "s": 26,
+              "i": 0
+            },
+            "tier3": {
+              "p": 259,
+              "f": 65,
+              "s": 16,
+              "i": 0
+            }
+          }
+        },
+        "mx-central-1": {
+          "rate": 87.5,
+          "passed": 886,
+          "failed": 126,
+          "skipped": 42,
+          "indeterminate": 0,
+          "count": 1054,
+          "tiers": {
+            "tier1": {
+              "p": 461,
+              "f": 28,
+              "s": 0,
+              "i": 0
+            },
+            "tier2": {
+              "p": 165,
+              "f": 34,
+              "s": 26,
+              "i": 0
+            },
+            "tier3": {
+              "p": 260,
+              "f": 64,
               "s": 16,
               "i": 0
             }
           }
         },
         "sa-east-1": {
-          "rate": 87.6,
-          "passed": 887,
-          "failed": 125,
+          "rate": 87.5,
+          "passed": 886,
+          "failed": 126,
           "skipped": 42,
           "indeterminate": 0,
           "count": 1054,
@@ -8517,17 +8517,17 @@
               "i": 0
             },
             "tier3": {
-              "p": 261,
-              "f": 63,
+              "p": 260,
+              "f": 64,
               "s": 16,
               "i": 0
             }
           }
         },
         "us-east-1": {
-          "rate": 87.6,
-          "passed": 887,
-          "failed": 125,
+          "rate": 87.5,
+          "passed": 886,
+          "failed": 126,
           "skipped": 42,
           "indeterminate": 0,
           "count": 1054,
@@ -8545,17 +8545,17 @@
               "i": 0
             },
             "tier3": {
-              "p": 261,
-              "f": 63,
+              "p": 260,
+              "f": 64,
               "s": 16,
               "i": 0
             }
           }
         },
         "us-east-2": {
-          "rate": 87.6,
-          "passed": 887,
-          "failed": 125,
+          "rate": 87.5,
+          "passed": 886,
+          "failed": 126,
           "skipped": 42,
           "indeterminate": 0,
           "count": 1054,
@@ -8573,8 +8573,8 @@
               "i": 0
             },
             "tier3": {
-              "p": 261,
-              "f": 63,
+              "p": 260,
+              "f": 64,
               "s": 16,
               "i": 0
             }
@@ -8609,9 +8609,9 @@
           }
         },
         "us-west-2": {
-          "rate": 87.6,
-          "passed": 887,
-          "failed": 125,
+          "rate": 87.5,
+          "passed": 886,
+          "failed": 126,
           "skipped": 42,
           "indeterminate": 0,
           "count": 1054,
@@ -8629,8 +8629,8 @@
               "i": 0
             },
             "tier3": {
-              "p": 261,
-              "f": 63,
+              "p": 260,
+              "f": 64,
               "s": 16,
               "i": 0
             }

--- a/scripts/lib/drift.mjs
+++ b/scripts/lib/drift.mjs
@@ -100,9 +100,29 @@ export function diffCaptures(baseline, observed) {
   return { probes, nullRoundTrip: diffNullRoundTrip(baseline?.nullRoundTrip, observed?.nullRoundTrip) }
 }
 
+/**
+ * The probes in a diff that actually moved.
+ *
+ * A probe present on only one side is reported by diffCaptures as added or
+ * removed, which is true and worth seeing, but it is not drift: a probe with no
+ * baseline has no earlier answer to have moved from. Only an across-time diff
+ * can produce those - a cross-region diff compares two blocks from the same
+ * capture run, so both sides always carry the same probe set - and across time
+ * they mean the capture script gained or lost a probe, not that AWS changed.
+ * Counted as drift, a newly added probe is named on every red run that follows,
+ * against a baseline that never carried it.
+ */
+export function driftedProbes(diff) {
+  const onlyTheProbeSetMoved = (p) =>
+    Array.isArray(p?.changed) &&
+    p.changed.length > 0 &&
+    p.changed.every((c) => c === 'added' || c === 'removed')
+  return (diff?.probes ?? []).filter((p) => !onlyTheProbeSetMoved(p))
+}
+
 /** True when a diff result carries no divergence at all. */
 export function isClean(diff) {
-  return (diff?.probes?.length ?? 0) === 0 && !diff?.nullRoundTrip
+  return driftedProbes(diff).length === 0 && !diff?.nullRoundTrip
 }
 
 /**

--- a/scripts/lib/drift.test.mjs
+++ b/scripts/lib/drift.test.mjs
@@ -2,7 +2,7 @@ import { describe, it, expect } from 'vitest'
 import { readFileSync } from 'node:fs'
 import { fileURLToPath } from 'node:url'
 import { dirname, join } from 'node:path'
-import { diffCaptures, diffProbe, diffRegions, isClean } from './drift.mjs'
+import { diffCaptures, diffProbe, diffRegions, driftedProbes, isClean } from './drift.mjs'
 
 const here = dirname(fileURLToPath(import.meta.url))
 const snapshot = JSON.parse(
@@ -66,6 +66,26 @@ describe('diffCaptures', () => {
     const ids = diffCaptures(base, obs).probes
     expect(ids.find((p) => p.id === 'only-base').changed).toEqual(['removed'])
     expect(ids.find((p) => p.id === 'only-obs').changed).toEqual(['added'])
+  })
+
+  it('does not count an added or removed probe as drift', () => {
+    // Adding a probe to the capture script leaves every older baseline without
+    // it. That is a changed probe set, not a changed answer, and reporting it
+    // as drift made a scheduled red name the new probe as the thing that moved.
+    const base = block(probe({ id: 'kept' }))
+    const obs = block(probe({ id: 'kept' }), probe({ id: 'brand-new' }))
+    const d = diffCaptures(base, obs)
+    expect(d.probes.map((p) => p.id)).toEqual(['brand-new'])
+    expect(driftedProbes(d)).toEqual([])
+    expect(isClean(d)).toBe(true)
+  })
+
+  it('still counts a probe whose answer moved, alongside an added one', () => {
+    const base = block(probe({ id: 'kept', message: 'before' }))
+    const obs = block(probe({ id: 'kept', message: 'after' }), probe({ id: 'brand-new' }))
+    const d = diffCaptures(base, obs)
+    expect(driftedProbes(d).map((p) => p.id)).toEqual(['kept'])
+    expect(isClean(d)).toBe(false)
   })
 
   it('flags a nullRoundTrip divergence', () => {

--- a/scripts/report-failure.mjs
+++ b/scripts/report-failure.mjs
@@ -34,6 +34,7 @@
 
 import { existsSync, readFileSync, writeFileSync } from 'node:fs'
 import { classifyResults } from './lib/classify.mjs'
+import { driftedProbes } from './lib/drift.mjs'
 
 /**
  * Classify every assertion in a Vitest JSON report (merging its indeterminate
@@ -96,7 +97,7 @@ export function verdictFromDrift(driftResult) {
       probes: [],
     }
   }
-  const probes = (driftResult.drift?.probes ?? []).map((p) => p.id)
+  const probes = driftedProbes(driftResult.drift).map((p) => p.id)
   // A round-trip-only change carries no probe id, so name it explicitly or the
   // issue would claim drift with nothing to act on.
   if (driftResult.drift?.nullRoundTrip) probes.push('{ NULL: false } round-trip')

--- a/scripts/report-failure.test.mjs
+++ b/scripts/report-failure.test.mjs
@@ -86,6 +86,21 @@ describe('verdictFromDrift', () => {
     expect(v.probes).toEqual(['s_put_table_empty', 'b_put_dup_ss'])
   })
 
+  it('does not list a probe the baseline never carried', () => {
+    // A probe added to the capture script is absent from every older baseline,
+    // so listing it as drift points triage at a probe that has not moved.
+    const v = verdictFromDrift({
+      clean: false,
+      drift: {
+        probes: [
+          { id: 's_put_table_empty', changed: ['message'] },
+          { id: 'o_bg_empty_requestitems', changed: ['added'] },
+        ],
+      },
+    })
+    expect(v.probes).toEqual(['s_put_table_empty'])
+  })
+
   it('gives no verdict when the diff was not comparable (missing region block)', () => {
     expect(verdictFromDrift({ comparable: false, clean: false, drift: { probes: [] } })).toBeNull()
   })

--- a/tests/tier3/error-messages/batchGetItem.test.ts
+++ b/tests/tier3/error-messages/batchGetItem.test.ts
@@ -13,7 +13,10 @@ describe('BatchGetItem — exact error messages', { tags: ['batch', 'data-plane'
   it('empty RequestItems: full required-parameter error', async (ctx) => {
     // Split behaviour (registry row batch-get-item-empty-request-items-message):
     // the answer differs by region, so what the target actually returned is
-    // recorded for per-region scoring.
+    // recorded for per-region scoring. eu-west-2 is pinned, and it moved to the
+    // validation framework's generic constraint message between the 2026-08-08
+    // and 2026-08-15 sweeps; 22 regions still answer the bespoke sentence
+    // `The requestItems parameter is required for BatchGetItem`.
     try {
       await observeSplit(ctx.task, () => ddb.send(new BatchGetItemCommand({ RequestItems: {} })))
       expect.unreachable('should have thrown')
@@ -21,7 +24,7 @@ describe('BatchGetItem — exact error messages', { tags: ['batch', 'data-plane'
       expect(err).toBeInstanceOf(DynamoDBServiceException)
       expect((err as DynamoDBServiceException).name).toBe('ValidationException')
       expect((err as DynamoDBServiceException).message).toBe(
-        'The requestItems parameter is required for BatchGetItem',
+        "1 validation error detected: Value at 'RequestItems' failed to satisfy constraint: Member must have length greater than or equal to 1",
       )
     }
   })

--- a/tests/tier3/validation-ordering/batchOperations.test.ts
+++ b/tests/tier3/validation-ordering/batchOperations.test.ts
@@ -4,10 +4,22 @@ import {
   DynamoDBServiceException,
 } from '@aws-sdk/client-dynamodb'
 import { ddb } from '../../../src/client.js'
-import { observeSplit } from '../../../src/observation-sink.js'
 import { declareTables, hashTableDef } from '../../../src/helpers.js'
 
 declareTables(hashTableDef)
+
+// What these two assert is the ordering: an empty RequestItems map is refused
+// before the map is read, so the request never reaches a table. The wording of
+// the refusal is regional and is not this tier's business. The 2026-06
+// validation-framework rollout is replacing the bespoke sentence
+// `The <op>Items parameter is required for <Op>` with the framework's generic
+// `Value at 'RequestItems' failed to satisfy constraint: ...`, and as of
+// 2026-08-17 BatchGetItem has crossed in 11 of the 33 answering regions while
+// BatchWriteItem has crossed in none. Matching the parameter name
+// case-insensitively spans both wordings, so a rewording does not turn an
+// ordering test red. Registry row batch-get-item-empty-request-items-message
+// and the tier 3 error-messages test it keys to pin the exact wording.
+const REJECTS_EMPTY_REQUEST_ITEMS = /requestitems/i
 
 describe('Batch operations — validation ordering', { tags: ['batch', 'data-plane', 'negative-path'] }, () => {
   it('BatchWriteItem rejects empty RequestItems', async () => {
@@ -22,28 +34,23 @@ describe('Batch operations — validation ordering', { tags: ['batch', 'data-pla
       expect(e).toBeInstanceOf(DynamoDBServiceException)
       const err = e as DynamoDBServiceException
       expect(err.name).toBe('ValidationException')
-      expect(err.message).toContain('requestItems')
+      expect(err.message).toMatch(REJECTS_EMPTY_REQUEST_ITEMS)
     }
   })
 
-  it('BatchGetItem rejects empty RequestItems', async (ctx) => {
-    // Split behaviour (registry row batch-get-item-empty-request-items-ordering):
-    // the answer differs by region, so what the target actually returned is
-    // recorded for per-region scoring.
+  it('BatchGetItem rejects empty RequestItems', async () => {
     try {
-      await observeSplit(ctx.task, () =>
-        ddb.send(
-          new BatchGetItemCommand({
-            RequestItems: {},
-          }),
-        ),
+      await ddb.send(
+        new BatchGetItemCommand({
+          RequestItems: {},
+        }),
       )
       expect.unreachable('should have thrown')
     } catch (e: unknown) {
       expect(e).toBeInstanceOf(DynamoDBServiceException)
       const err = e as DynamoDBServiceException
       expect(err.name).toBe('ValidationException')
-      expect(err.message).toContain('requestItems')
+      expect(err.message).toMatch(REJECTS_EMPTY_REQUEST_ITEMS)
     }
   })
 


### PR DESCRIPTION
## What this changes

eu-west-2 crossed to the validation framework's generic constraint message for
`BatchGetItem` with an empty `RequestItems` map between the 2026-08-08 and
2026-08-15 sweeps. That turned the scheduled ground-truth run red and left
`batch-get-item-empty-request-items-message` recording the wrong answer for the
region it pins.

The row is re-characterised against a 34-region capture taken on 2026-08-17: 11
of the 33 answering regions return the generic message, 22 return the bespoke
required-parameter sentence, and me-central-1 joins the row. The exact-message
assertion moves to the generic wording. Closes #152, closes #156, and supersedes
#126.

The matching validation-ordering row is retired, closing #153 and superseding
#127. Both wordings refuse the map before it is read, which is all that tier
asserts, so its assertion matches the parameter name case-insensitively and
spans both cohorts. The `BatchWriteItem` case beside it is written the same way;
no region has moved it yet.

Two things the red run exposed in the drift reporting are fixed alongside it. A
probe absent from the baseline is no longer counted as drift, so a probe added
to the capture script is not named on every red run that follows. And the weekly
cross-region capture now includes eu-west-2, ordered after the gating job rather
than excluded from it: without the baseline region in the document,
`drift-diff.mjs` cannot run in cross-region mode at all, so the lens the capture
feeds was comparing against a separate and older file. A scheduled red also
keeps the eu-west-2 capture its verdict was read from, which previously died
with the runner.

## Checklist

- [x] New or modified tests run against real AWS DynamoDB and pass
- ~~New or modified tests run against at least one emulator target and behave as
  expected~~ - no new tests; the two modified assertions are re-characterised
  against real AWS, and every emulator target runs them on merge
- [x] Linked issue or a short note explaining the motivation
- [x] I agree my contribution is licensed under the project's terms
  (Apache License, Version 2.0)

## Tier and scope

This touches the split registry and the results pipeline. `registry/splits.json`
loses a row and re-records another, `registry/suite-manifest.json` is
regenerated, and `README.md` and `results/summary.json` are rebuilt from the new
registry.

Six emulator rows move in the Regions column because they are scored from
results measured before this change: a committed pass is credited to the pinned
region's answer, and that answer has moved. The conformance run on merge
re-measures every target and republishes the board.
