### PR TITLE
Score the A+ tripwire at the measured ref

### DIFF
--- a/scripts/summarise.test.mjs
+++ b/scripts/summarise.test.mjs
@@ -1039,13 +1039,13 @@ describe('committed results pipeline', () => {
       const target = targets.find((x) => x.slug === slug);
       const verdicts = classifyResults(target.raw, target.sidecar ?? null);
       for (const [region, r] of Object.entries(t.regions)) {
-        const fails = verdictsForRegion(verdicts, context.registry, region).filter(
+        const fails = verdictsForRegion(verdicts, measuredInputs.registry, region).filter(
           (v) => v.verdict === 'fail',
         );
         expect(fails.length, `${slug}'s scored fail count in ${region}`).toBe(r.failed);
         for (const f of fails) {
           expect(
-            splitFor(context.registry, f),
+            splitFor(measuredInputs.registry, f),
             `${slug} fails "${f.fullName}" in ${region}, and it is not one of the registry's confirmed splits - a non-split behaviour is varying by region`,
           ).toBeTruthy();
         }


### PR DESCRIPTION
## What this changes

The A+ tripwire re-scored each target with the working tree's split registry,
then compared the count against a board built from the registry at the measured
ref. The two disagree for as long as the registry has moved past the last
release, so admitting a split turned `main` red until the next one.

That is the deadlock the same file already avoids for the denominator, which
reads the manifest at the measured ref for exactly this reason. Both readings
now come from the same place.

The `BatchWriteItem` empty-`RequestItems` split, admitted the day after v3.2.1
was tagged, is what fired it: dynoxide scores two fails in eu-north-1 under
`main`'s registry and one under v3.2.1's, and both are confirmed splits.

The check keeps its teeth. It still guards 2 targets and examines 176
region-failures against the registry's rows.

## Checklist

- ~~New or modified tests run against real AWS DynamoDB and pass~~
  - No conformance test changes; this is the tooling suite.
- ~~New or modified tests run against at least one emulator target and behave
  as expected~~
  - As above.
- [x] Linked issue or a short note explaining the motivation
- [x] I agree my contribution is licensed under the project's terms
  (Apache License, Version 2.0)
