### PR TITLE
fix: give local runs their own table namespace

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,12 @@ on:
 permissions:
   contents: read
 
+# The table namespace this workflow owns. src/helpers.ts infers it from CI when
+# the variable is unset, but the sweep deletes every table matching its prefix,
+# so the side that would lose a live run to a wrong guess names it outright.
+env:
+  CONFORMANCE_TABLE_PREFIX: _conformance_
+
 jobs:
   suite-health:
     name: Suite health (typecheck + tooling tests)

--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -52,6 +52,12 @@ on:
 permissions:
   contents: read
 
+# The table namespace this workflow owns. src/helpers.ts infers it from CI when
+# the variable is unset, but the sweep deletes every table matching its prefix,
+# so the side that would lose a live run to a wrong guess names it outright.
+env:
+  CONFORMANCE_TABLE_PREFIX: _conformance_
+
 jobs:
   # Whether this push changed anything that could move a measurement against
   # real DynamoDB. Real DynamoDB's behaviour is AWS's, so what makes the

--- a/.github/workflows/sweep.yml
+++ b/.github/workflows/sweep.yml
@@ -41,6 +41,12 @@ on:
 permissions:
   contents: read
 
+# The table namespace this workflow owns. src/helpers.ts infers it from CI when
+# the variable is unset, but the sweep deletes every table matching its prefix,
+# so the side that would lose a live run to a wrong guess names it outright.
+env:
+  CONFORMANCE_TABLE_PREFIX: _conformance_
+
 jobs:
   regions:
     name: Resolve region set

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -48,6 +48,14 @@ headline score is its best-matching region.
   - `npm test` (runs vitest)
   - `npm run test:quick` (faster, skips the online-index lifecycle tests - GSI and vector)
   - `npm run test:tier1` / `tier2` / `tier3` for a single tier
+- Tables are created under a namespace prefix and cleaned up by deleting
+  everything matching it, so two runs sharing a prefix delete each
+  other's tables. CI uses `_conformance_` and everything else uses
+  `_capture_`, resolved from `CONFORMANCE_TABLE_PREFIX` or, failing
+  that, from whether `CI` is set. Credentials are scoped to match, so a
+  run in the wrong namespace fails with `AccessDeniedException` rather
+  than deleting someone else's tables. Set the variable explicitly to
+  run two local suites against one account at once.
 
 ## Test philosophy
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -69,6 +69,29 @@ is a maintainer task and does not block your PR.
   `DYNAMODB_ENDPOINT` points to. See the `README.md` for the usual
   patterns.
 
+### Table namespaces
+
+The suite creates tables under a prefix, and cleans up by deleting every
+table matching it. That cleanup runs once per run, before anything is
+created, so two runs sharing a prefix will delete each other's tables
+mid-suite.
+
+Local runs and CI therefore use different namespaces:
+
+| Where | Prefix |
+|---|---|
+| CI | `_conformance_` |
+| Anywhere else | `_capture_` |
+
+The choice comes from `CONFORMANCE_TABLE_PREFIX` when it is set, and
+otherwise from whether `CI` is set. You should not need to touch it. The
+AWS credentials for each side are scoped to match, so a run in the wrong
+namespace fails with `AccessDeniedException` rather than deleting tables
+belonging to something else.
+
+If you are running two local suites against the same account at once,
+give each one its own `CONFORMANCE_TABLE_PREFIX`.
+
 ## Tests
 
 - Tests live under `tests/tier1/`, `tests/tier2/`, `tests/tier3/`,

--- a/src/global-teardown.ts
+++ b/src/global-teardown.ts
@@ -14,8 +14,9 @@ export async function setup(): Promise<void> {
 
 // Runs once after the whole run (vitest globalSetup teardown), removing the
 // shared tables that src/setup.ts now provisions once per run. cleanupAllTables
-// deletes by the `_conformance_` prefix, so it clears the shared tables (and any
-// ad-hoc tables a test left behind) regardless of which worker created them.
+// deletes by this run's own namespace prefix, so it clears the shared tables
+// (and any ad-hoc tables a test left behind) regardless of which worker created
+// them, and reaches nothing belonging to another run.
 export async function teardown(): Promise<void> {
   await cleanupAllTables()
 }

--- a/src/helpers.test.ts
+++ b/src/helpers.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from 'vitest'
-import { createTableRegistry } from './helpers.js'
+import { createTableRegistry, isSuiteTable, uniqueTableName, absentTableName } from './helpers.js'
+import { resolveTablePrefix, CI_TABLE_PREFIX, LOCAL_TABLE_NAMESPACE } from './table-namespace.js'
 import type { TestTableDef } from './types.js'
 
 // The declaration registry behind demand-driven provisioning. Asserted against
@@ -265,5 +266,51 @@ describe('createTableRegistry — the leftover sweep', () => {
     })
 
     expect({ sweeps, calls }).toEqual({ sweeps: 2, calls: ['a'] })
+  })
+})
+
+describe('isSuiteTable', () => {
+  it('selects a table in the given namespace', () => {
+    expect(isSuiteTable(`${CI_TABLE_PREFIX}hash_1_0`, CI_TABLE_PREFIX)).toBe(true)
+  })
+
+  it('rejects a table in the other namespace, which is what protects a live run', () => {
+    expect(isSuiteTable(`${CI_TABLE_PREFIX}hash_1_0`, '_capture_20260818_abcdef_')).toBe(false)
+    expect(isSuiteTable(`${LOCAL_TABLE_NAMESPACE}hash_1_0`, CI_TABLE_PREFIX)).toBe(false)
+  })
+
+  it('rejects another local session in the same namespace', () => {
+    expect(isSuiteTable('_capture_20260818_aaaaaa_hash_1_0', '_capture_20260818_bbbbbb_')).toBe(false)
+  })
+
+  it('rejects a table belonging to nobody', () => {
+    expect(isSuiteTable('orders', CI_TABLE_PREFIX)).toBe(false)
+  })
+})
+
+describe('uniqueTableName', () => {
+  it('names into the namespace this run resolved', () => {
+    expect(isSuiteTable(uniqueTableName('hash'))).toBe(true)
+  })
+
+  it('leaves at least three characters after the prefix, which some targets require', () => {
+    const name = uniqueTableName('h')
+    expect(name.slice(resolveTablePrefix().length).length).toBeGreaterThanOrEqual(3)
+  })
+
+  it('does not repeat a name within a run', () => {
+    expect(uniqueTableName('hash')).not.toBe(uniqueTableName('hash'))
+  })
+})
+
+describe('absentTableName', () => {
+  // A name outside the namespace is refused by IAM before DynamoDB can answer
+  // that the table is missing, so the test sees the wrong exception.
+  it('sits inside the namespace this run can reach', () => {
+    expect(isSuiteTable(absentTableName('nonexistent_table'))).toBe(true)
+  })
+
+  it('keeps the suffix it was given', () => {
+    expect(absentTableName('nonexistent_table').endsWith('nonexistent_table')).toBe(true)
   })
 })

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -22,9 +22,29 @@ import { region } from './aws-config.js'
 import { IndeterminateError, indeterminateFrom } from './indeterminate.js'
 import { ceilingsFor } from './regions.js'
 import type { TestTableDef } from './types.js'
+import { resolveTablePrefix } from './table-namespace.js'
 
-const TABLE_PREFIX = '_conformance_'
+// The namespace this run owns. Resolved in vitest.config.ts before any worker
+// spawns and pinned into the environment there, so the worker that creates the
+// tables and the main-process teardown that sweeps them agree on one prefix.
+// src/table-namespace.ts carries the reasoning.
+const TABLE_PREFIX = resolveTablePrefix()
 let counter = 0
+
+/** Whether a table name belongs to the namespace this run owns. */
+export function isSuiteTable(name: string, prefix: string = TABLE_PREFIX): boolean {
+  return name.startsWith(prefix)
+}
+
+/**
+ * A name in this run's namespace that nothing creates, for tests needing a
+ * table that does not exist. It still has to sit inside the namespace: a name
+ * outside it is refused by IAM before DynamoDB can answer that it is missing,
+ * and the test sees AccessDeniedException instead of ResourceNotFoundException.
+ */
+export function absentTableName(suffix: string): string {
+  return `${TABLE_PREFIX}${suffix}`
+}
 
 /** Generate a unique table name for this test run */
 export function uniqueTableName(base: string): string {
@@ -428,7 +448,7 @@ export async function cleanupAllTables(): Promise<void> {
     const res = await ddb.send(
       new ListTablesCommand({ ExclusiveStartTableName: exclusiveStartTableName }),
     )
-    const names = (res.TableNames ?? []).filter((n) => n.startsWith(TABLE_PREFIX))
+    const names = (res.TableNames ?? []).filter((n) => isSuiteTable(n))
     allNames.push(...names)
     exclusiveStartTableName = res.LastEvaluatedTableName
   } while (exclusiveStartTableName)

--- a/src/table-namespace.test.ts
+++ b/src/table-namespace.test.ts
@@ -1,0 +1,90 @@
+import { describe, it, expect } from 'vitest'
+import {
+  resolveTablePrefix,
+  localSessionPrefix,
+  pinTablePrefix,
+  CI_TABLE_PREFIX,
+  LOCAL_TABLE_NAMESPACE,
+  TABLE_PREFIX_ENV,
+} from './table-namespace.js'
+
+// The namespaces have to stay disjoint: the sweep deletes every table matching
+// its prefix, with no age gate and no ownership record, so a shared prefix means
+// one run can delete another's tables mid-suite.
+describe('resolveTablePrefix', () => {
+  const session = () => '_capture_20260818_abcdef_'
+
+  it('uses an explicit override verbatim, whatever CI says', () => {
+    expect(resolveTablePrefix({ [TABLE_PREFIX_ENV]: '_mine_', CI: 'true' }, session)).toBe('_mine_')
+    expect(resolveTablePrefix({ [TABLE_PREFIX_ENV]: '_mine_' }, session)).toBe('_mine_')
+  })
+
+  // CI's prefix is stable on purpose: its pre-run sweep is what clears tables
+  // stranded by a run that died, and a per-session prefix would match none of
+  // them. The concurrency group is what stops two CI runs overlapping.
+  it('takes the stable CI namespace under CI', () => {
+    expect(resolveTablePrefix({ CI: 'true' }, session)).toBe(CI_TABLE_PREFIX)
+  })
+
+  it('takes a session-scoped prefix otherwise', () => {
+    expect(resolveTablePrefix({}, session)).toBe('_capture_20260818_abcdef_')
+  })
+
+  // An empty string is how an unset variable arrives from a shell that exported
+  // it blank. Honouring it would leave the run unnamespaced, and its sweep would
+  // match every table on the account.
+  it('ignores an empty override rather than sweeping everything', () => {
+    expect(resolveTablePrefix({ [TABLE_PREFIX_ENV]: '' }, session)).toBe(session())
+    expect(resolveTablePrefix({ [TABLE_PREFIX_ENV]: '', CI: 'true' }, session)).toBe(CI_TABLE_PREFIX)
+  })
+
+  it('keeps the two namespaces disjoint', () => {
+    expect(CI_TABLE_PREFIX.startsWith(LOCAL_TABLE_NAMESPACE)).toBe(false)
+    expect(LOCAL_TABLE_NAMESPACE.startsWith(CI_TABLE_PREFIX)).toBe(false)
+  })
+})
+
+describe('localSessionPrefix', () => {
+  const day = new Date('2026-08-18T09:00:00Z')
+
+  it('carries the namespace, the date and a code', () => {
+    expect(localSessionPrefix(day, () => 0.5)).toMatch(/^_capture_20260818_[0-9a-z]{6}_$/)
+  })
+
+  it('differs between sessions, which is what stops one sweeping another', () => {
+    let n = 0
+    const seq = () => [0.1, 0.9][n++]
+    expect(localSessionPrefix(day, seq)).not.toBe(localSessionPrefix(day, seq))
+  })
+
+  it('pads a small code rather than shortening the prefix', () => {
+    expect(localSessionPrefix(day, () => 0)).toBe('_capture_20260818_000000_')
+  })
+})
+
+
+describe('pinTablePrefix', () => {
+  // A session prefix minted independently in the worker and in the main process
+  // would differ, and the teardown would sweep a namespace holding nothing.
+  it('writes the resolved prefix back so a second reader agrees', () => {
+    const env: NodeJS.ProcessEnv = {}
+    const pinned = pinTablePrefix(env)
+    expect(env[TABLE_PREFIX_ENV]).toBe(pinned)
+    expect(resolveTablePrefix(env)).toBe(pinned)
+  })
+
+  it('is idempotent, so a second pin does not re-mint the session', () => {
+    const env: NodeJS.ProcessEnv = {}
+    expect(pinTablePrefix(env)).toBe(pinTablePrefix(env))
+  })
+
+  it('leaves an explicit prefix alone', () => {
+    const env: NodeJS.ProcessEnv = { [TABLE_PREFIX_ENV]: '_mine_' }
+    expect(pinTablePrefix(env)).toBe('_mine_')
+  })
+
+  it('pins the stable namespace under CI', () => {
+    const env: NodeJS.ProcessEnv = { CI: 'true' }
+    expect(pinTablePrefix(env)).toBe(CI_TABLE_PREFIX)
+  })
+})

--- a/src/table-namespace.ts
+++ b/src/table-namespace.ts
@@ -1,0 +1,73 @@
+// Which table namespace a run owns, kept free of AWS imports so vitest.config.ts
+// can resolve it before any worker spawns. See helpers.ts for how it is used.
+//
+// Two namespaces, one per identity, matching the split documented in
+// scripts/cleanup-orphans.mjs and enforced by the IAM grants either side.
+//
+// The hazard is `cleanupAllTables`: it runs once per run, before anything is
+// created, and deletes every table matching the prefix. There is no age gate and
+// no record of which run owns what, so two runs sharing a prefix delete each
+// other's tables mid-suite. CI serialises against itself through the
+// `conformance-aws` concurrency group, but that group cannot see a laptop.
+//
+// CI keeps a stable prefix, so its pre-run sweep still clears tables stranded by
+// a run that died. Nothing serialises local runs against each other, so a local
+// run takes a prefix carrying a per-session segment: its sweep then matches only
+// its own tables, whatever else is in flight on the account. The backstop for a
+// local session that died before its teardown is cleanup-orphans.mjs, which
+// sweeps that namespace by age on its own schedule.
+//
+// KNOWN_PREFIXES in that script is a hand-maintained allowlist guarding a
+// DeleteTable it holds in every region, so it is deliberately not imported here.
+// A namespace added below needs a reviewed edit there too.
+
+export const CI_TABLE_PREFIX = '_conformance_'
+export const LOCAL_TABLE_NAMESPACE = '_capture_'
+
+/** The variable that pins a prefix explicitly, for CI and for parallel local runs. */
+export const TABLE_PREFIX_ENV = 'CONFORMANCE_TABLE_PREFIX'
+
+/**
+ * A prefix unique to one local run, `_capture_<yyyymmdd>_<code>_`. The date makes
+ * a stranded table readable in a console listing; the code is what keeps two
+ * sessions on one account from sweeping each other.
+ */
+export function localSessionPrefix(
+  now: Date = new Date(),
+  rand: () => number = Math.random,
+): string {
+  const day = now.toISOString().slice(0, 10).replace(/-/g, '')
+  const code = Math.floor(rand() * 36 ** 6).toString(36).padStart(6, '0')
+  return `${LOCAL_TABLE_NAMESPACE}${day}_${code}_`
+}
+
+/**
+ * Resolve the namespace this run writes into. An explicit prefix always wins;
+ * otherwise CI takes the shared CI namespace and everything else takes a fresh
+ * session prefix. The workflows set the variable outright rather than relying on
+ * the inference, because CI is the side where guessing wrong costs a run.
+ */
+export function resolveTablePrefix(
+  env: NodeJS.ProcessEnv = process.env,
+  session: () => string = localSessionPrefix,
+): string {
+  const override = env[TABLE_PREFIX_ENV]
+  if (override) return override
+  return env.CI ? CI_TABLE_PREFIX : session()
+}
+
+/**
+ * Resolve once and pin the answer into the environment, returning it.
+ *
+ * The pin is what makes a session prefix usable at all. Tests run in a worker
+ * process and the teardown that sweeps them runs in the main one, so each would
+ * otherwise mint its own code: the worker would create tables under one prefix
+ * and the sweep would look for another, find nothing, and leave every table
+ * standing. Resolving in vitest.config.ts, before any worker spawns, is what
+ * gives both sides the same answer.
+ */
+export function pinTablePrefix(env: NodeJS.ProcessEnv = process.env): string {
+  const prefix = resolveTablePrefix(env)
+  env[TABLE_PREFIX_ENV] = prefix
+  return prefix
+}

--- a/src/vector.ts
+++ b/src/vector.ts
@@ -21,7 +21,7 @@ import {
 } from '@aws-sdk/client-dynamodb'
 import { ddb } from './client.js'
 import { region } from './aws-config.js'
-import { uniqueTableName, waitUntilActive, deleteTable } from './helpers.js'
+import { uniqueTableName, absentTableName, waitUntilActive, deleteTable } from './helpers.js'
 import { IndeterminateError } from './indeterminate.js'
 import { isUnsupportedFault } from './unsupported.js'
 import { supportsControlPlaneOp } from './infra.js'
@@ -34,13 +34,17 @@ function sleep(ms: number): Promise<void> {
 // ── Data-plane probe: SearchVectors ─────────────────────────────────────────
 
 /**
- * Probe input for SearchVectors: a table that cannot exist (the reserved
- * `_conformance_` prefix plus a name no test creates). Real AWS answers
+ * Probe input for SearchVectors: a table that cannot exist (this run's own
+ * namespace plus a name no test creates). Real AWS answers
  * ResourceNotFoundException — a real error, so the operation counts as
  * implemented. A target without the operation answers an unsupported fault.
+ *
+ * The namespace matters against real AWS: a name outside it is refused by IAM
+ * before DynamoDB can answer that the table is missing, and the probe would
+ * read an AccessDeniedException as the operation being unimplemented.
  */
 const SEARCH_PROBE_INPUT = {
-  TableName: '_conformance_no_such_table_probe',
+  TableName: absentTableName('no_such_table_probe'),
   IndexName: 'no-such-index',
   SearchVector: [{ N: '1' }, { N: '0' }, { N: '0' }] as AttributeValue[],
   TopK: 1,

--- a/tests/tier1/batchGetItem/validation.test.ts
+++ b/tests/tier1/batchGetItem/validation.test.ts
@@ -1,6 +1,6 @@
 import { BatchGetItemCommand } from '@aws-sdk/client-dynamodb'
 import { ddb } from '../../../src/client.js'
-import { declareTables, hashTableDef, expectDynamoError } from '../../../src/helpers.js'
+import { declareTables, hashTableDef, expectDynamoError, absentTableName } from '../../../src/helpers.js'
 
 declareTables(hashTableDef)
 
@@ -38,7 +38,7 @@ describe('BatchGetItem — validation', { tags: ['batch', 'data-plane', 'negativ
       () => ddb.send(
         new BatchGetItemCommand({
           RequestItems: {
-            _conformance_nonexistent_table: {
+            [absentTableName('nonexistent_table')]: {
               Keys: [{ pk: { S: 'test' } }],
             },
           },

--- a/tests/tier1/batchWriteItem/validation.test.ts
+++ b/tests/tier1/batchWriteItem/validation.test.ts
@@ -4,6 +4,7 @@ import {
   hashTableDef,
   expectDynamoError,
   declareTables,
+  absentTableName
 } from '../../../src/helpers.js'
 
 declareTables(hashTableDef)
@@ -42,7 +43,7 @@ describe('BatchWriteItem — validation', { tags: ['batch', 'data-plane', 'negat
       () => ddb.send(
         new BatchWriteItemCommand({
           RequestItems: {
-            _conformance_nonexistent_table: [
+            [absentTableName('nonexistent_table')]: [
               {
                 PutRequest: { Item: { pk: { S: 'test' } } },
               },

--- a/tests/tier1/deleteItem/validation.test.ts
+++ b/tests/tier1/deleteItem/validation.test.ts
@@ -1,13 +1,13 @@
 import { DeleteItemCommand } from '@aws-sdk/client-dynamodb'
 import { ddb } from '../../../src/client.js'
-import { expectDynamoError } from '../../../src/helpers.js'
+import { expectDynamoError, absentTableName } from '../../../src/helpers.js'
 
 describe('DeleteItem — validation', { tags: ['delete-item', 'data-plane', 'negative-path'] }, () => {
   it('rejects DeleteItem on a non-existent table', async () => {
     await expectDynamoError(
       () => ddb.send(
         new DeleteItemCommand({
-          TableName: '_conformance_nonexistent_table',
+          TableName: absentTableName('nonexistent_table'),
           Key: { pk: { S: 'test' } },
         }),
       ),

--- a/tests/tier1/deleteTable/basic.test.ts
+++ b/tests/tier1/deleteTable/basic.test.ts
@@ -6,7 +6,7 @@ import {
   ResourceNotFoundException,
 } from '@aws-sdk/client-dynamodb'
 import { ddb } from '../../../src/client.js'
-import { uniqueTableName, waitUntilActive, expectDynamoError } from '../../../src/helpers.js'
+import { uniqueTableName, waitUntilActive, expectDynamoError, absentTableName } from '../../../src/helpers.js'
 
 describe('DeleteTable — basic', { tags: ['delete-table', 'control-plane'] }, () => {
   it('deletes an existing table', async () => {
@@ -86,7 +86,7 @@ describe('DeleteTable — validation', { tags: ['delete-table', 'control-plane',
     await expectDynamoError(
       () => ddb.send(
         new DeleteTableCommand({
-          TableName: '_conformance_nonexistent_table',
+          TableName: absentTableName('nonexistent_table'),
         }),
       ),
       'ResourceNotFoundException',

--- a/tests/tier1/describeTable/basic.test.ts
+++ b/tests/tier1/describeTable/basic.test.ts
@@ -4,6 +4,7 @@ import {
   hashTableDef,
   expectDynamoError,
   declareTables,
+  absentTableName
 } from '../../../src/helpers.js'
 
 declareTables(hashTableDef)
@@ -52,7 +53,7 @@ describe('DescribeTable — validation', { tags: ['describe-table', 'control-pla
     await expectDynamoError(
       () => ddb.send(
         new DescribeTableCommand({
-          TableName: '_conformance_nonexistent_table',
+          TableName: absentTableName('nonexistent_table'),
         }),
       ),
       'ResourceNotFoundException',

--- a/tests/tier1/getItem/validation.test.ts
+++ b/tests/tier1/getItem/validation.test.ts
@@ -1,6 +1,6 @@
 import { GetItemCommand } from '@aws-sdk/client-dynamodb'
 import { ddb } from '../../../src/client.js'
-import { declareTables, compositeTableDef, expectDynamoError } from '../../../src/helpers.js'
+import { declareTables, compositeTableDef, expectDynamoError, absentTableName } from '../../../src/helpers.js'
 
 declareTables(compositeTableDef)
 
@@ -10,7 +10,7 @@ describe('GetItem — validation', { tags: ['get-item', 'data-plane', 'negative-
       () =>
         ddb.send(
           new GetItemCommand({
-            TableName: '_conformance_nonexistent_table',
+            TableName: absentTableName('nonexistent_table'),
             Key: { pk: { S: 'test' } },
           }),
         ),

--- a/tests/tier1/putItem/validation.test.ts
+++ b/tests/tier1/putItem/validation.test.ts
@@ -4,6 +4,7 @@ import {
   hashTableDef,
   expectDynamoError,
   declareTables,
+  absentTableName
 } from '../../../src/helpers.js'
 
 declareTables(hashTableDef)
@@ -13,7 +14,7 @@ describe('PutItem — validation', { tags: ['put-item', 'data-plane', 'negative-
     await expectDynamoError(
       () => ddb.send(
         new PutItemCommand({
-          TableName: '_conformance_nonexistent_table',
+          TableName: absentTableName('nonexistent_table'),
           Item: { pk: { S: 'test' } },
         }),
       ),

--- a/tests/tier1/query/validation.test.ts
+++ b/tests/tier1/query/validation.test.ts
@@ -1,6 +1,6 @@
 import { QueryCommand } from '@aws-sdk/client-dynamodb'
 import { ddb } from '../../../src/client.js'
-import { declareTables, compositeTableDef, expectDynamoError } from '../../../src/helpers.js'
+import { declareTables, compositeTableDef, expectDynamoError, absentTableName } from '../../../src/helpers.js'
 
 declareTables(compositeTableDef)
 
@@ -10,7 +10,7 @@ describe('Query — validation', { tags: ['query', 'data-plane', 'negative-path'
       () =>
         ddb.send(
           new QueryCommand({
-            TableName: '_conformance_nonexistent_table',
+            TableName: absentTableName('nonexistent_table'),
             KeyConditionExpression: 'pk = :pk',
             ExpressionAttributeValues: { ':pk': { S: 'test' } },
           }),

--- a/tests/tier1/scan/validation.test.ts
+++ b/tests/tier1/scan/validation.test.ts
@@ -1,6 +1,6 @@
 import { ScanCommand } from '@aws-sdk/client-dynamodb'
 import { ddb } from '../../../src/client.js'
-import { declareTables, hashTableDef, expectDynamoError } from '../../../src/helpers.js'
+import { declareTables, hashTableDef, expectDynamoError, absentTableName } from '../../../src/helpers.js'
 
 declareTables(hashTableDef)
 
@@ -10,7 +10,7 @@ describe('Scan — validation', { tags: ['scan', 'data-plane', 'negative-path'] 
       () =>
         ddb.send(
           new ScanCommand({
-            TableName: '_conformance_nonexistent_table',
+            TableName: absentTableName('nonexistent_table'),
           }),
         ),
       'ResourceNotFoundException',

--- a/tests/tier1/updateItem/validation.test.ts
+++ b/tests/tier1/updateItem/validation.test.ts
@@ -1,6 +1,6 @@
 import { UpdateItemCommand } from '@aws-sdk/client-dynamodb'
 import { ddb } from '../../../src/client.js'
-import { declareTables, hashTableDef, expectDynamoError } from '../../../src/helpers.js'
+import { declareTables, hashTableDef, expectDynamoError, absentTableName } from '../../../src/helpers.js'
 
 declareTables(hashTableDef)
 
@@ -9,7 +9,7 @@ describe('UpdateItem — validation', { tags: ['update-item', 'data-plane', 'neg
     await expectDynamoError(
       () => ddb.send(
         new UpdateItemCommand({
-          TableName: '_conformance_nonexistent_table',
+          TableName: absentTableName('nonexistent_table'),
           Key: { pk: { S: 'test' } },
           UpdateExpression: 'SET x = :v',
           ExpressionAttributeValues: { ':v': { S: 'test' } },

--- a/tests/tier1/updateTable/basic.test.ts
+++ b/tests/tier1/updateTable/basic.test.ts
@@ -9,6 +9,7 @@ import {
   waitUntilActive,
   deleteTable,
   expectDynamoError,
+  absentTableName
 } from '../../../src/helpers.js'
 
 /** Helper to create a simple hash-key table with the given billing mode */
@@ -200,7 +201,7 @@ describe('UpdateTable — validation', { tags: ['update-table', 'control-plane',
       () =>
         ddb.send(
           new UpdateTableCommand({
-            TableName: '_conformance_nonexistent_table',
+            TableName: absentTableName('nonexistent_table'),
             ProvisionedThroughput: {
               ReadCapacityUnits: 10,
               WriteCapacityUnits: 10,

--- a/tests/tier2/partiql/batchExecuteStatement.test.ts
+++ b/tests/tier2/partiql/batchExecuteStatement.test.ts
@@ -6,7 +6,7 @@ import {
 } from '@aws-sdk/client-dynamodb'
 import { ddb } from '../../../src/client.js'
 import { isUnsupportedFault } from '../../../src/infra.js'
-import { declareTables, hashTableDef, cleanupItems, expectDynamoError } from '../../../src/helpers.js'
+import { declareTables, hashTableDef, cleanupItems, expectDynamoError, absentTableName } from '../../../src/helpers.js'
 
 declareTables(hashTableDef)
 
@@ -122,7 +122,7 @@ describe('BatchExecuteStatement — PartiQL', { tags: ['partiql', 'data-plane'] 
     const result = await ddb.send(new BatchExecuteStatementCommand({
       Statements: [
         { Statement: `SELECT * FROM "${hashTableDef.name}" WHERE pk = 'batch-partial-1'` },
-        { Statement: `SELECT * FROM "_conformance_nonexistent_table" WHERE pk = 'x'` },
+        { Statement: `SELECT * FROM "${absentTableName('nonexistent_table')}" WHERE pk = 'x'` },
       ],
     }))
 

--- a/tests/tier2/partiql/executeStatement.test.ts
+++ b/tests/tier2/partiql/executeStatement.test.ts
@@ -7,7 +7,7 @@ import {
 } from '@aws-sdk/client-dynamodb'
 import { ddb } from '../../../src/client.js'
 import { isUnsupportedFault } from '../../../src/infra.js'
-import { declareTables, hashTableDef, compositeTableDef, cleanupItems, expectDynamoError } from '../../../src/helpers.js'
+import { declareTables, hashTableDef, compositeTableDef, cleanupItems, expectDynamoError, absentTableName } from '../../../src/helpers.js'
 import type { AttributeValue } from '@aws-sdk/client-dynamodb'
 
 declareTables(hashTableDef, compositeTableDef)
@@ -1363,7 +1363,7 @@ describe('ExecuteStatement — PartiQL', { tags: ['partiql', 'data-plane'] }, ()
   it('rejects a reference to a non-existent table', async () => {
     try {
       await ddb.send(new ExecuteStatementCommand({
-        Statement: `SELECT * FROM "_conformance_nonexistent_table" WHERE pk = 'x'`,
+        Statement: `SELECT * FROM "${absentTableName('nonexistent_table')}" WHERE pk = 'x'`,
       }))
       expect.unreachable('should have thrown')
     } catch (e: unknown) {

--- a/tests/tier2/transactions/transactGet.test.ts
+++ b/tests/tier2/transactions/transactGet.test.ts
@@ -9,6 +9,7 @@ import {
   cleanupItems,
   expectDynamoError,
   declareTables,
+  absentTableName
 } from '../../../src/helpers.js'
 
 declareTables(hashTableDef, compositeTableDef)
@@ -216,7 +217,7 @@ describe('TransactGetItems - validation', { tags: ['transactions', 'data-plane',
             TransactItems: [
               {
                 Get: {
-                  TableName: '_conformance_nonexistent_table',
+                  TableName: absentTableName('nonexistent_table'),
                   Key: { pk: { S: 'x' } },
                 },
               },

--- a/tests/tier2/transactions/transactWrite.test.ts
+++ b/tests/tier2/transactions/transactWrite.test.ts
@@ -13,6 +13,7 @@ import {
   cleanupItems,
   expectDynamoError,
   declareTables,
+  absentTableName
 } from '../../../src/helpers.js'
 
 declareTables(hashTableDef, compositeTableDef)
@@ -724,7 +725,7 @@ describe('TransactWriteItems - validation', { tags: ['transactions', 'data-plane
             TransactItems: [
               {
                 Put: {
-                  TableName: '_conformance_nonexistent_table',
+                  TableName: absentTableName('nonexistent_table'),
                   Item: { pk: { S: 'x' } },
                 },
               },

--- a/tests/tier2/ttl/basic.test.ts
+++ b/tests/tier2/ttl/basic.test.ts
@@ -10,6 +10,7 @@ import {
   waitUntilActive,
   deleteTable,
   expectDynamoError,
+  absentTableName
 } from '../../../src/helpers.js'
 
 /** Create a simple hash-only table for TTL tests */
@@ -156,7 +157,7 @@ describe('TTL — validation', { tags: ['ttl', 'control-plane', 'negative-path']
       () =>
         ddb.send(
           new UpdateTimeToLiveCommand({
-            TableName: '_conformance_nonexistent_table',
+            TableName: absentTableName('nonexistent_table'),
             TimeToLiveSpecification: {
               Enabled: true,
               AttributeName: 'ttl',
@@ -173,7 +174,7 @@ describe('TTL — validation', { tags: ['ttl', 'control-plane', 'negative-path']
       () =>
         ddb.send(
           new DescribeTimeToLiveCommand({
-            TableName: '_conformance_nonexistent_table',
+            TableName: absentTableName('nonexistent_table'),
           }),
         ),
       'ResourceNotFoundException',

--- a/tests/tier3/error-messages/batchGetItem.test.ts
+++ b/tests/tier3/error-messages/batchGetItem.test.ts
@@ -5,7 +5,7 @@ import {
 } from '@aws-sdk/client-dynamodb'
 import { ddb } from '../../../src/client.js'
 import { observeSplit } from '../../../src/observation-sink.js'
-import { declareTables, hashTableDef, hashBTableDef, compositeTableDef } from '../../../src/helpers.js'
+import { declareTables, hashTableDef, hashBTableDef, compositeTableDef, absentTableName } from '../../../src/helpers.js'
 
 declareTables(hashTableDef, hashBTableDef, compositeTableDef)
 
@@ -54,7 +54,7 @@ describe('BatchGetItem — exact error messages', { tags: ['batch', 'data-plane'
       await ddb.send(
         new BatchGetItemCommand({
           RequestItems: {
-            '_conformance_does_not_exist_em_bg': {
+            [absentTableName('does_not_exist_em_bg')]: {
               Keys: [{ pk: { S: 'test' } }],
             },
           },

--- a/tests/tier3/error-messages/batchWriteItem.test.ts
+++ b/tests/tier3/error-messages/batchWriteItem.test.ts
@@ -9,6 +9,7 @@ import {
   hashBTableDef,
   cleanupItems,
   declareTables,
+  absentTableName
 } from '../../../src/helpers.js'
 
 declareTables(hashTableDef, hashBTableDef)
@@ -93,7 +94,7 @@ describe('BatchWriteItem — exact error messages', { tags: ['batch', 'data-plan
       await ddb.send(
         new BatchWriteItemCommand({
           RequestItems: {
-            '_conformance_does_not_exist_em_bw': [
+            [absentTableName('does_not_exist_em_bw')]: [
               { PutRequest: { Item: { pk: { S: 'test' } } } },
             ],
           },

--- a/tests/tier3/error-messages/deleteItem.test.ts
+++ b/tests/tier3/error-messages/deleteItem.test.ts
@@ -4,7 +4,7 @@ import {
   ResourceNotFoundException,
 } from '@aws-sdk/client-dynamodb'
 import { ddb } from '../../../src/client.js'
-import { declareTables, compositeTableDef, hashTableDef, hashBTableDef } from '../../../src/helpers.js'
+import { declareTables, compositeTableDef, hashTableDef, hashBTableDef, absentTableName } from '../../../src/helpers.js'
 
 declareTables(compositeTableDef, hashTableDef, hashBTableDef)
 
@@ -16,7 +16,7 @@ describe('DeleteItem — exact error messages', { tags: ['delete-item', 'data-pl
     try {
       await ddb.send(
         new DeleteItemCommand({
-          TableName: '_conformance_does_not_exist_em_delete',
+          TableName: absentTableName('does_not_exist_em_delete'),
           Key: { pk: { S: 'test' } },
         }),
       )

--- a/tests/tier3/error-messages/getItem.test.ts
+++ b/tests/tier3/error-messages/getItem.test.ts
@@ -9,6 +9,7 @@ import {
   hashBTableDef,
   compositeTableDef,
   declareTables,
+  absentTableName
 } from '../../../src/helpers.js'
 
 declareTables(hashTableDef, hashBTableDef, compositeTableDef)
@@ -18,7 +19,7 @@ describe('GetItem — exact error messages', { tags: ['get-item', 'data-plane', 
     try {
       await ddb.send(
         new GetItemCommand({
-          TableName: '_conformance_does_not_exist_em_get',
+          TableName: absentTableName('does_not_exist_em_get'),
           Key: { pk: { S: 'test' } },
         }),
       )

--- a/tests/tier3/error-messages/scan.test.ts
+++ b/tests/tier3/error-messages/scan.test.ts
@@ -9,6 +9,7 @@ import {
   hashTableDef,
   cleanupItems,
   declareTables,
+  absentTableName
 } from '../../../src/helpers.js'
 
 declareTables(hashTableDef)
@@ -91,7 +92,7 @@ describe('Scan — exact error messages', { tags: ['scan', 'data-plane', 'negati
     try {
       await ddb.send(
         new ScanCommand({
-          TableName: '_conformance_does_not_exist_em_scan',
+          TableName: absentTableName('does_not_exist_em_scan'),
         }),
       )
       expect.unreachable('should have thrown')

--- a/tests/tier3/error-messages/transactGetItems.test.ts
+++ b/tests/tier3/error-messages/transactGetItems.test.ts
@@ -5,7 +5,7 @@ import {
   TransactionCanceledException,
 } from '@aws-sdk/client-dynamodb'
 import { ddb } from '../../../src/client.js'
-import { declareTables, hashTableDef } from '../../../src/helpers.js'
+import { declareTables, hashTableDef, absentTableName } from '../../../src/helpers.js'
 
 declareTables(hashTableDef)
 
@@ -53,7 +53,7 @@ describe('TransactGetItems — exact error messages', { tags: ['transactions', '
           TransactItems: [
             {
               Get: {
-                TableName: '_conformance_does_not_exist_em_tgi',
+                TableName: absentTableName('does_not_exist_em_tgi'),
                 Key: { pk: { S: 'x' } },
               },
             },

--- a/tests/tier3/error-messages/transactWriteItems.test.ts
+++ b/tests/tier3/error-messages/transactWriteItems.test.ts
@@ -13,6 +13,7 @@ import {
   hashBTableDef,
   cleanupItems,
   declareTables,
+  absentTableName
 } from '../../../src/helpers.js'
 
 declareTables(hashTableDef, hashBTableDef)
@@ -111,7 +112,7 @@ describe('TransactWriteItems — exact error messages', { tags: ['transactions',
           TransactItems: [
             {
               Put: {
-                TableName: '_conformance_does_not_exist_em_twi',
+                TableName: absentTableName('does_not_exist_em_twi'),
                 Item: { pk: { S: 'x' } },
               },
             },

--- a/tests/tier3/validation-ordering/createTable.test.ts
+++ b/tests/tier3/validation-ordering/createTable.test.ts
@@ -3,6 +3,7 @@ import {
   DynamoDBServiceException,
 } from '@aws-sdk/client-dynamodb'
 import { ddb } from '../../../src/client.js'
+import { absentTableName } from '../../../src/helpers.js'
 
 describe('CreateTable — validation ordering', { tags: ['create-table', 'control-plane', 'negative-path'] }, () => {
   it('empty TableName reports only tableName constraint', async () => {
@@ -45,7 +46,7 @@ describe('CreateTable — validation ordering', { tags: ['create-table', 'contro
     try {
       await ddb.send(
         new CreateTableCommand({
-          TableName: '_conformance_valid_table_name',
+          TableName: absentTableName('valid_table_name'),
           AttributeDefinitions: [{ AttributeName: 'pk', AttributeType: 'S' }],
           KeySchema: [
             { AttributeName: 'pk', KeyType: 'INVALID' },
@@ -66,7 +67,7 @@ describe('CreateTable — validation ordering', { tags: ['create-table', 'contro
     try {
       await ddb.send(
         new CreateTableCommand({
-          TableName: '_conformance_valid_table_name',
+          TableName: absentTableName('valid_table_name'),
           AttributeDefinitions: [{ AttributeName: 'pk', AttributeType: 'S' }],
           KeySchema: [
             { AttributeName: 'pk', KeyType: 'INVALID' },
@@ -87,7 +88,7 @@ describe('CreateTable — validation ordering', { tags: ['create-table', 'contro
     try {
       await ddb.send(
         new CreateTableCommand({
-          TableName: '_conformance_dupkey',
+          TableName: absentTableName('dupkey'),
           AttributeDefinitions: [{ AttributeName: 'pk', AttributeType: 'S' }],
           KeySchema: [
             { AttributeName: 'pk', KeyType: 'HASH' },
@@ -109,7 +110,7 @@ describe('CreateTable — validation ordering', { tags: ['create-table', 'contro
     try {
       await ddb.send(
         new CreateTableCommand({
-          TableName: '_conformance_threekey',
+          TableName: absentTableName('threekey'),
           AttributeDefinitions: [
             { AttributeName: 'pk', AttributeType: 'S' },
             { AttributeName: 'sk', AttributeType: 'S' },
@@ -138,7 +139,7 @@ describe('CreateTable — validation ordering', { tags: ['create-table', 'contro
     try {
       await ddb.send(
         new CreateTableCommand({
-          TableName: '_conformance_badbilling',
+          TableName: absentTableName('badbilling'),
           AttributeDefinitions: [{ AttributeName: 'pk', AttributeType: 'S' }],
           KeySchema: [{ AttributeName: 'pk', KeyType: 'HASH' }],
           // @ts-expect-error -- testing invalid BillingMode

--- a/tests/tier3/validation-ordering/deleteItem.test.ts
+++ b/tests/tier3/validation-ordering/deleteItem.test.ts
@@ -3,6 +3,7 @@ import {
   DynamoDBServiceException,
 } from '@aws-sdk/client-dynamodb'
 import { ddb } from '../../../src/client.js'
+import { absentTableName } from '../../../src/helpers.js'
 
 describe('DeleteItem — validation ordering', { tags: ['delete-item', 'data-plane', 'negative-path'] }, () => {
   it('empty TableName reports only tableName constraint', async () => {
@@ -30,7 +31,7 @@ describe('DeleteItem — validation ordering', { tags: ['delete-item', 'data-pla
     try {
       await ddb.send(
         new DeleteItemCommand({
-          TableName: '_conformance_valid_table_name',
+          TableName: absentTableName('valid_table_name'),
           Key: { pk: { S: 'test' } },
           ReturnValues: 'INVALID',
           ReturnConsumedCapacity: 'INVALID',

--- a/tests/tier3/validation-ordering/putItem.test.ts
+++ b/tests/tier3/validation-ordering/putItem.test.ts
@@ -3,6 +3,7 @@ import {
   DynamoDBServiceException,
 } from '@aws-sdk/client-dynamodb'
 import { ddb } from '../../../src/client.js'
+import { absentTableName } from '../../../src/helpers.js'
 import { observeSplit } from '../../../src/observation-sink.js'
 
 describe('PutItem — validation ordering', { tags: ['put-item', 'data-plane', 'negative-path'] }, () => {
@@ -59,7 +60,7 @@ describe('PutItem — validation ordering', { tags: ['put-item', 'data-plane', '
     try {
       await ddb.send(
         new PutItemCommand({
-          TableName: '_conformance_valid_table_name',
+          TableName: absentTableName('valid_table_name'),
           Item: { pk: { S: 'test' } },
           ReturnConsumedCapacity: 'INVALID',
           ReturnItemCollectionMetrics: 'INVALID',

--- a/tests/tier3/validation-ordering/updateItem.test.ts
+++ b/tests/tier3/validation-ordering/updateItem.test.ts
@@ -3,6 +3,7 @@ import {
   DynamoDBServiceException,
 } from '@aws-sdk/client-dynamodb'
 import { ddb } from '../../../src/client.js'
+import { absentTableName } from '../../../src/helpers.js'
 import { observeSplit } from '../../../src/observation-sink.js'
 
 describe('UpdateItem — validation ordering', { tags: ['update-item', 'data-plane', 'negative-path'] }, () => {
@@ -35,7 +36,7 @@ describe('UpdateItem — validation ordering', { tags: ['update-item', 'data-pla
       await observeSplit(ctx.task, () =>
         ddb.send(
           new UpdateItemCommand({
-            TableName: '_conformance_valid_table_name',
+            TableName: absentTableName('valid_table_name'),
             Key: { pk: { S: 'test' } },
             ReturnValues: 'INVALID',
             ReturnConsumedCapacity: 'INVALID',

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,15 +1,25 @@
 import { defineConfig } from 'vitest/config'
 import { TAGS } from './src/tags.js'
 import { resultTargetFrom } from './scripts/lib/result-target.mjs'
+import { pinTablePrefix } from './src/table-namespace.js'
 
 // Naming a target is what opts a run into writing a published results file;
 // an unconfigured run goes to the gitignored scratch slug. See
 // scripts/lib/result-target.mjs for why the default is not the ground truth.
 const resultTarget = resultTargetFrom()
 
+// Pin the table namespace here, before anything spawns. Tests run in a worker
+// and the teardown that sweeps their tables runs in the main process, so a
+// prefix resolved independently in each would differ and the sweep would find
+// nothing. Pinning it into this process's environment covers the main process,
+// and handing the same value to `env` below covers the worker.
+// See src/table-namespace.ts.
+const tablePrefix = pinTablePrefix()
+
 export default defineConfig({
   test: {
     globals: true,
+    env: { CONFORMANCE_TABLE_PREFIX: tablePrefix },
     testTimeout: 30_000,
     hookTimeout: 180_000,
     // Bounded retry, opt-in via CONFORMANCE_RETRY (set only on the real-AWS


### PR DESCRIPTION
## What this changes

The suite hardcoded the `_conformance_` table prefix, so a run on a developer
machine wrote into CI's namespace. `cleanupAllTables` deletes every table
matching the prefix, once per run, before anything is created and with no age
gate, so a local run starting mid-CI-run took CI's live tables with it. CI
serialises against itself through the `conformance-aws` concurrency group; that
group cannot see a laptop.

The split already existed everywhere else. `scripts/cleanup-orphans.mjs`
documents it, holds both prefixes in its allowlist, and `sweep.yml` runs a daily
capture-namespace sweep beside the conformance one. Only the suite ignored it.

The prefix now resolves from `CONFORMANCE_TABLE_PREFIX`, falling back to
`_conformance_` under CI and a per-session `_capture_<date>_<code>_` otherwise.
CI stays on a stable prefix because its pre-run sweep is what clears tables a
dead run stranded; local runs have nothing serialising them, so the session
segment keeps two of them off each other.

It resolves in `vitest.config.ts` rather than at first import. Tests run in a
worker and the teardown that sweeps them runs in the main process, so a prefix
minted independently in each would differ and the sweep would find nothing. That
is also why the resolution sits in its own module: importing `helpers.ts` into
the config would construct an AWS client at config-load time.

Tests naming a table that does not exist now build the name through
`absentTableName`. Against real AWS a name outside the run's namespace is
refused before DynamoDB can answer that the table is missing, so those tests saw
`AccessDeniedException` where they expected `ResourceNotFoundException`. The
`SearchVectors` support probe had the same problem, where the wrong exception
reads as the operation being absent.

No change to the suite's composition: `registry/suite-manifest.json` still
matches at 1054 tests.

## Checklist

- [x] New or modified tests run against real AWS DynamoDB and pass
- [x] New or modified tests run against at least one emulator target and behave
  as expected
- [x] Linked issue or a short note explaining the motivation
- [x] I agree my contribution is licensed under the project's terms (Apache
  License, Version 2.0)

`tests/tier1` and `tests/tier3` pass in full against eu-west-2, 111 files and
829 tests. Two suites then ran concurrently, 148 and 199 tests, both green,
without touching each other's tables.

Against Dynoxide 0.13.0 the full `test:quick` run is identical either side of
this branch: 1039 tests, 973 passing, 11 failing, 55 skipped, with no test
changing status and none added or removed. The 11 failures are pre-existing
divergences in index write capacity and one exact message, unchanged here.

## Tier and scope

No tier definitions or results-pipeline changes. The three workflows that run
the suite gain a top-level `CONFORMANCE_TABLE_PREFIX: _conformance_`, so CI
names its namespace outright rather than relying on the `CI` inference.
