### PR TITLE
feat: pin the vector index readiness contract

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,48 @@ section its date and version, so several branches can write ahead of one.
 
 ## Unreleased
 
+AWS corrected the vector index readiness documentation, prompted by [a write-up
+of the earlier guidance][vector-docs] that drew on the suite's measurements. The
+ACTIVE-plus-backfilling state the old advice was built around, and which no
+index ever occupies, is gone from the three pages that described it. The wait
+now reads "Backfilling is not true" rather than "is false", so a check written
+literally from it fires on both creation paths instead of neither. The tutorial
+no longer says a search during backfill can return incomplete results. Two
+things the suite had measured but nobody had written down are documented as
+well: that DescribeTable reporting ACTIVE leads the dedicated search endpoint,
+and that the readiness check depending on neither status field is a real search
+in a retry loop.
+
+[vector-docs]: https://martinhicks.dev/articles/dynamodb-vector-search-docs-get-wrong
+
+That contract is now pinned rather than described. The UpdateTable walk asserts
+that Backfilling true is only ever reported alongside CREATING, that an ACTIVE
+index reports no Backfilling field at all, and that the base table goes ACTIVE
+while the index is still building, which is what makes a table waiter the wrong
+gate for a search. The first search that succeeds has to carry every seeded
+item, since the backfill window answers with an error rather than a partial
+view. On the CreateTable path a new test runs the documented check the way an
+application would, and every rejection before the first served response has to
+be the retryable ValidationException rather than a not-found.
+
+The suite's own search wait now absorbs those two rejections and rethrows every
+other answer, so a fixture waiting on an index that is ACTIVE but not yet served
+no longer fails on the lag it was waiting out. Two files asserting exact
+rejection messages wait for a served search rather than for ACTIVE: "does not
+have the specified index" is also what a freshly ACTIVE index says, and it would
+otherwise stand in for whichever message the case asked for.
+
+The tutorial's other new claim, that a table cannot be deleted while a vector
+index is being created, has a test of its own. Only the UpdateTable path can ask
+it. Across three runs an index created with its table reached ACTIVE in the same
+250ms poll as the table, so the table is never ACTIVE with the index still
+building there, and a DeleteTable during creation is refused for the table's own
+status rather than with the documented index wording. Adding an index to a live
+table opens that window about thirty seconds in. The test cancels the index
+afterwards instead of waiting out the backfill, which a still-creating vector
+index turns out to accept the way a backfilling GSI does, so it costs a minute
+rather than seventeen.
+
 A release now dispatches its measurement as the results bot rather than with
 the workflow's own token. GitHub raises no `workflow_run` event when a run
 started by `GITHUB_TOKEN` finishes, so 3.2.0 measured green for three hours and

--- a/README.md
+++ b/README.md
@@ -478,7 +478,7 @@ npm test
 | Local emulators | ~2-5 seconds | ~2-5 seconds |
 | Real DynamoDB | ~1-3.5 hours | ~20-25 minutes |
 
-The full suite includes slow online-index lifecycle tests: 14 UpdateTable GSI tests that add and remove Global Secondary Indexes from existing tables, plus the UpdateTable vector index lifecycle test, which backfills on the same machinery. On real DynamoDB, each index creation triggers a backfill that usually takes 5-15 minutes even on small tables, and has been observed taking 25+ on a slow night (a 25-item vector index took ~17). These tests are important for conformance but they dominate runtime against real AWS.
+The full suite includes slow online-index lifecycle tests: 14 UpdateTable GSI tests that add and remove Global Secondary Indexes from existing tables, plus two UpdateTable vector index tests, which backfill on the same machinery: the lifecycle walk, and a shorter one asserting that the table cannot be deleted while an index is still being created. That second one cancels the index rather than waiting the backfill out, so it costs about a minute. On real DynamoDB, each index creation triggers a backfill that usually takes 5-15 minutes even on small tables, and has been observed taking 25+ on a slow night (a 25-item vector index took ~17). These tests are important for conformance but they dominate runtime against real AWS.
 
 `test:quick` excludes the online-index lifecycle tests (GSI and vector) for faster local iteration. CI's gating real-DynamoDB job runs `test:gating`, which drops those *and* the S3 and Kinesis integration suites (see "Operations every emulator skips" above), so a slow async import can't redden the build. Emulator targets run the full `npm test` since index creation is instant locally.
 

--- a/captures/2026-08-21-vector-readiness-docs.json
+++ b/captures/2026-08-21-vector-readiness-docs.json
@@ -1,0 +1,135 @@
+{
+  "capturedAt": "2026-08-21",
+  "kind": "documentation",
+  "issue": 125,
+  "supersedes": "captures/2026-08-12-vector-backfill-docs.json",
+  "subject": "What AWS documents about vector index readiness, after the corrections",
+  "note": "Not an API response. AWS rewrote the vector index readiness guidance and the three problems the 2026-08-12 capture recorded are all fixed. That file stays as the dated record of what the pages said when the suite measured them; this one records what they say now, so the assertions that used to rest on measurement alone can cite a documented contract. The corrections were prompted by https://martinhicks.dev/articles/dynamodb-vector-search-docs-get-wrong, which set out the three problems from this suite's measurements.",
+  "measuredOn": {
+    "region": "eu-west-2",
+    "characterisedOn": "2026-08-11",
+    "reMeasuredOn": "2026-08-21",
+    "note": "Most of what this file quotes is behaviour the suite already recorded on 2026-08-11; what changed is the documentation. The corrected pages added one claim the suite had never measured, about DeleteTable during index creation, so that one was measured fresh. Doing so turned up two things the new prose does not account for, recorded under measuredWhileChecking."
+  },
+  "corrections": [
+    {
+      "problem": "The documented state machine described a state the index never occupies.",
+      "was": "It then moves to IndexStatus ACTIVE with Backfilling set to true while DynamoDB populates the index from existing base table data.",
+      "now": "It remains CREATING while DynamoDB populates the index from existing base table data, and reports Backfilling as true during that phase. When the index is ready, IndexStatus becomes ACTIVE and the Backfilling field is no longer reported.",
+      "page": "Data synchronization between tables and vector indexes",
+      "url": "https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/VectorSearchDataSync.html",
+      "anchor": "VectorSearchDataSync.Backfilling",
+      "alsoFixedIn": [
+        "VectorSearchWorkingWith.html - the numbered walk now reads CREATING with Backfilling absent or false, then CREATING with Backfilling true, then ACTIVE with Backfilling no longer reported.",
+        "VectorSearchTroubleshooting.html - the cause cell now reads 'IndexStatus is CREATING, either while the index is provisioned or while it backfills existing data', dropping the ACTIVE-plus-backfilling half."
+      ]
+    },
+    {
+      "problem": "The readiness check was written against a field that disappears rather than settling to false, so a literal implementation never fired.",
+      "was": "Use DescribeTable and wait until IndexStatus is ACTIVE and Backfilling is false before you search.",
+      "now": "Use DescribeTable and wait until IndexStatus is ACTIVE and Backfilling is not true before you search.",
+      "page": "Data synchronization between tables and vector indexes",
+      "url": "https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/VectorSearchDataSync.html",
+      "anchor": "VectorSearchDataSync.Backfilling",
+      "alsoFixedIn": [
+        "VectorSearchWorkingWith.html - 'wait until IndexStatus is ACTIVE and Backfilling is not true before you search'.",
+        "VectorSearchTroubleshooting.html - 'wait until IndexStatus is ACTIVE and Backfilling is not true, then retry the search'.",
+        "VectorSearchTutorial.html - 'wait until IndexStatus is ACTIVE and Backfilling is not true before you search', plus a new sentence that Backfilling is reported only while the index is CREATING and is absent once it is ACTIVE."
+      ],
+      "residual": {
+        "page": "Troubleshooting vector indexes",
+        "url": "https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/VectorSearchTroubleshooting.html",
+        "anchor": "VectorSearchTroubleshooting.ChangePartitionKey",
+        "quote": "Wait for the new index to finish backfilling. Call DescribeTable and confirm that IndexStatus is ACTIVE and Backfilling is false.",
+        "note": "One step of the partition-key migration runbook still says false rather than not true. The main guidance on all four pages is corrected; this one instance is not, and a reader following it waits on a field that is gone. Left recorded rather than asserted, because the suite has no way to test a runbook step."
+      }
+    },
+    {
+      "problem": "The tutorial said searching during backfill could return incomplete results, which contradicted the other three pages and the measured behaviour.",
+      "was": "Searching an index that is not yet ACTIVE fails, and searching during backfill can return incomplete results.",
+      "now": "Searching an index that is not yet ACTIVE fails with a ValidationException. Searching during backfill also returns a ValidationException. It does not return partial results.",
+      "page": "Tutorial: Your first vector search",
+      "url": "https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/VectorSearchTutorial.html",
+      "anchor": "VectorSearchTutorial"
+    }
+  ],
+  "newlyDocumented": [
+    {
+      "subject": "DescribeTable reporting ACTIVE leads the search endpoint.",
+      "page": "Creating and searching vector indexes",
+      "url": "https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/VectorSearchWorkingWith.html",
+      "anchor": "VectorSearchWorkingWith.Create.ExistingTable",
+      "callout": "A newly ready index is not immediately searchable",
+      "quote": "SearchVectors requests are served by a dedicated search endpoint, separate from the endpoint that serves DescribeTable. After DescribeTable first reports IndexStatus ACTIVE, the search endpoint can require additional time before it begins serving the index. During that interval SearchVectors returns a ValidationException, typically The table does not have the specified index.",
+      "secondQuote": "Treat a ValidationException on the first searches after index creation as retryable rather than as a failure. Code that searches immediately after observing ACTIVE might appear to work in one environment and fail in another. The interval is brief and varies.",
+      "thirdQuote": "For a readiness check that does not depend on either status field, issue a real SearchVectors request in a retry loop. Treat the first successful response as the signal that the index is ready.",
+      "note": "The suite measured this and built its waiters around it before it was documented. The troubleshooting table now carries a matching row whose symptom is the not-found wording arriving while DescribeTable reports ACTIVE."
+    },
+    {
+      "subject": "The table waiter is the wrong gate for a search.",
+      "page": "Tutorial: Your first vector search",
+      "url": "https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/VectorSearchTutorial.html",
+      "anchor": "VectorSearchTutorial",
+      "callout": "Wait for the index, not just the table",
+      "quote": "Do not use aws dynamodb wait table-exists to gate the search. That waiter matches on Table.TableStatus, which becomes ACTIVE while the vector index can still be CREATING. There is no waiter for vector index readiness, so you must poll DescribeTable as shown."
+    },
+    {
+      "subject": "Backfill duration does not scale with the item count.",
+      "page": "Data synchronization between tables and vector indexes",
+      "url": "https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/VectorSearchDataSync.html",
+      "anchor": "VectorSearchDataSync.Backfilling",
+      "quote": "Index construction drives backfill duration, not the number of items in the base table. Even a table with very few items can take a substantial amount of time to finish backfilling. Poll DescribeTable rather than assuming a small table will be ready quickly.",
+      "note": "Matches the suite's own figure: roughly 17 minutes for an index added to a 25-item table. Not asserted, since a duration is not a contract, but it is why the UpdateTable walk carries a 2,400-second ceiling."
+    },
+    {
+      "subject": "The two pre-ready rejections are named.",
+      "page": "Troubleshooting vector indexes",
+      "url": "https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/VectorSearchTroubleshooting.html",
+      "anchor": "VectorSearchTroubleshooting",
+      "symptom": "ValidationException: Cannot search backfilling vector index: <indexName> or ValidationException: The table does not have the specified index: <indexName>",
+      "cause": "The vector index is not yet ready for search. IndexStatus is CREATING, either while the index is provisioned or while it backfills existing data.",
+      "resolution": "Use DescribeTable and wait until IndexStatus is ACTIVE and Backfilling is not true, then retry the search. Treat ValidationException as retryable during index creation.",
+      "note": "Both messages match what the suite recorded on 2026-08-11. The first is also the answer for an index name that never existed, so it carries no information on its own about which of the two situations a caller is in."
+    },
+    {
+      "subject": "A table cannot be deleted while a vector index is being created.",
+      "page": "Tutorial: Your first vector search",
+      "url": "https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/VectorSearchTutorial.html",
+      "anchor": "VectorSearchTutorial",
+      "callout": "Wait for the index, not just the table",
+      "quote": "For the same reason, you cannot delete the table until every vector index has finished creating. DeleteTable returns ResourceInUseException with the message \"Cannot delete table while indexes are being created, updated, or deleted.\"",
+      "measured": "Confirmed on the UpdateTable path. The answer is ResourceInUseException with the message \"Attempt to change a resource which is still in use: Cannot delete table while indexes are being created, updated, or deleted.\" The documented sentence is the clause after the envelope, not the whole message, so the suite asserts the clause within it."
+    }
+  ],
+  "stillSilent": {
+    "page": "SearchVectors API reference",
+    "url": "https://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_SearchVectors.html",
+    "quote": "The index must be in the ACTIVE state.",
+    "note": "Unchanged. The IndexName parameter still requires ACTIVE, ResourceNotFoundException still notes that a resource's status might not be ACTIVE, and neither mentions backfilling, the Backfilling flag, or the endpoint lag. The listed errors still omit the ValidationException the pre-ready window actually returns, so a reader working from the API reference alone would expect a not-found and write a retry that never fires."
+  },
+  "assertionStatus": {
+    "createTablePath": "tests/tier2/vectorSearch/lifecycle.test.ts asserts Backfilling stays undefined on every poll and that seen statuses stay within CREATING and ACTIVE. A second block runs the documented readiness check end to end: poll to ACTIVE, then search in a retry loop, with every rejection before the first served response required to be a ValidationException carrying one of the two named messages.",
+    "updateTablePath": "tests/tier2/vectorSearch/updateLifecycle.test.ts now pins the pairing the old prose got wrong. Backfilling true is asserted to occur only alongside CREATING, an ACTIVE index is asserted to report no Backfilling field at all, and the base table is required to have been seen ACTIVE while the index was still CREATING. The first search that succeeds must carry every seeded item, which is the tutorial's corrected claim that the backfill window returns an error rather than a partial view.",
+    "readinessPredicate": "src/vector.ts implements the documented wait as IndexStatus ACTIVE and Backfilling not true, and src/vector.test.ts pins each cell of it so neither the ACTIVE-only reading nor the equals-false reading can return.",
+    "endpointLag": "src/vector.ts treats the two named rejections as retryable inside the search wait and rethrows every other answer, so a malformed request still surfaces as itself rather than as a readiness timeout. Fixtures that assert on an exact rejection message now wait for a served search rather than for ACTIVE, since the not-found wording would otherwise stand in for whichever message the case asked for.",
+    "deleteDuringCreation": "tests/tier2/vectorSearch/updateLifecycle.test.ts carries a second test that adds an index to a live table, waits for the table to return to ACTIVE with the index still CREATING, and asserts the documented ResourceInUseException. It then cancels the index rather than waiting out the backfill, and asserts the table is deletable once the index is gone."
+  },
+  "measuredWhileChecking": [
+    {
+      "subject": "On the CreateTable path there is no window in which the table is ACTIVE and the vector index is not.",
+      "measured": "Three runs in eu-west-2 on 2026-08-21, polling DescribeTable every 250ms from the CreateTable call. In all three the table and the index reported ACTIVE in the same poll, at 14.8s, 15.1s and 14.2s. No poll ever saw TableStatus ACTIVE beside IndexStatus CREATING.",
+      "consequence": "The tutorial gives that state as the reason not to gate a search on \"aws dynamodb wait table-exists\": \"That waiter matches on Table.TableStatus, which becomes ACTIVE while the vector index can still be CREATING.\" The advice is sound, and the state does occur, but on the UpdateTable path rather than the CreateTable path the tutorial walks the reader through. A reader testing the warning against the tutorial's own steps would not reproduce it.",
+      "pinned": "No. A target whose table and index settle together is not diverging, and asserting simultaneity would assert the outcome of a race. The suite pins the state where it is reachable by construction, in the UpdateTable walk, and leaves this as a measurement."
+    },
+    {
+      "subject": "The DeleteTable refusal during CreateTable-path index creation cites the table, not the index.",
+      "measured": "DeleteTable issued immediately after CreateTable, while both the table and the index were CREATING, answered ResourceInUseException: \"Attempt to change a resource which is still in use: Table is being created: <tableName>\". The documented index wording was not returned on this path in any run.",
+      "consequence": "The documented message is reachable only once the table is ACTIVE, which on this path is also the moment the index becomes ACTIVE. The claim belongs to the UpdateTable path, though the callout making it sits in the CreateTable tutorial."
+    },
+    {
+      "subject": "A vector index still CREATING accepts a Delete.",
+      "measured": "With the table ACTIVE and the index CREATING with Backfilling true, UpdateTable with a Delete action for that index was accepted rather than refused by the one-online-action limit. The index moved to DELETING, the table to UPDATING, and the index was gone about five seconds later, after which DeleteTable succeeded.",
+      "note": "Undocumented either way, and it matches how a backfilling GSI behaves. It is what lets the suite test the refusal in about a minute instead of waiting out a seventeen-minute backfill to release the table."
+    }
+  ]
+}

--- a/captures/README.md
+++ b/captures/README.md
@@ -27,6 +27,42 @@ baseline lives in the dated snapshot below instead, and the scheduled-run drift
 verdict flags when it needs refreshing. Currently seeded from the 2026-06-09
 capture until the first scheduled run overwrites it.
 
+## 2026-08-21-vector-readiness-docs.json
+
+AWS rewrote the vector index readiness guidance, and all three problems the
+2026-08-12 capture recorded are fixed: the impossible ACTIVE-plus-backfilling
+state is gone from every page that carried it, the wait now reads "Backfilling
+is not true" rather than "is false", and the tutorial no longer claims a search
+during backfill can return incomplete results. The corrections were prompted by
+[a write-up of those three problems][writeup], which drew on this suite's
+measurements.
+
+[writeup]: https://martinhicks.dev/articles/dynamodb-vector-search-docs-get-wrong
+
+This file records what the pages say now, quote by quote against what they said
+before, so the assertions that used to rest on measurement alone can cite a
+documented contract. It also records what is newly documented and was not
+before: that DescribeTable reporting ACTIVE leads the dedicated search endpoint,
+that the ValidationException answered in between is retryable, and that the
+readiness check which depends on neither status field is a real search in a
+retry loop. One residual is noted rather than asserted, since the suite cannot
+test a runbook step: the partition-key migration steps still say to wait for
+Backfilling false.
+
+Most of it needed no re-measuring: the behaviour it quotes is what the suite
+recorded on 2026-08-11, and what moved is the documentation. The corrected pages
+do carry one claim the suite had never measured, that a table cannot be deleted
+while a vector index is being created, so that one was measured fresh. It holds.
+
+Measuring it turned up two things the new prose does not account for, both filed
+under `measuredWhileChecking`. The tutorial gives "the table goes ACTIVE while
+the index can still be CREATING" as its reason not to gate a search on `wait
+table-exists`, but on the CreateTable path the tutorial itself walks, the table
+and the index reached ACTIVE in the same 250ms poll on all three runs. The state
+is real and the advice is sound; it is the UpdateTable path that shows it. A
+DeleteTable during CreateTable-path index creation is likewise refused for the
+table's own status, not with the documented index wording.
+
 ## 2026-08-12-vector-backfill-docs.json
 
 The one capture that is not an API response. AWS's developer guide states two
@@ -37,8 +73,11 @@ incomplete results", and the API reference is silent. The suite asserts the
 error, so this file fixes the prose on both sides with its URLs and anchors,
 dated, rather than leaving the claim resting on a changelog sentence. Measured
 behaviour lives in `tests/tier2/vectorSearch/updateLifecycle.test.ts`; this is
-the evidence for the disagreement it settles. Re-check it if AWS edits either
-side.
+the evidence for the disagreement it settles.
+
+Superseded on 2026-08-21, when AWS corrected the pages. Kept as the dated record
+of what they said while the suite was measuring them; see
+`2026-08-21-vector-readiness-docs.json` above for what they say now.
 
 ## 2026-07-21-null-false-envelope.json
 

--- a/registry/suite-manifest.json
+++ b/registry/suite-manifest.json
@@ -1,7 +1,7 @@
 {
-  "generated": "2026-08-17",
-  "commit": "a82d4567e03439f606a991a5bb6caa2c3c80b9af",
-  "count": 1054,
+  "generated": "2026-08-21",
+  "commit": "d92ddad3b0c73f58869fb725387cc7684ba231a0",
+  "count": 1056,
   "tests": [
     "tests/tier1/batchGetItem/basic.test.ts::BatchGetItem — ProjectionExpression returns only projected attributes",
     "tests/tier1/batchGetItem/basic.test.ts::BatchGetItem — basic handles a mix of existing and non-existing keys",
@@ -701,6 +701,7 @@
     "tests/tier2/vectorSearch/lifecycle.test.ts::CreateTable — vector index lifecycle accepts the 4096-dimension boundary",
     "tests/tier2/vectorSearch/lifecycle.test.ts::CreateTable — vector index lifecycle round-trips a SearchSchema of HASH and INLINE_FILTER elements",
     "tests/tier2/vectorSearch/lifecycle.test.ts::CreateTable — vector index lifecycle walks CREATING to ACTIVE and describes the index faithfully",
+    "tests/tier2/vectorSearch/lifecycle.test.ts::SearchVectors — index readiness after CreateTable rejects retryably between ACTIVE and the first served search",
     "tests/tier2/vectorSearch/partiql.test.ts::PartiQL — vector indexes are out of reach reads the vector attribute off the base table like any other item",
     "tests/tier2/vectorSearch/partiql.test.ts::PartiQL — vector indexes are out of reach rejects a PartiQL read of a vector index",
     "tests/tier2/vectorSearch/search.test.ts::SearchVectors — deterministic search behaviour COSINE: identical vector scores 0, opposite scores 2, lower is closer",
@@ -711,6 +712,7 @@
     "tests/tier2/vectorSearch/search.test.ts::SearchVectors — deterministic search behaviour returns the identical vector as the top match",
     "tests/tier2/vectorSearch/search.test.ts::SearchVectors — deterministic search behaviour stores full precision on the base table and f32 in the index",
     "tests/tier2/vectorSearch/updateLifecycle.test.ts::UpdateTable — vector index lifecycle adds an index that backfills like a GSI, enforces one online action, then deletes it",
+    "tests/tier2/vectorSearch/updateLifecycle.test.ts::UpdateTable — vector index lifecycle refuses to delete the table while a vector index is still being created",
     "tests/tier2/vectorSearch/validation.test.ts::CreateTable — vector index request validation rejects Dimensions of 0 at the request model layer",
     "tests/tier2/vectorSearch/validation.test.ts::CreateTable — vector index request validation rejects an index name shorter than 3 characters",
     "tests/tier2/vectorSearch/validation.test.ts::SearchVectors — request validation rejects TopK of 0 at the request model layer",

--- a/results/tag-manifest.json
+++ b/results/tag-manifest.json
@@ -884,6 +884,12 @@
         "create-table",
         "control-plane",
         "vector"
+      ],
+      "SearchVectors — index readiness after CreateTable": [
+        "search-vectors",
+        "create-table",
+        "data-plane",
+        "vector"
       ]
     },
     "tests/tier2/vectorSearch/partiql.test.ts": {
@@ -903,6 +909,7 @@
     "tests/tier2/vectorSearch/updateLifecycle.test.ts": {
       "UpdateTable — vector index lifecycle": [
         "update-table",
+        "delete-table",
         "search-vectors",
         "control-plane",
         "vector",

--- a/site/data/tag-manifest.json
+++ b/site/data/tag-manifest.json
@@ -884,6 +884,12 @@
         "create-table",
         "control-plane",
         "vector"
+      ],
+      "SearchVectors — index readiness after CreateTable": [
+        "search-vectors",
+        "create-table",
+        "data-plane",
+        "vector"
       ]
     },
     "tests/tier2/vectorSearch/partiql.test.ts": {
@@ -903,6 +909,7 @@
     "tests/tier2/vectorSearch/updateLifecycle.test.ts": {
       "UpdateTable — vector index lifecycle": [
         "update-table",
+        "delete-table",
         "search-vectors",
         "control-plane",
         "vector",

--- a/src/vector.test.ts
+++ b/src/vector.test.ts
@@ -134,6 +134,18 @@ describe('supportsVectorIndexes', () => {
   })
 })
 
+/** The documented readiness predicate, exercised cell by cell. */
+async function settlesOn(index: Record<string, unknown>): Promise<boolean> {
+  const vector = await loadVector()
+  sendMock.mockResolvedValue({
+    Table: { VectorIndexes: [{ IndexName: 'vix', ...index }] },
+  })
+  return await vector
+    .waitForVectorIndexActive('t', 'vix', { timeoutMs: 30 })
+    .then(() => true)
+    .catch(() => false)
+}
+
 describe('waitForVectorIndexActive', () => {
   it('resolves once the index is ACTIVE and not backfilling', async () => {
     const vector = await loadVector()
@@ -141,6 +153,27 @@ describe('waitForVectorIndexActive', () => {
       Table: { VectorIndexes: [{ IndexName: 'vix', IndexStatus: 'ACTIVE' }] },
     })
     await expect(vector.waitForVectorIndexActive('t', 'vix')).resolves.toBeUndefined()
+  })
+
+  // AWS documents the wait as "IndexStatus is ACTIVE and Backfilling is not
+  // true". An absent field is the terminal state on both creation paths, so
+  // reading the check as `Backfilling === false` would wait forever; and ACTIVE
+  // on its own would return during a backfill if one were ever reported that
+  // way. Each cell is pinned so neither reading can creep back in.
+  it('treats an absent Backfilling field as done', async () => {
+    expect(await settlesOn({ IndexStatus: 'ACTIVE' })).toBe(true)
+  })
+
+  it('treats Backfilling false as done', async () => {
+    expect(await settlesOn({ IndexStatus: 'ACTIVE', Backfilling: false })).toBe(true)
+  })
+
+  it('keeps waiting while Backfilling is true, whatever the status says', async () => {
+    expect(await settlesOn({ IndexStatus: 'ACTIVE', Backfilling: true })).toBe(false)
+  })
+
+  it('keeps waiting while the status is CREATING, whatever Backfilling says', async () => {
+    expect(await settlesOn({ IndexStatus: 'CREATING', Backfilling: false })).toBe(false)
   })
 
   it('types a ceiling expiry as indeterminate, never a divergence', async () => {
@@ -188,5 +221,126 @@ describe('waitForVectorSearchable', () => {
       .catch((e: unknown) => e)) as { name?: string; reason?: string } | null
     expect(err?.name).toBe('IndeterminateError')
     expect(err?.reason).toBe('vector-consistency-timeout')
+  })
+
+  // The search endpoint can lag DescribeTable, and AWS documents the resulting
+  // ValidationException as retryable rather than as an answer. The loop absorbs
+  // the two readiness rejections by name and nothing else, so a malformed
+  // request still surfaces as itself instead of as a readiness timeout.
+  it('retries through a readiness rejection and returns on the first real answer', async () => {
+    const vector = await loadVector()
+    let calls = 0
+    sendMock.mockImplementation(() => {
+      calls += 1
+      if (calls === 1) {
+        return Promise.reject(
+          serviceError('ValidationException', 'The table does not have the specified index: vix'),
+        )
+      }
+      if (calls === 2) {
+        return Promise.reject(
+          serviceError('ValidationException', 'Cannot search backfilling vector index: vix'),
+        )
+      }
+      return Promise.resolve({ SearchResults: [{}] })
+    })
+    await expect(
+      vector.waitForVectorSearchable({
+        tableName: 't',
+        indexName: 'vix',
+        searchVector: [{ N: '1' }],
+        expectedCount: 1,
+      }),
+    ).resolves.toBeUndefined()
+    expect(calls).toBe(3)
+  })
+
+  it('rethrows a rejection that is not about readiness', async () => {
+    const vector = await loadVector()
+    sendMock.mockRejectedValue(
+      serviceError('ValidationException', 'Provided TopK value is out of valid range'),
+    )
+    await expect(
+      vector.waitForVectorSearchable({
+        tableName: 't',
+        indexName: 'vix',
+        searchVector: [{ N: '1' }],
+        expectedCount: 1,
+      }),
+    ).rejects.toThrow('Provided TopK value is out of valid range')
+  })
+
+  it('rethrows a readiness rejection that names a different index', async () => {
+    const vector = await loadVector()
+    sendMock.mockRejectedValue(
+      serviceError('ValidationException', 'The table does not have the specified index: other'),
+    )
+    await expect(
+      vector.waitForVectorSearchable({
+        tableName: 't',
+        indexName: 'vix',
+        searchVector: [{ N: '1' }],
+        expectedCount: 1,
+      }),
+    ).rejects.toThrow('The table does not have the specified index: other')
+  })
+})
+
+describe('waitForVectorIndexSearchable', () => {
+  it('waits for ACTIVE, then for the search endpoint to serve the index', async () => {
+    const vector = await loadVector()
+    let searches = 0
+    sendMock.mockImplementation((cmd) => {
+      if (named(cmd) === 'DescribeTableCommand') {
+        return Promise.resolve({
+          Table: { VectorIndexes: [{ IndexName: 'vix', IndexStatus: 'ACTIVE' }] },
+        })
+      }
+      searches += 1
+      if (searches === 1) {
+        return Promise.reject(
+          serviceError('ValidationException', 'The table does not have the specified index: vix'),
+        )
+      }
+      return Promise.resolve({ SearchResults: [] })
+    })
+    await expect(
+      vector.waitForVectorIndexSearchable({
+        tableName: 't',
+        indexName: 'vix',
+        searchVector: [{ N: '1' }],
+      }),
+    ).resolves.toBeUndefined()
+    // An empty index is ready: the first response that comes back at all ends
+    // the wait, whether or not it carries results.
+    expect(searches).toBe(2)
+  })
+
+  // Nothing here waits on item visibility, so the consistency reason would name
+  // the wrong failure. An index that goes ACTIVE and never serves a search is an
+  // index timeout.
+  it('types a search that never gets served as an index timeout', async () => {
+    const vector = await loadVector()
+    sendMock.mockImplementation((cmd) => {
+      if (named(cmd) === 'DescribeTableCommand') {
+        return Promise.resolve({
+          Table: { VectorIndexes: [{ IndexName: 'vix', IndexStatus: 'ACTIVE' }] },
+        })
+      }
+      return Promise.reject(
+        serviceError('ValidationException', 'The table does not have the specified index: vix'),
+      )
+    })
+    const err = (await vector
+      .waitForVectorIndexSearchable({
+        tableName: 't',
+        indexName: 'vix',
+        searchVector: [{ N: '1' }],
+        timeoutMs: 30,
+      })
+      .then(() => null)
+      .catch((e: unknown) => e)) as { name?: string; reason?: string } | null
+    expect(err?.name).toBe('IndeterminateError')
+    expect(err?.reason).toBe('vector-index-timeout')
   })
 })

--- a/src/vector.ts
+++ b/src/vector.ts
@@ -10,6 +10,15 @@
 // The waiters follow the shape of waitUntilActive / waitForGsiConsistency in
 // helpers.ts: a ceiling expiring is an IndeterminateError (a failed
 // observation), never a divergence.
+//
+// The readiness contract they implement - poll DescribeTable until IndexStatus
+// is ACTIVE and Backfilling is not true, then prove it with a real search in a
+// retry loop - is what AWS documents, as of the corrections it made to the
+// vector search pages on 2026-08-20. Those followed
+// https://martinhicks.dev/articles/dynamodb-vector-search-docs-get-wrong, which
+// set out three problems in the previous guidance from this suite's
+// measurements. captures/2026-08-21-vector-readiness-docs.json records what the
+// pages said before and after, quote by quote.
 
 import {
   CreateTableCommand,
@@ -197,10 +206,17 @@ export async function describeVectorIndex(
 /**
  * Wait until a vector index is ACTIVE and done backfilling.
  *
- * `Backfilling` is only reported for indexes added via UpdateTable; for an
- * index created with the table, DescribeTable leaves the field unset while
- * the status alone walks to ACTIVE (there is no BACKFILLING status value).
- * An unset field therefore counts as "not backfilling" on both paths.
+ * The predicate is `IndexStatus === 'ACTIVE' && Backfilling !== true`, which is
+ * the check AWS documents: "wait until IndexStatus is ACTIVE and Backfilling is
+ * not true before you search". The `!== true` carries the whole thing.
+ * `Backfilling` is a CREATING-time field that disappears rather than settling
+ * to false, and it is never reported at all for an index created with its
+ * table, so the same check written as `Backfilling === false` never fires on
+ * either path.
+ *
+ * ACTIVE is necessary and not sufficient. SearchVectors is served by a separate
+ * endpoint that can lag behind DescribeTable, so anything that goes on to
+ * search wants waitForVectorIndexSearchable instead.
  */
 export async function waitForVectorIndexActive(
   tableName: string,
@@ -225,10 +241,83 @@ export async function waitForVectorIndexActive(
 }
 
 /**
+ * The two rejections AWS documents for a vector index that is not yet serving
+ * searches: one for the window before the index resolves, one for the backfill
+ * itself. The troubleshooting guide names both, says to treat a
+ * ValidationException as retryable during index creation, and names the first
+ * again for the interval after IndexStatus turns ACTIVE while the dedicated
+ * search endpoint is still catching up.
+ *
+ * Deliberately narrow. A retry loop that absorbed every ValidationException
+ * would bury a genuinely malformed request under a readiness timeout, so
+ * anything outside these two is rethrown as the answer it is.
+ */
+function isVectorIndexNotReady(err: unknown, indexName: string): boolean {
+  if (!(err instanceof DynamoDBServiceException)) return false
+  if (err.name !== 'ValidationException') return false
+  return (
+    err.message.includes(`The table does not have the specified index: ${indexName}`) ||
+    err.message.includes(`Cannot search backfilling vector index: ${indexName}`)
+  )
+}
+
+/**
+ * The readiness check AWS documents, end to end: poll DescribeTable until the
+ * index is ACTIVE and not backfilling, then prove the search endpoint agrees by
+ * issuing a real SearchVectors in a retry loop and taking the first successful
+ * response as the signal.
+ *
+ * Both halves are needed. The status fields alone are not enough — DescribeTable
+ * and SearchVectors are served by different endpoints, and the search one can
+ * begin serving the index a beat after the description says ACTIVE — and a
+ * search alone would spend the whole backfill collecting rejections it could
+ * have waited out. A fixture that asserts anything about a search wants this
+ * rather than waitForVectorIndexActive, or its first assertion races the lag and
+ * reads a readiness rejection as the answer to whatever it asked.
+ *
+ * The probe search must be shaped for the index it probes: a vector of the right
+ * dimensions, and the partition key value if the search schema declares one.
+ * Neither is guessable from here, and a malformed probe rejects for a reason the
+ * loop is right not to swallow.
+ */
+export async function waitForVectorIndexSearchable(opts: {
+  tableName: string
+  indexName: string
+  searchVector: AttributeValue[]
+  searchConditionExpression?: string
+  expressionAttributeValues?: Record<string, AttributeValue>
+  timeoutMs?: number
+}): Promise<void> {
+  // Both halves wait on index readiness, so both take the table-active ceiling.
+  // The consistency ceiling waitForVectorSearchable defaults to is sized for
+  // item visibility on a serving index, which is not what is being waited on.
+  const timeoutMs = opts.timeoutMs ?? ceilingsFor(region).tableActiveMs
+  await waitForVectorIndexActive(opts.tableName, opts.indexName, { timeoutMs })
+  try {
+    await waitForVectorSearchable({ ...opts, expectedCount: 0, timeoutMs })
+  } catch (err) {
+    if (err instanceof IndeterminateError) {
+      // Re-typed: nothing here waits on item visibility, so a consistency
+      // reason would name the wrong thing. The index reached ACTIVE and then
+      // never served a search.
+      throw new IndeterminateError(
+        'vector-index-timeout',
+        `Vector index ${opts.indexName} on ${opts.tableName} became ACTIVE but never served a search`,
+        { cause: err },
+      )
+    }
+    throw err
+  }
+}
+
+/**
  * Wait until a search returns the expected number of results — the vector
  * index is eventually consistent with no documented visibility bound, so a
  * test must hold positive evidence that the index has caught up before it
  * asserts anything about search results (especially an absence).
+ *
+ * An expectedCount of 0 makes this the documented readiness loop on its own:
+ * the first response that comes back at all ends the wait.
  */
 export async function waitForVectorSearchable(opts: {
   tableName: string
@@ -243,17 +332,29 @@ export async function waitForVectorSearchable(opts: {
   const start = Date.now()
   let delay = 0
   while (Date.now() - start < timeoutMs) {
-    const res = await ddb.send(
-      new SearchVectorsCommand({
-        TableName: opts.tableName,
-        IndexName: opts.indexName,
-        SearchVector: opts.searchVector,
-        TopK: Math.max(opts.expectedCount, 1),
-        SearchConditionExpression: opts.searchConditionExpression,
-        ExpressionAttributeValues: opts.expressionAttributeValues,
-      }),
-    )
-    if ((res.SearchResults ?? []).length >= opts.expectedCount) return
+    let found: number | undefined
+    try {
+      const res = await ddb.send(
+        new SearchVectorsCommand({
+          TableName: opts.tableName,
+          IndexName: opts.indexName,
+          SearchVector: opts.searchVector,
+          TopK: Math.max(opts.expectedCount, 1),
+          SearchConditionExpression: opts.searchConditionExpression,
+          ExpressionAttributeValues: opts.expressionAttributeValues,
+        }),
+      )
+      found = (res.SearchResults ?? []).length
+    } catch (err) {
+      // Documented: after DescribeTable first reports ACTIVE, the dedicated
+      // search endpoint can need longer before it serves the index, and
+      // SearchVectors answers ValidationException for that interval. AWS's own
+      // advice is to treat it as retryable and let the first successful
+      // response be the readiness signal, so the loop absorbs exactly those two
+      // rejections and rethrows every other answer.
+      if (!isVectorIndexNotReady(err, opts.indexName)) throw err
+    }
+    if (found !== undefined && found >= opts.expectedCount) return
     if (delay > 0) await sleep(delay)
     // Grows: `delay || 500` re-evaluated to 500 on every pass, so this polled
     // at a flat 500ms and the 2000ms ceiling was unreachable.

--- a/tests/tier2/vectorSearch/lifecycle.test.ts
+++ b/tests/tier2/vectorSearch/lifecycle.test.ts
@@ -1,11 +1,12 @@
-import { CreateTableCommand, type VectorIndex } from '@aws-sdk/client-dynamodb'
+import { CreateTableCommand, SearchVectorsCommand, DynamoDBServiceException, type VectorIndex } from '@aws-sdk/client-dynamodb'
 import { ddb } from '../../../src/client.js'
 import { region } from '../../../src/aws-config.js'
 import { uniqueTableName, deleteTable } from '../../../src/helpers.js'
 import { ceilingsFor } from '../../../src/regions.js'
-import { IndeterminateError } from '../../../src/indeterminate.js'
+import { IndeterminateError, indeterminateFrom } from '../../../src/indeterminate.js'
 import {
   skipUnlessVectorIndexes,
+  skipUnlessVectorSearch,
   describeVectorIndex,
   waitForVectorIndexActive,
 } from '../../../src/vector.js'
@@ -128,4 +129,87 @@ describe('CreateTable — vector index lifecycle', { tags: ['create-table', 'con
     const ix = (await describeVectorIndex(tableName, 'vix'))!
     expect(ix.Dimensions).toBe(4096)
   }, 150_000)
+})
+
+describe('SearchVectors — index readiness after CreateTable', { tags: ['search-vectors', 'create-table', 'data-plane', 'vector'] }, () => {
+  skipUnlessVectorSearch()
+
+  // The readiness check AWS documents, run the way an application would run
+  // it. DescribeTable reporting ACTIVE is where the guidance used to stop. It
+  // now says SearchVectors is served by a separate endpoint that can begin
+  // serving the index later, that the ValidationException answered in the
+  // meantime is retryable rather than a failure, and that the check which
+  // depends on neither status field is a real search in a retry loop whose
+  // first successful response is the signal.
+  //
+  // The lag is documented as brief and variable, so nothing here asserts that
+  // it happened: an index that serves its first search is ready and passes.
+  // What is pinned is the shape of every rejection collected on the way,
+  // because that is what decides whether "treat it as retryable" is safe
+  // advice. A target answering ResourceNotFoundException instead - which is
+  // what the API reference's error list implies for a resource whose status
+  // is not ACTIVE - strands a caller following the documented loop, since a
+  // not-found is the same answer it would get for a name that never existed.
+  it('rejects retryably between ACTIVE and the first served search', async () => {
+    const tableName = uniqueTableName('vec_ready')
+    tablesToCleanup.push(tableName)
+    await ddb.send(
+      new CreateTableCommand({
+        TableName: tableName,
+        AttributeDefinitions: [{ AttributeName: 'pk', AttributeType: 'S' }],
+        KeySchema: [{ AttributeName: 'pk', KeyType: 'HASH' }],
+        BillingMode: 'PAY_PER_REQUEST',
+        VectorIndexes: [vix()],
+      }),
+    )
+
+    // Step one: poll the index's own status, not the table's. On this path
+    // Backfilling is never reported, so IndexStatus alone carries the signal.
+    await waitForVectorIndexActive(tableName, 'vix')
+    const described = (await describeVectorIndex(tableName, 'vix'))!
+    expect(described.IndexStatus).toBe('ACTIVE')
+    expect(described.Backfilling).toBeUndefined()
+
+    // Step two: prove it with a real search.
+    const deadline = Date.now() + ceilingsFor(region).tableActiveMs
+    for (;;) {
+      let results: unknown[] | undefined
+      try {
+        const res = await ddb.send(
+          new SearchVectorsCommand({
+            TableName: tableName,
+            IndexName: 'vix',
+            SearchVector: [{ N: '1' }, { N: '0' }, { N: '0' }],
+            TopK: 1,
+          }),
+        )
+        results = res.SearchResults ?? []
+      } catch (err) {
+        // A throttle or transport fault mid-poll is a failed observation, not
+        // an answer about readiness.
+        const indeterminate = indeterminateFrom(err)
+        if (indeterminate) throw indeterminate
+        expect(err).toBeInstanceOf(DynamoDBServiceException)
+        expect((err as DynamoDBServiceException).name).toBe('ValidationException')
+        expect((err as DynamoDBServiceException).message).toMatch(
+          /The table does not have the specified index: vix|Cannot search backfilling vector index: vix/,
+        )
+      }
+      // Asserted outside the try, or a surprising answer would fall into the
+      // catch and be reported as a rejection that failed to look like one.
+      if (results !== undefined) {
+        // A served index with nothing in it answers with no results, rather
+        // than with the rejection an unserved one gives.
+        expect(results).toEqual([])
+        break
+      }
+      if (Date.now() > deadline) {
+        throw new IndeterminateError(
+          'vector-index-timeout',
+          `Vector index vix on ${tableName} reported ACTIVE but never served a search`,
+        )
+      }
+      await new Promise((r) => setTimeout(r, 500))
+    }
+  }, 300_000)
 })

--- a/tests/tier2/vectorSearch/updateLifecycle.test.ts
+++ b/tests/tier2/vectorSearch/updateLifecycle.test.ts
@@ -1,4 +1,4 @@
-import { CreateTableCommand, DescribeTableCommand, UpdateTableCommand, PutItemCommand, SearchVectorsCommand, DynamoDBServiceException } from '@aws-sdk/client-dynamodb'
+import { CreateTableCommand, DescribeTableCommand, DeleteTableCommand, UpdateTableCommand, PutItemCommand, SearchVectorsCommand, DynamoDBServiceException } from '@aws-sdk/client-dynamodb'
 import { ddb } from '../../../src/client.js'
 import { uniqueTableName, waitUntilActive, deleteTable, expectDynamoError } from '../../../src/helpers.js'
 import { skipUnlessVectorIndexes, describeVectorIndex } from '../../../src/vector.js'
@@ -17,7 +17,7 @@ afterAll(async () => {
   await Promise.all(tablesToCleanup.map(deleteTable))
 })
 
-describe('UpdateTable — vector index lifecycle', { tags: ['update-table', 'search-vectors', 'control-plane', 'vector', 'slow'] }, () => {
+describe('UpdateTable — vector index lifecycle', { tags: ['update-table', 'delete-table', 'search-vectors', 'control-plane', 'vector', 'slow'] }, () => {
   skipUnlessVectorIndexes()
 
   // Characterised 2026-08-11 (eu-west-2): an index added to a 25-item table
@@ -30,6 +30,12 @@ describe('UpdateTable — vector index lifecycle', { tags: ['update-table', 'sea
   // backfilling vector index". DescribeTable flipping to ACTIVE can lead the
   // search plane by a beat, so readiness is proven by a search succeeding,
   // never by the description alone.
+  //
+  // All of that is now the documented sequence too, so the assertions below
+  // pin it rather than describing it. The developer guide previously built its
+  // waiting advice around an ACTIVE-plus-Backfilling-true state this walk never
+  // occupies; it now numbers the same three steps this test observes. See
+  // captures/2026-08-21-vector-readiness-docs.json for the before and after.
   it('adds an index that backfills like a GSI, enforces one online action, then deletes it', async ({ skip }) => {
     const tableName = uniqueTableName('vec_upd')
     tablesToCleanup.push(tableName)
@@ -84,19 +90,43 @@ describe('UpdateTable — vector index lifecycle', { tags: ['update-table', 'sea
       throw err
     }
 
-    // Walk to searchable: statuses stay within CREATING/ACTIVE, Backfilling
-    // is reported on this path, and every pre-ready search failure is one of
-    // the two characterised rejections. Readiness is a successful search that
-    // reflects every seeded item — a search can succeed with a partial view
-    // for a beat, so a short response keeps polling rather than asserting.
+    // Walk to searchable. Four claims are pinned on every poll:
+    //
+    //  - Statuses stay within CREATING and ACTIVE. There is no BACKFILLING
+    //    status value.
+    //  - Backfilling true is only ever reported alongside CREATING. The state
+    //    the old guidance built its waiting advice around, ACTIVE with
+    //    Backfilling true, is never occupied.
+    //  - Once the index is ACTIVE the field is gone rather than false. That is
+    //    why the documented wait reads "Backfilling is not true"; a readiness
+    //    check written as `=== false` never fires on this path and has nothing
+    //    to read at all on the CreateTable path.
+    //  - The base table reports ACTIVE while the index is still CREATING, which
+    //    is the reason a table waiter is the wrong gate for a search.
+    //
+    // Table and index status come from one DescribeTable rather than two, or a
+    // transition between the calls would make the pairing meaningless.
+    //
+    // Readiness itself is a search that succeeds, never the description. Every
+    // pre-ready failure must be one of the two characterised rejections, and
+    // the first success must carry every seeded item: the backfill window is
+    // documented as returning an error, not a partial view.
     const seenStatuses = new Set<string>()
     let sawBackfillingField = false
+    let sawActiveTableWithCreatingIndex = false
     const deadline = Date.now() + 2_400_000
     for (;;) {
-      const ix = await describeVectorIndex(tableName, 'vix')
+      const described = await ddb.send(new DescribeTableCommand({ TableName: tableName }))
+      const ix = (described.Table?.VectorIndexes ?? []).find((i) => i.IndexName === 'vix')
       if (ix?.IndexStatus) seenStatuses.add(ix.IndexStatus)
       if (ix?.Backfilling !== undefined) sawBackfillingField = true
-      let ready = false
+      if (ix?.Backfilling === true) expect(ix.IndexStatus).toBe('CREATING')
+      if (ix?.IndexStatus === 'ACTIVE') expect(ix.Backfilling).toBeUndefined()
+      if (described.Table?.TableStatus === 'ACTIVE' && ix?.IndexStatus === 'CREATING') {
+        sawActiveTableWithCreatingIndex = true
+      }
+
+      let found: number | undefined
       try {
         const res = await ddb.send(
           new SearchVectorsCommand({
@@ -106,7 +136,7 @@ describe('UpdateTable — vector index lifecycle', { tags: ['update-table', 'sea
             TopK: 5,
           }),
         )
-        ready = (res.SearchResults ?? []).length === 5
+        found = (res.SearchResults ?? []).length
       } catch (err) {
         // A throttle or transport fault mid-poll is a failed observation,
         // not an answer; anything else must be one of the two characterised
@@ -119,7 +149,12 @@ describe('UpdateTable — vector index lifecycle', { tags: ['update-table', 'sea
           /The table does not have the specified index: vix|Cannot search backfilling vector index: vix/,
         )
       }
-      if (ready) break
+      // Asserted outside the try, or a short answer would be caught and read as
+      // a pre-ready rejection that failed to look like one.
+      if (found !== undefined) {
+        expect(found).toBe(5)
+        break
+      }
       if (Date.now() > deadline) {
         throw new IndeterminateError(
           'vector-index-timeout',
@@ -130,6 +165,7 @@ describe('UpdateTable — vector index lifecycle', { tags: ['update-table', 'sea
     }
     expect([...seenStatuses].every((s) => s === 'CREATING' || s === 'ACTIVE')).toBe(true)
     expect(sawBackfillingField).toBe(true)
+    expect(sawActiveTableWithCreatingIndex).toBe(true)
 
     // One online index action per call, enforced with the GSI machinery's
     // own error.
@@ -182,4 +218,130 @@ describe('UpdateTable — vector index lifecycle', { tags: ['update-table', 'sea
     // internal deadlines or vitest kills the test as a failure before either
     // internal ceiling can type the expiry as indeterminate.
   }, 2_820_000)
+
+  // The other half of "wait for the index, not just the table": while a vector
+  // index is being created, the table underneath it cannot be deleted. AWS
+  // documents this in the tutorial's readiness callout, quoting the message as
+  // "Cannot delete table while indexes are being created, updated, or deleted."
+  // The answer carries the ResourceInUseException envelope in front of that
+  // sentence, so the assertion matches the documented clause within it.
+  //
+  // Only the UpdateTable path can ask the question. Measured in eu-west-2 on
+  // 2026-08-21, an index created as part of CreateTable reaches ACTIVE in the
+  // same DescribeTable poll as its own table - three runs, polling at 250ms,
+  // no gap in any of them - so the table is never ACTIVE with the index still
+  // CREATING there, and a DeleteTable during creation is refused for the
+  // table's own status instead ("Table is being created"). Adding an index to a
+  // live table is what opens that window, about 31 seconds after the
+  // UpdateTable call, and it then stays open for the whole backfill.
+  //
+  // Cleanup cancels the index rather than waiting the backfill out. A vector
+  // index in CREATING accepts a Delete the way a backfilling GSI does, and the
+  // table is deletable about five seconds later. That keeps this to a minute in
+  // a lane where the test above runs for seventeen.
+  it('refuses to delete the table while a vector index is still being created', async ({ skip }) => {
+    const tableName = uniqueTableName('vec_del')
+    tablesToCleanup.push(tableName)
+    await ddb.send(
+      new CreateTableCommand({
+        TableName: tableName,
+        AttributeDefinitions: [{ AttributeName: 'pk', AttributeType: 'S' }],
+        KeySchema: [{ AttributeName: 'pk', KeyType: 'HASH' }],
+        BillingMode: 'PAY_PER_REQUEST',
+      }),
+    )
+    await waitUntilActive(tableName)
+    for (let i = 0; i < 5; i++) {
+      await ddb.send(
+        new PutItemCommand({
+          TableName: tableName,
+          Item: {
+            pk: { S: `item-${i}` },
+            embedding: { L: [{ N: String(i) }, { N: '1' }, { N: '0' }] },
+          },
+        }),
+      )
+    }
+
+    // As above: a target may implement vector indexes at CreateTable without
+    // implementing VectorIndexUpdates, and that is scope rather than divergence.
+    try {
+      await ddb.send(
+        new UpdateTableCommand({
+          TableName: tableName,
+          VectorIndexUpdates: [
+            {
+              Create: {
+                IndexName: 'vix',
+                VectorAttribute: { AttributeName: 'embedding' },
+                Dimensions: 3,
+                DistanceFunction: 'COSINE',
+                Projection: { ProjectionType: 'ALL' },
+              },
+            },
+          ],
+        }),
+      )
+    } catch (err) {
+      if (
+        isUnsupportedFault(err) ||
+        (err instanceof DynamoDBServiceException && err.name === 'ValidationException')
+      ) {
+        return skip()
+      }
+      throw err
+    }
+
+    // Wait for the state the claim is about: the table back to ACTIVE with the
+    // index still CREATING.
+    const reachDeadline = Date.now() + 300_000
+    for (;;) {
+      const described = await ddb.send(new DescribeTableCommand({ TableName: tableName }))
+      const ix = (described.Table?.VectorIndexes ?? []).find((i) => i.IndexName === 'vix')
+      if (described.Table?.TableStatus === 'ACTIVE' && ix?.IndexStatus === 'CREATING') break
+      // An index that reached ACTIVE without the table ever being seen ACTIVE
+      // beside it would leave the question unaskable, not answered.
+      expect(ix?.IndexStatus).not.toBe('ACTIVE')
+      if (Date.now() > reachDeadline) {
+        throw new IndeterminateError(
+          'vector-index-timeout',
+          `Table ${tableName} never reported ACTIVE while vector index vix was CREATING`,
+        )
+      }
+      await new Promise((r) => setTimeout(r, 1000))
+    }
+
+    await expectDynamoError(
+      () => ddb.send(new DeleteTableCommand({ TableName: tableName })),
+      'ResourceInUseException',
+      'Cannot delete table while indexes are being created, updated, or deleted.',
+    )
+
+    // Cancelling is what makes this cheap, and it is its own small claim: a
+    // vector index still CREATING takes a Delete rather than answering the
+    // one-online-action limit.
+    await ddb.send(
+      new UpdateTableCommand({
+        TableName: tableName,
+        VectorIndexUpdates: [{ Delete: { IndexName: 'vix' } }],
+      }),
+    )
+    const goneDeadline = Date.now() + 300_000
+    for (;;) {
+      const ix = await describeVectorIndex(tableName, 'vix')
+      if (!ix) break
+      if (Date.now() > goneDeadline) {
+        throw new IndeterminateError(
+          'vector-index-timeout',
+          `Cancelled vector index vix on ${tableName} never disappeared`,
+        )
+      }
+      await new Promise((r) => setTimeout(r, 2000))
+    }
+    // Once the index is gone the table is deletable again, which is the same
+    // claim from the other side.
+    await ddb.send(new DeleteTableCommand({ TableName: tableName }))
+    // Timeout: the reach ceiling (300s) plus the cancel ceiling (300s) plus
+    // setup margin, on the same rule as the test above.
+  }, 700_000)
 })

--- a/tests/tier2/vectorSearch/validation.test.ts
+++ b/tests/tier2/vectorSearch/validation.test.ts
@@ -9,7 +9,7 @@ import {
   skipUnlessVectorIndexes,
   skipUnlessVectorSearch,
   supportsVectorSearch,
-  waitForVectorIndexActive,
+  waitForVectorIndexSearchable,
 } from '../../../src/vector.js'
 
 // Request-model-layer rejections (the "N validation errors detected" family)
@@ -76,7 +76,15 @@ describe('SearchVectors — request validation', { tags: ['search-vectors', 'dat
     // Registered before the create so a partial setup still gets torn down.
     created = true
     await ddb.send(new CreateTableCommand(vectorTableInput(tableName)))
-    await waitForVectorIndexActive(tableName, 'vix')
+    // Searchable, not merely ACTIVE. The not-found case below asserts on "does
+    // not have the specified index", which is also the wording a freshly ACTIVE
+    // index answers while the search endpoint is still catching up, so waiting
+    // on the description alone could pass that case for the wrong reason.
+    await waitForVectorIndexSearchable({
+      tableName,
+      indexName: 'vix',
+      searchVector: [{ N: '1' }, { N: '0' }, { N: '0' }],
+    })
   })
 
   afterAll(async () => {

--- a/tests/tier3/error-messages/searchVectors.test.ts
+++ b/tests/tier3/error-messages/searchVectors.test.ts
@@ -9,7 +9,7 @@ import { uniqueTableName, deleteTable } from '../../../src/helpers.js'
 import {
   skipUnlessVectorSearch,
   supportsVectorSearch,
-  waitForVectorIndexActive,
+  waitForVectorIndexSearchable,
 } from '../../../src/vector.js'
 
 // Exact SearchVectors rejection messages, characterised against real DynamoDB
@@ -82,8 +82,25 @@ describe('SearchVectors — exact error messages', { tags: ['search-vectors', 'd
         ],
       }),
     )
-    await waitForVectorIndexActive(tableName, 'plain')
-    await waitForVectorIndexActive(tableName, 'schema')
+    // Searchable, not merely ACTIVE. Every case below asserts an exact
+    // rejection message, and the interval where the search endpoint has not yet
+    // begun serving a freshly ACTIVE index answers its own ValidationException
+    // — for the 'plain' index, one whose wording ("does not have the specified
+    // index") is indistinguishable from the answer for a name that never
+    // existed. Waiting on the description alone would let that stand in for
+    // whichever message the case actually asked for.
+    await waitForVectorIndexSearchable({
+      tableName,
+      indexName: 'plain',
+      searchVector: vec(1, 0, 0),
+    })
+    await waitForVectorIndexSearchable({
+      tableName,
+      indexName: 'schema',
+      searchVector: vec(1, 0, 0),
+      searchConditionExpression: 'tenant = :t',
+      expressionAttributeValues: { ':t': { S: 'probe' } },
+    })
   })
 
   afterAll(async () => {


### PR DESCRIPTION
## What this changes

AWS corrected the vector index readiness guidance in the developer guide. The suite now asserts that contract rather than describing it:

- the documented wait, `IndexStatus` ACTIVE and `Backfilling` not `true`, cell by cell — the field disappears rather than settling to `false`
- `Backfilling: true` only ever reported alongside `CREATING`, and no `Backfilling` field at all once ACTIVE
- the base table reaching ACTIVE while the index is still `CREATING`, which is why a table waiter is the wrong gate for a search
- ACTIVE is not searchable. The dedicated search endpoint can lag, the `ValidationException` it answers in between is retryable, and readiness is proven by a real search in a retry loop
- backfill returns an error rather than a partial view, so the first successful search carries every seeded item
- `DeleteTable` is refused while an index is creating. That only reproduces on the UpdateTable path; an index created with its table reaches ACTIVE in the same `DescribeTable` poll as the table

Two fixes fell out of it. `waitForVectorSearchable` had no `catch`, so the documented endpoint lag would have thrown rather than retried. Two files asserting exact rejection messages waited only for ACTIVE, where "does not have the specified index" could stand in for whichever message the case was testing; both now wait for a served search.

`captures/2026-08-21-vector-readiness-docs.json` records the corrected prose quote by quote against what it replaced, plus three measurements the new prose does not account for.

Refs #125.

## Checklist

- [x] New or modified tests run against real AWS DynamoDB and pass
- [x] New or modified tests run against at least one emulator target and behave as expected — Dynoxide, DynamoDB Local, Dynalite, LocalStack, Floci and Ministack all pass on this PR. No target implements vector search, so the family skips through its support probes rather than erroring.
- [x] Linked issue or a short note explaining the motivation
- [x] I agree my contribution is licensed under the project's terms (Apache License, Version 2.0)

## Tier and scope

Tier 2 and Tier 3 vector coverage only. Both manifests regenerated; the denominator moves 1054 → 1056.
