### PR TITLE
Bound what an unreachable region costs the sweep

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -15,8 +15,24 @@ const retryConfig = {
   retryMode: 'standard',
 } as const
 
+// Connect timeout, pinned for the same reason as the retry policy and left
+// unset by the SDK: @smithy/node-http-handler applies no connectionTimeout of
+// its own, so establishing a TCP connection is bounded only by the kernel,
+// which gives up on an unroutable address after roughly two minutes. Both
+// outcomes classify as `transport` either way, so this changes how long a
+// failed observation takes to reach that verdict, never what the verdict is.
+//
+// Only the connection is bounded. requestTimeout stays off: a control-plane
+// call that legitimately runs long (a table creation, a GSI backfill) must not
+// be cut off and misread as a failed observation.
+const CONNECTION_TIMEOUT_MS = 5_000
+
+const httpConfig = {
+  requestHandler: { connectionTimeout: CONNECTION_TIMEOUT_MS },
+} as const
+
 /** Low-level DynamoDB client */
-export const ddb = new DynamoDBClient({ ...commonConfig, ...retryConfig })
+export const ddb = new DynamoDBClient({ ...commonConfig, ...retryConfig, ...httpConfig })
 
 /** DynamoDB Streams client */
-export const ddbStreams = new DynamoDBStreamsClient({ ...commonConfig, ...retryConfig })
+export const ddbStreams = new DynamoDBStreamsClient({ ...commonConfig, ...retryConfig, ...httpConfig })

--- a/src/indeterminate-sink.test.ts
+++ b/src/indeterminate-sink.test.ts
@@ -3,8 +3,12 @@ import { existsSync, mkdtempSync, readFileSync, rmSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import {
+  ABANDON_PROVISIONING_AFTER,
   clearIndeterminateMarker,
   clearStaleSidecar,
+  noteProvisioningFailed,
+  noteProvisioningSucceeded,
+  provisioningAbandoned,
   recordRunLevel,
   resetSinkForTesting,
   resultSlug,
@@ -80,6 +84,40 @@ describe('recordRunLevel', () => {
   it('records nothing at all for a clean run: no file exists', () => {
     // Absence of the sidecar is the signal that nothing was absent.
     expect(existsSync(sidecarPath('dynamodb', dir))).toBe(false)
+  })
+})
+
+describe('provisioningAbandoned', () => {
+  it('holds off until provisioning has failed enough files running', () => {
+    for (let i = 0; i < ABANDON_PROVISIONING_AFTER - 1; i++) {
+      noteProvisioningFailed()
+      expect(provisioningAbandoned()).toBe(false)
+    }
+    noteProvisioningFailed()
+    expect(provisioningAbandoned()).toBe(true)
+  })
+
+  it('does not abandon a target over failures a later file recovered from', () => {
+    // The per-file retry exists for exactly this: a transient fault during one
+    // file's provisioning must not take out the files behind it, however many
+    // separate blips a long run accumulates.
+    for (let i = 0; i < ABANDON_PROVISIONING_AFTER * 3; i++) {
+      noteProvisioningFailed()
+      noteProvisioningSucceeded()
+    }
+    expect(provisioningAbandoned()).toBe(false)
+  })
+
+  it('starts counting again from zero after a recovery', () => {
+    noteProvisioningFailed()
+    noteProvisioningFailed()
+    noteProvisioningSucceeded()
+    for (let i = 0; i < ABANDON_PROVISIONING_AFTER - 1; i++) noteProvisioningFailed()
+    expect(provisioningAbandoned()).toBe(false)
+  })
+
+  it('is false for a run that has never failed provisioning', () => {
+    expect(provisioningAbandoned()).toBe(false)
   })
 })
 

--- a/src/indeterminate-sink.ts
+++ b/src/indeterminate-sink.ts
@@ -95,6 +95,46 @@ export function recordedRunLevel(): readonly RunLevelIndeterminate[] {
   return recorded
 }
 
+// ── Abandoning an unreachable target ────────────────────────────────────────
+//
+// The shared tables are provisioned in a beforeAll that vitest runs once per
+// test file, and a rejected attempt is dropped from the memo in src/helpers.ts
+// so the next file tries again. That retry earns its place: a transient fault
+// during one file's provisioning must not take out the hundred files behind
+// it.
+//
+// A target whose endpoint never answers is the other case, and the same retry
+// turns it into one failed attempt per test file, each paying the SDK's full
+// retry budget before it gives up. The weekly sweep runs inside a two-hour
+// credential window, so a region that has gone dark spends the entire window
+// re-answering a question already settled by its first failure - and settled in
+// the artefact too, because that failure wrote the sidecar.
+//
+// So the retry is kept and bounded. Consecutive failures, reset by any
+// provisioning that succeeds, so a blip costs one attempt and a dark target
+// costs this many.
+export const ABANDON_PROVISIONING_AFTER = 3
+
+let consecutiveProvisioningFailures = 0
+
+/** Note that provisioning succeeded, clearing any run of failures before it. */
+export function noteProvisioningSucceeded(): void {
+  consecutiveProvisioningFailures = 0
+}
+
+/** Note that provisioning failed on a failed observation. Determinate
+ * failures are not counted: a target answering definitely is reachable, and
+ * whatever it is refusing is a real result for every file that asks. */
+export function noteProvisioningFailed(): void {
+  consecutiveProvisioningFailures += 1
+}
+
+/** True once provisioning has failed enough files running to call the target
+ * unreachable for this run. */
+export function provisioningAbandoned(): boolean {
+  return consecutiveProvisioningFailures >= ABANDON_PROVISIONING_AFTER
+}
+
 /** Remove a previous run's sidecar. A clean run must leave no sidecar behind. */
 export function clearStaleSidecar(opts: { slug?: string; dir?: string } = {}): void {
   rmSync(sidecarPath(opts.slug ?? resultSlug(), opts.dir ?? resultsDir()), {
@@ -105,6 +145,7 @@ export function clearStaleSidecar(opts: { slug?: string; dir?: string } = {}): v
 /** Test hook: reset the in-memory sink between unit tests. */
 export function resetSinkForTesting(): void {
   recorded.length = 0
+  consecutiveProvisioningFailures = 0
 }
 
 // ── Test-level marker hooks ─────────────────────────────────────────────────

--- a/src/setup.ts
+++ b/src/setup.ts
@@ -1,7 +1,11 @@
 import { cleanupAllTablesOnce, provisionDeclaredTables } from './helpers.js'
-import { indeterminateFrom } from './indeterminate.js'
+import { IndeterminateError, indeterminateFrom } from './indeterminate.js'
 import {
+  ABANDON_PROVISIONING_AFTER,
   clearIndeterminateMarker,
+  noteProvisioningFailed,
+  noteProvisioningSucceeded,
+  provisioningAbandoned,
   recordRunLevel,
   stampIndeterminateMarker,
 } from './indeterminate-sink.js'
@@ -16,8 +20,21 @@ import { clearObservedMarker } from './observation-sink.js'
 // run start. Final teardown runs once in src/global-teardown.ts.
 beforeAll(async () => {
   try {
+    // A target that has failed provisioning this many files running is
+    // unreachable for this run, and the sidecar saying so was written by the
+    // first of those failures. Attempting again cannot change the run's verdict
+    // and costs another full retry budget, so the remaining files give up
+    // immediately - see ABANDON_PROVISIONING_AFTER for why the retry is bounded
+    // rather than removed.
+    if (provisioningAbandoned()) {
+      throw new IndeterminateError(
+        'transport',
+        `provisioning abandoned: ${ABANDON_PROVISIONING_AFTER} consecutive failed observations`,
+      )
+    }
     await cleanupAllTablesOnce()
     await provisionDeclaredTables()
+    noteProvisioningSucceeded()
   } catch (e: unknown) {
     // Vitest does not retry beforeAll, so a provisioning failure takes out the
     // whole run and no test ever executes to annotate itself. When the failure
@@ -26,6 +43,7 @@ beforeAll(async () => {
     // produced nothing" instead of several hundred behavioural disagreements.
     const indeterminate = indeterminateFrom(e)
     if (indeterminate) {
+      noteProvisioningFailed()
       recordRunLevel({
         reason: indeterminate.reason,
         phase: 'provisioning',


### PR DESCRIPTION
## What this changes

A region that answers nothing does not fail its sweep job, it grinds. Provisioning
is retried once per test file by design, so a transient fault does not take out the
files behind it, and with no connect timeout each of those attempts waits out the
kernel's TCP timeout instead. me-south-1 spent the full 115-minute job timeout that
way on 2026-08-22, across 135 files, which is also why that sweep run reads
cancelled although all 33 answering regions finished.

Two bounds. `src/client.ts` pins a 5s connectionTimeout beside the retry policy it
already pins, because `@smithy/node-http-handler` applies none of its own. And the
per-file retry stops after three consecutive failed observations, counted only for
indeterminate failures and reset by any provisioning that succeeds, so one blip
still recovers on the next file while a dark region gives up in seconds.

Classification does not move. `ETIMEDOUT` and the handler's `TimeoutError` both
already read as `transport`, so this changes how long a failed observation takes to
reach that verdict, not what the verdict is. Checked against a blackholed endpoint:
15.4s, three attempts at five seconds, recorded as `transport`.

Relates to #93. The region is genuinely dark, so it stays dropped and the issue
stays open.

## Checklist

- ~~New or modified tests run against real AWS DynamoDB and pass~~ - no conformance
  tests change; the new unit tests cover the retry bound and need no AWS
- ~~New or modified tests run against at least one emulator target and behave as
  expected~~ - as above
- [x] Linked issue or a short note explaining the motivation
- [x] I agree my contribution is licensed under the project's terms
  (Apache License, Version 2.0)
