### PR TITLE
fix(ci): dispatch the measurement as the App, not GITHUB_TOKEN

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -64,7 +64,7 @@ jobs:
       #
       # contents:write and nothing else, because this is the token `checkout`
       # receives and `npm ci` runs beside. The dispatch needs actions:write and
-      # mints its own further down rather than widening this one.
+      # mints its own below rather than widening this one.
       #
       # create-github-app-token can only narrow what the installation was
       # granted, so asking for a permission it does not hold fails the whole
@@ -77,6 +77,24 @@ jobs:
           client-id: ${{ vars.RESULTS_BOT_CLIENT_ID }}
           private-key: ${{ secrets.RESULTS_BOT_PRIVATE_KEY }}
           permission-contents: write
+
+      # The token that starts the measurement, minted up here rather than
+      # beside the step at the end of the job that reads it. A mint fails
+      # outright when the installation does not hold what it asks for, and by
+      # the time the dispatch runs the bump is committed, the tag is pushed and
+      # the draft is open - so a late failure would strand a cut that then has
+      # to be finished by hand. Failing before any of that costs nothing.
+      #
+      # Separate from the token above because they are handed to different
+      # things: that one goes to actions/checkout and sits beside `npm ci` on a
+      # freshly bumped tree, this one is read by the dispatch and nowhere else.
+      - name: Mint a dispatch token
+        id: dispatch-token
+        uses: actions/create-github-app-token@v3
+        with:
+          client-id: ${{ vars.RESULTS_BOT_CLIENT_ID }}
+          private-key: ${{ secrets.RESULTS_BOT_PRIVATE_KEY }}
+          permission-actions: write
 
       - uses: actions/checkout@v7
         with:
@@ -197,18 +215,6 @@ jobs:
             --title "v$VERSION" \
             --notes-file "$NOTES" \
             --draft
-
-      # A second token, deliberately not the one minted at the top. This one is
-      # read by the step below and nowhere else, so it carries actions:write
-      # alone instead of widening the token that checkout and `npm ci` sit next
-      # to.
-      - name: Mint a dispatch token
-        id: dispatch-token
-        uses: actions/create-github-app-token@v3
-        with:
-          client-id: ${{ vars.RESULTS_BOT_CLIENT_ID }}
-          private-key: ${{ secrets.RESULTS_BOT_PRIVATE_KEY }}
-          permission-actions: write
 
       # The measurement that will publish it.
       #

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,9 @@ name: Cut a release
 # the run fails, dispatch conformance.yml from main with its `ref` input set to
 # the tag; that same path finishes the release. Dispatching on the tag itself
 # measures it and publishes nothing - see the measurement step at the end of
-# this file.
+# this file. If the measurement went green but no board landed, the run is
+# fine and only the handover was missed: dispatch results-table.yml with that
+# run's id.
 #
 # So this workflow runs once per version and never has to tolerate its own
 # output, which is what makes its preconditions safe to state absolutely.
@@ -27,19 +29,22 @@ on:
         description: "Version to release (MAJOR.MINOR.PATCH, no leading v)"
         required: true
 
-# For GITHUB_TOKEN, which does the reading and the dispatching. The App token
-# minted below is separate and is only used for what needs to get past main's
-# ruleset. Splitting them this way keeps the App's grant at contents:write,
-# which is all it has ever had.
+# For GITHUB_TOKEN, which does the reading. The App tokens minted below are
+# separate, and each is scoped to the one thing it is for: getting past main's
+# ruleset, and starting the measurement.
 permissions:
   contents: read
   # The head commit's check runs are their own permission; contents does not
   # cover them.
   checks: read
-  # Dispatching the measurement. A workflow_dispatch is the documented exception
-  # to GITHUB_TOKEN not starting further workflow runs, so the conformance run
-  # does start - and the last step confirms it did rather than assuming.
-  actions: write
+  # Reading this run's own check suite, not dispatching. GITHUB_TOKEN can start
+  # a run - workflow_dispatch is the documented exception to it not starting
+  # further runs - but the run it starts is attributed to github-actions[bot],
+  # and GitHub emits no workflow_run event when a run attributed that way
+  # completes. So the measurement ran green for three hours and
+  # results-table.yml never heard about it, leaving v3.2.0's draft open. The
+  # dispatch is made with an App token for that reason and no other.
+  actions: read
 
 # One cut at a time. Queue rather than cancel: a cancelled run can leave a
 # bumped tree committed with no tag behind it.
@@ -57,11 +62,14 @@ jobs:
       # pushing the bump commit and the tag relaxes no protection. It is also
       # what can see draft releases, which need push access.
       #
-      # contents:write and nothing else. create-github-app-token can only narrow
-      # what the installation was granted, so asking for a permission it does
-      # not hold fails the whole step with a 422 before anything else runs -
-      # which is exactly what happened when this also asked for actions:write
-      # and checks:read. Everything those were for now runs on GITHUB_TOKEN.
+      # contents:write and nothing else, because this is the token `checkout`
+      # receives and `npm ci` runs beside. The dispatch needs actions:write and
+      # mints its own further down rather than widening this one.
+      #
+      # create-github-app-token can only narrow what the installation was
+      # granted, so asking for a permission it does not hold fails the whole
+      # step with a 422 before anything else runs. The App has no Checks grant,
+      # which is why checks:read stays on GITHUB_TOKEN.
       - name: Mint a token for the results bot
         id: app-token
         uses: actions/create-github-app-token@v3
@@ -190,6 +198,18 @@ jobs:
             --notes-file "$NOTES" \
             --draft
 
+      # A second token, deliberately not the one minted at the top. This one is
+      # read by the step below and nowhere else, so it carries actions:write
+      # alone instead of widening the token that checkout and `npm ci` sit next
+      # to.
+      - name: Mint a dispatch token
+        id: dispatch-token
+        uses: actions/create-github-app-token@v3
+        with:
+          client-id: ${{ vars.RESULTS_BOT_CLIENT_ID }}
+          private-key: ${{ secrets.RESULTS_BOT_PRIVATE_KEY }}
+          permission-actions: write
+
       # The measurement that will publish it.
       #
       # Dispatched on main with the tag as an input, not on the tag itself.
@@ -203,9 +223,10 @@ jobs:
       # stays correct if another tag is cut while the run is queued.
       - name: Measure the new tag
         env:
-          # GITHUB_TOKEN, carrying actions:write. A workflow_dispatch is the
-          # documented exception to GITHUB_TOKEN not starting further runs.
-          GH_TOKEN: ${{ github.token }}
+          # The App, not GITHUB_TOKEN. Either one starts the run; only this one
+          # produces a run whose completion emits a workflow_run event, which is
+          # what results-table.yml listens to. See the permissions block.
+          GH_TOKEN: ${{ steps.dispatch-token.outputs.token }}
           VERSION: ${{ inputs.version }}
         run: |
           set -euo pipefail

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ section its date and version, so several branches can write ahead of one.
 
 ## Unreleased
 
+A release now dispatches its measurement as the results bot rather than with
+the workflow's own token. GitHub raises no `workflow_run` event when a run
+started by `GITHUB_TOKEN` finishes, so 3.2.0 measured green for three hours and
+its board only landed once the results table was dispatched by hand.
+
 ## 2026-08-18 (3.2.0)
 
 The board now measures the most recent release tag rather than `main`. Merging

--- a/scripts/measured-ref-wiring.test.mjs
+++ b/scripts/measured-ref-wiring.test.mjs
@@ -65,6 +65,34 @@ describe('the release measurement reaches the publisher', () => {
     const release = uncommented(read('release'))
     expect(release).toMatch(/gh workflow run conformance\.yml --ref main -f "ref=v\$VERSION"/)
   })
+
+  it('dispatches as the App rather than with GITHUB_TOKEN', () => {
+    // GITHUB_TOKEN starts the run - a workflow_dispatch is the documented
+    // exception to it not starting further runs - but GitHub attributes that
+    // run to github-actions[bot] and emits no workflow_run event when it
+    // completes. So results-table.yml never hears the measurement finish and
+    // the draft never flips, which is what happened to v3.2.0: three hours
+    // green, nothing published, nothing red to say why. Only the identity
+    // holding the token fixes it, so only the identity is asserted here.
+    const steps = yaml.load(read('release')).jobs.release.steps
+    const measure = steps.find((step) => step.name === 'Measure the new tag')
+    expect(measure, 'release.yml no longer has a step named "Measure the new tag"').toBeTruthy()
+
+    const token = measure.env?.GH_TOKEN ?? ''
+    expect(token, 'the measurement is dispatched with GITHUB_TOKEN again').not.toContain(
+      'github.token',
+    )
+
+    const mintedBy = /steps\.([\w-]+)\.outputs\.token/.exec(token)?.[1]
+    expect(mintedBy, `the dispatch reads ${token}, which no step in this job mints`).toBeTruthy()
+
+    const mint = steps.find((step) => step.id === mintedBy)
+    expect(mint, `no step with id ${mintedBy} mints the token the dispatch reads`).toBeTruthy()
+    expect(mint.uses).toContain('actions/create-github-app-token')
+    // Narrowed at the mint, not inherited: create-github-app-token hands back
+    // everything the installation grants unless it is asked for less.
+    expect(mint.with?.['permission-actions']).toBe('write')
+  })
 })
 
 describe('a lane never measures a ref the resolver did not give it', () => {

--- a/scripts/release.test.mjs
+++ b/scripts/release.test.mjs
@@ -394,6 +394,18 @@ describe('release.yml', () => {
     )
   })
 
+  it('mints both tokens before anything is committed, tagged or drafted', () => {
+    // A mint of a permission the installation does not hold fails outright.
+    // Minted beside the dispatch, that failure would land after the bump, the
+    // tag and the draft, leaving a cut only a person can finish.
+    const names = workflow.jobs.release.steps.map((s) => s.name ?? s.uses)
+    const lastMint = names.findLastIndex((n) => (n ?? '').startsWith('actions/create-github-app-token') || /Mint/.test(n ?? ''))
+    const firstSideEffect = names.findIndex((n) => ['Commit the bump', 'Tag and push', 'Create the draft release'].includes(n))
+    expect(lastMint, 'release.yml no longer mints App tokens').toBeGreaterThan(-1)
+    expect(firstSideEffect, 'release.yml no longer commits, tags or drafts').toBeGreaterThan(-1)
+    expect(lastMint).toBeLessThan(firstSideEffect)
+  })
+
   it('takes what the App cannot grant from GITHUB_TOKEN instead', () => {
     // The head commit's check runs. The App has no Checks grant, and asking
     // for one fails the mint outright.

--- a/scripts/release.test.mjs
+++ b/scripts/release.test.mjs
@@ -375,26 +375,35 @@ describe('release.yml', () => {
     expect(inputs.version.required).toBe(true)
   })
 
-  it('asks the App only for the permission its installation grants', () => {
-    // create-github-app-token can narrow what an installation was granted, not
-    // add to it, so requesting a permission the App does not hold fails the
-    // mint with a 422 before any other step runs. The results bot has
-    // contents:write and nothing else - results-table.yml has relied on exactly
-    // that for as long as it has existed. A cut asking for actions:write and
-    // checks:read died at step two of twelve.
-    const mint = workflow.jobs.release.steps.find((s) =>
+  it('mints each App token with only the permission the step it feeds needs', () => {
+    // Two tokens, because they are handed to different things. The first is
+    // read by actions/checkout and sits beside `npm ci` on a freshly bumped
+    // tree, so it stays at contents:write however much the installation
+    // grants. The second is read by the dispatch and nothing else.
+    //
+    // create-github-app-token narrows what an installation was granted, it
+    // never adds to it, so asking for a permission the App does not hold fails
+    // the mint with a 422 before any other step runs - which is why a cut that
+    // also asked for checks:read died at step two of twelve.
+    const mints = workflow.jobs.release.steps.filter((s) =>
       (s.uses ?? '').startsWith('actions/create-github-app-token'),
     )
-    expect(mint, 'release.yml no longer mints an App token').toBeTruthy()
-    expect(Object.keys(mint.with).filter((k) => k.startsWith('permission-'))).toEqual([
-      'permission-contents',
-    ])
+    expect(mints, 'release.yml no longer mints two App tokens').toHaveLength(2)
+    expect(mints.map((m) => Object.keys(m.with).filter((k) => k.startsWith('permission-')))).toEqual(
+      [['permission-contents'], ['permission-actions']],
+    )
   })
 
   it('takes what the App cannot grant from GITHUB_TOKEN instead', () => {
-    // Reading the head commit's check runs and dispatching the measurement are
-    // both within GITHUB_TOKEN's reach; neither is within the App's.
-    expect(workflow.permissions).toMatchObject({ checks: 'read', actions: 'write' })
+    // The head commit's check runs. The App has no Checks grant, and asking
+    // for one fails the mint outright.
+    //
+    // actions is read, not write: GITHUB_TOKEN reads this run's own check
+    // suite here but no longer starts the measurement. A run dispatched with
+    // GITHUB_TOKEN is attributed to github-actions[bot], and a run attributed
+    // that way emits no workflow_run event when it completes, so the board
+    // never lands and the draft never flips.
+    expect(workflow.permissions).toMatchObject({ checks: 'read', actions: 'read' })
   })
 
   it('confirms the measurement run actually started', () => {


### PR DESCRIPTION
## What this changes

`release.yml` dispatches the conformance measurement with an App token instead
of `GITHUB_TOKEN`. A run dispatched with `GITHUB_TOKEN` is attributed to
`github-actions[bot]`, and GitHub raises no `workflow_run` event when a run
attributed that way completes, so `results-table.yml` never fired for v3.2.0:
three hours green, no board, and a draft release left open with nothing red to
say why. The board had to be dispatched by hand.

The dispatch mints its own token scoped to `permission-actions: write`, leaving
the token `checkout` receives and `npm ci` runs beside at `contents: write`.
`GITHUB_TOKEN` drops to `actions: read`, which is all it still needs to read
this run's own check suite. Both mints now sit at the top of the job, so a
permission the installation does not hold fails the cut before the bump, the
tag and the draft exist rather than after.

Needs Actions: read and write on the results bot installation, which is granted.

## Checklist

- ~~New or modified tests run against real AWS DynamoDB and pass~~ - CI wiring
  only, no suite tests touched
- ~~New or modified tests run against at least one emulator target and behave
  as expected~~ - as above
- [x] Linked issue or a short note explaining the motivation
- [x] I agree my contribution is licensed under the project's terms
  (Apache License, Version 2.0)

## Tier and scope

Touches the release path into the results pipeline, not the pipeline itself.
No regenerated artefacts. Three wiring tests cover it: the dispatch reads an
App token rather than `github.token`, the step minting it asks for
`permission-actions: write`, and both mints precede the commit, tag and draft
steps. The two permission assertions from #159 are updated to match.
